### PR TITLE
feat(backend): macro CRUD, DSK toggle, audio passthrough, streaming stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/nano": "^7.0.0",
     "@types/node": "^22.15.3",
     "tsx": "^4.19.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,20 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.3(@types/node@22.19.17)(vite@8.0.7(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
+
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -222,8 +234,133 @@ packages:
   '@fastify/websocket@11.2.0':
     resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.123.0':
+    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/nano@7.0.0':
     resolution: {integrity: sha512-8kQR6ELho0uu+0u88cExObK6Pjn2p4SVSdZVAAb0H8vXse9kEMJG9pIqLpsx3ZWMHXIGnFSmW9I6McEzzcjkQA==}
@@ -231,6 +368,35 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
+
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
+
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
+
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
+
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -245,6 +411,10 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -267,9 +437,16 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -282,6 +459,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -301,6 +482,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -313,6 +497,13 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -343,6 +534,15 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
@@ -412,6 +612,83 @@ packages:
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -431,6 +708,11 @@ packages:
     resolution: {integrity: sha512-bJOFIPLExIbF6mljnfExXX9Cub4W0puhDjVMp+qV40xl/DBvgKao7St4+6/GB6EoHZap7eFnrnx4mnp5KYgwJA==}
     engines: {node: '>=14'}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -441,12 +723,25 @@ packages:
   obliterator@2.0.5:
     resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
@@ -457,6 +752,10 @@ packages:
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
 
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
@@ -501,6 +800,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rolldown@1.0.0-rc.13:
+    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -539,12 +843,25 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
@@ -556,9 +873,27 @@ packages:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -575,6 +910,95 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@8.0.7:
+    resolution: {integrity: sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -600,6 +1024,22 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -716,7 +1156,85 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.123.0': {}
+
   '@pinojs/redact@0.4.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/nano@7.0.0':
     dependencies:
@@ -727,6 +1245,47 @@ snapshots:
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@vitest/expect@4.1.3':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.3(vite@8.0.7(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.7(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.3':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.3':
+    dependencies:
+      '@vitest/utils': 4.1.3
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.3': {}
+
+  '@vitest/utils@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   abstract-logging@2.0.1: {}
 
@@ -740,6 +1299,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
 
@@ -768,15 +1329,21 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chai@6.2.2: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
 
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -798,6 +1365,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -838,6 +1407,12 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -888,6 +1463,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   find-my-way@9.5.0:
     dependencies:
@@ -960,6 +1539,59 @@ snapshots:
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   mime-db@1.52.0: {}
@@ -980,17 +1612,27 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  nanoid@3.3.11: {}
+
   node-abort-controller@3.1.1: {}
 
   object-inspect@1.13.4: {}
 
   obliterator@2.0.5: {}
 
+  obug@2.1.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -1011,6 +1653,12 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   process-warning@4.0.1: {}
 
@@ -1041,6 +1689,27 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rolldown@1.0.0-rc.13:
+    dependencies:
+      '@oxc-project/types': 0.123.0
+      '@rolldown/pluginutils': 1.0.0-rc.13
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
 
   safe-buffer@5.2.1: {}
 
@@ -1084,11 +1753,19 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   stream-shift@1.0.3: {}
 
@@ -1100,7 +1777,21 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
   toad-cache@3.7.0: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.21.0:
     dependencies:
@@ -1114,6 +1805,51 @@ snapshots:
   undici-types@6.21.0: {}
 
   util-deprecate@1.0.2: {}
+
+  vite@8.0.7(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.13
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.1.3(@types/node@22.19.17)(vite@8.0.7(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.7(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 

--- a/src/__tests__/macros.test.ts
+++ b/src/__tests__/macros.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Tests for macros and streaming stats routes.
+ *
+ * CouchDB is mocked via vi.mock('../db/index.js') — no real database required.
+ *
+ * ZodError handling: the server error handler checks `instanceof ZodError` and
+ * returns HTTP 400. All Zod validation failures are therefore expected to
+ * produce 400 responses.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../server.js';
+
+// ---------------------------------------------------------------------------
+// Mock the CouchDB layer
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getTemplatesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+// Prevent the WebSocket controller from doing anything at startup
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A minimal ProductionDoc fixture that satisfies all route handlers. */
+function makeProductionDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'prod-test-1',
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Test Production',
+    status: 'inactive',
+    sources: [],
+    pipeline: { stromConfig: null, status: 'stopped' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Macros routes
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/productions/:id/macros', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 201 with a macro whose id starts with "macro-"', async () => {
+    const doc = makeProductionDoc();
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ id: 'prod-test-1', rev: '2-def', ok: true });
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/macros',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        slot: 0,
+        label: 'Cut to Cam 1',
+        color: '#3B82F6',
+        actions: [{ type: 'CUT', sourceId: 'src-cam1' }],
+      }),
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ id: string; slot: number; label: string; color: string }>();
+    expect(body.id).toMatch(/^macro-/);
+    expect(body.slot).toBe(0);
+    expect(body.label).toBe('Cut to Cam 1');
+    expect(body.color).toBe('#3B82F6');
+  });
+
+  it('persists the macro in the document passed to insert()', async () => {
+    const doc = makeProductionDoc();
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ id: 'prod-test-1', rev: '2-def', ok: true });
+
+    const server = await buildServer();
+    await server.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/macros',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        slot: 1,
+        label: 'Graphic On',
+        color: '#10B981',
+        actions: [{ type: 'GRAPHIC_ON', overlayId: 'overlay-1', layer: 0, visible: true }],
+      }),
+    });
+
+    expect(mockInsert).toHaveBeenCalledOnce();
+    const insertedDoc = mockInsert.mock.calls[0][0] as { macros: Array<{ slot: number }> };
+    expect(insertedDoc.macros).toHaveLength(1);
+    expect(insertedDoc.macros[0].slot).toBe(1);
+  });
+
+  it('returns 201 for slot=7 (boundary — maximum valid slot)', async () => {
+    mockGet.mockResolvedValue(makeProductionDoc());
+    mockInsert.mockResolvedValue({ id: 'prod-test-1', rev: '2-def', ok: true });
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/macros',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ slot: 7, label: 'Last slot', color: '#FFFFFF', actions: [] }),
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('returns 400 when slot=8 (above maximum of 7)', async () => {
+    // getDb().get() should not even be called — parse throws before that
+    mockGet.mockResolvedValue(makeProductionDoc());
+    mockInsert.mockResolvedValue({ id: 'prod-test-1', rev: '2-def', ok: true });
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/macros',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ slot: 8, label: 'Invalid', color: '#FF0000', actions: [] }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: string; statusCode: number }>();
+    expect(body.statusCode).toBe(400);
+    // The database should never have been touched
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when slot=-1 (below minimum of 0)', async () => {
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/macros',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ slot: -1, label: 'Invalid', color: '#FF0000', actions: [] }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when color format is invalid (not a hex color)', async () => {
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/macros',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ slot: 0, label: 'Test', color: 'red', actions: [] }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when label is empty (min length 1)', async () => {
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/macros',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ slot: 0, label: '', color: '#000000', actions: [] }),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/productions/:id/macros
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/productions/:id/macros', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty array when the production has no macros', async () => {
+    mockGet.mockResolvedValue(makeProductionDoc());
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/productions/prod-test-1/macros',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it('returns the macros array from the production document', async () => {
+    const macro = {
+      id: 'macro-abc-123',
+      slot: 2,
+      label: 'DSK Toggle',
+      color: '#F59E0B',
+      actions: [{ type: 'DSK_TOGGLE' }],
+    };
+    mockGet.mockResolvedValue(makeProductionDoc({ macros: [macro] }));
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/productions/prod-test-1/macros',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<typeof macro[]>();
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe('macro-abc-123');
+    expect(body[0].slot).toBe(2);
+  });
+
+  it('returns 404 when production does not exist', async () => {
+    mockGet.mockRejectedValue({ statusCode: 404, error: 'not_found' });
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/productions/non-existent/macros',
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toBe('Production not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/productions/:id/macros/:macroId
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/v1/productions/:id/macros/:macroId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when macroId does not exist in the production', async () => {
+    // Production exists but has no macros
+    mockGet.mockResolvedValue(makeProductionDoc({ macros: [] }));
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'DELETE',
+      url: '/api/v1/productions/prod-test-1/macros/macro-does-not-exist',
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toBe('Macro not found');
+  });
+
+  it('returns 404 when production doc has macros but none match the macroId', async () => {
+    const doc = makeProductionDoc({
+      macros: [{ id: 'macro-other', slot: 0, label: 'Other', color: '#000000', actions: [] }],
+    });
+    mockGet.mockResolvedValue(doc);
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'DELETE',
+      url: '/api/v1/productions/prod-test-1/macros/macro-unknown',
+    });
+
+    expect(res.statusCode).toBe(404);
+    // insert must NOT have been called — no document should be mutated
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 204 and removes the macro when it exists', async () => {
+    const macroId = 'macro-to-delete';
+    const doc = makeProductionDoc({
+      macros: [{ id: macroId, slot: 3, label: 'Delete me', color: '#EF4444', actions: [] }],
+    });
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ id: 'prod-test-1', rev: '2-def', ok: true });
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'DELETE',
+      url: `/api/v1/productions/prod-test-1/macros/${macroId}`,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(mockInsert).toHaveBeenCalledOnce();
+    const saved = mockInsert.mock.calls[0][0] as { macros: unknown[] };
+    expect(saved.macros).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/productions/:id/macros/:macroId
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/v1/productions/:id/macros/:macroId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when macroId does not exist', async () => {
+    mockGet.mockResolvedValue(makeProductionDoc({ macros: [] }));
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'PATCH',
+      url: '/api/v1/productions/prod-test-1/macros/macro-ghost',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'Updated' }),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toBe('Macro not found');
+  });
+
+  it('returns 200 with updated macro when patch is valid', async () => {
+    const macroId = 'macro-to-patch';
+    const original = { id: macroId, slot: 1, label: 'Original', color: '#111111', actions: [] };
+    mockGet.mockResolvedValue(makeProductionDoc({ macros: [original] }));
+    mockInsert.mockResolvedValue({ id: 'prod-test-1', rev: '2-def', ok: true });
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'PATCH',
+      url: `/api/v1/productions/prod-test-1/macros/${macroId}`,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'Updated Label', color: '#AABBCC' }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ id: string; label: string; color: string; slot: number }>();
+    expect(body.id).toBe(macroId);
+    expect(body.label).toBe('Updated Label');
+    expect(body.color).toBe('#AABBCC');
+    // Unchanged field should be preserved
+    expect(body.slot).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/productions/:id/stats/streaming
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/productions/:id/stats/streaming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns { active: false } when production has no stromFlowId', async () => {
+    // Production doc without stromFlowId
+    mockGet.mockResolvedValue(makeProductionDoc());
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/productions/prod-test-1/stats/streaming',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ active: false });
+  });
+
+  it('returns { active: false } when stromFlowId is explicitly undefined', async () => {
+    const doc = makeProductionDoc({ stromFlowId: undefined });
+    mockGet.mockResolvedValue(doc);
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/productions/prod-test-1/stats/streaming',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ active: boolean }>().active).toBe(false);
+  });
+
+  it('returns 404 when production does not exist', async () => {
+    mockGet.mockRejectedValue({ statusCode: 404, error: 'not_found' });
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/productions/non-existent/stats/streaming',
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toBe('Production not found');
+  });
+
+  it('returns { active: true, rtpStats: null, webrtcStats: null, error: string } when Strom fetch fails', async () => {
+    // Production doc with a stromFlowId triggers Strom API calls
+    mockGet.mockResolvedValue(makeProductionDoc({ stromFlowId: 'flow-abc' }));
+
+    const server = await buildServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/productions/prod-test-1/stats/streaming',
+    });
+
+    // Strom is not running in the test environment; the route should handle
+    // the fetch error gracefully and return a degraded (non-crash) response.
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ active: boolean; rtpStats: unknown; webrtcStats: unknown; error?: string }>();
+    expect(body.active).toBe(true);
+    expect(body.rtpStats).toBeNull();
+    expect(body.webrtcStats).toBeNull();
+    expect(typeof body.error).toBe('string');
+  });
+});

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -158,6 +158,7 @@ const DEFAULT_TEMPLATE: Omit<StromFlowTemplate, '_id' | '_rev'> = {
       addressProperty: 'endpoint_id',
     },
   ],
+  audioElements: [],
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 };

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,3 +1,34 @@
+// --------------- Macro types ---------------
+
+export type MacroActionType = 'CUT' | 'TRANSITION' | 'TAKE' | 'GRAPHIC_ON' | 'GRAPHIC_OFF' | 'DSK_TOGGLE';
+
+export interface MacroAction {
+  type: MacroActionType;
+  sourceId?: string;
+  transitionType?: string;
+  durationMs?: number;
+  overlayId?: string;
+  layer?: number;
+  visible?: boolean;
+}
+
+export interface Macro {
+  id: string;      // "macro-<uuid>"
+  slot: number;    // 0-7 (F1-F8)
+  label: string;
+  color: string;   // hex color, e.g. "#3B82F6"
+  actions: MacroAction[];
+}
+
+// --------------- Audio element types ---------------
+
+export interface AudioElement {
+  id: string;
+  blockId: string;
+  elementId: string;
+  label: string;
+}
+
 // --------------- Source types ---------------
 
 export type StreamType = 'srt' | 'whip';
@@ -81,6 +112,7 @@ export interface StromFlowTemplate {
   };
   /** Defines which blocks are parametric source inputs */
   inputs: TemplateInputSlot[];
+  audioElements: AudioElement[];
   createdAt: string;
   updatedAt: string;
 }
@@ -131,7 +163,9 @@ export interface ProductionDoc {
   stromFlowId?: string;
   pipeline: Pipeline;
   graphics: GraphicOverlay[];
+  macros: Macro[];
   tally: Tally;
+  mixerBlockId?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/routes/audio.ts
+++ b/src/routes/audio.ts
@@ -1,0 +1,80 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { getDb } from '../db/index.js';
+import { StromClient } from '../lib/strom.js';
+import { getStromToken } from '../lib/strom-token.js';
+import { config } from '../config.js';
+
+const AudioPatch = z.object({
+  property: z.string().min(1),
+  value: z.unknown(),
+});
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Strom request timed out')), ms),
+    ),
+  ]);
+}
+
+const audioRoutes: FastifyPluginAsync = async (fastify) => {
+  // Get audio element properties from Strom
+  fastify.get<{ Params: { id: string; elementId: string } }>(
+    '/api/v1/productions/:id/audio/:elementId',
+    async (req, reply) => {
+      try {
+        const doc = await getDb().get(req.params.id);
+        if (!doc.stromFlowId) {
+          return reply.status(409).send({ error: 'Pipeline not active', statusCode: 409 });
+        }
+        const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+        const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+        const result = await withTimeout(
+          strom.properties.getElement(doc.stromFlowId, req.params.elementId),
+          5000,
+        );
+        return reply.send(result);
+      } catch (err) {
+        const e = err as { statusCode?: number };
+        if (e?.statusCode === 404) {
+          return reply.status(404).send({ error: 'Production not found', statusCode: 404 });
+        }
+        throw err;
+      }
+    },
+  );
+
+  // Update an audio element property in Strom
+  fastify.patch<{ Params: { id: string; elementId: string } }>(
+    '/api/v1/productions/:id/audio/:elementId',
+    async (req, reply) => {
+      const body = AudioPatch.parse(req.body);
+      try {
+        const doc = await getDb().get(req.params.id);
+        if (!doc.stromFlowId) {
+          return reply.status(409).send({ error: 'Pipeline not active', statusCode: 409 });
+        }
+        const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+        const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+        const result = await withTimeout(
+          strom.properties.updateElement(doc.stromFlowId, req.params.elementId, {
+            property: body.property,
+            value: body.value,
+          }),
+          5000,
+        );
+        return reply.send(result);
+      } catch (err) {
+        const e = err as { statusCode?: number };
+        if (e?.statusCode === 404) {
+          return reply.status(404).send({ error: 'Production not found', statusCode: 404 });
+        }
+        throw err;
+      }
+    },
+  );
+};
+
+export default audioRoutes;

--- a/src/routes/macros.ts
+++ b/src/routes/macros.ts
@@ -1,0 +1,145 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { getDb } from '../db/index.js';
+import type { Macro, ProductionDoc } from '../db/types.js';
+
+const MacroActionSchema = z.object({
+  type: z.enum(['CUT', 'TRANSITION', 'TAKE', 'GRAPHIC_ON', 'GRAPHIC_OFF', 'DSK_TOGGLE']),
+  sourceId: z.string().optional(),
+  transitionType: z.string().optional(),
+  durationMs: z.number().int().positive().optional(),
+  overlayId: z.string().optional(),
+  layer: z.number().int().min(0).optional(),
+  visible: z.boolean().optional(),
+});
+
+const MacroInput = z.object({
+  slot: z.number().int().min(0).max(7),
+  label: z.string().min(1).max(50),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+  actions: z.array(MacroActionSchema).default([]),
+});
+
+const MacroPatch = z.object({
+  slot: z.number().int().min(0).max(7).optional(),
+  label: z.string().min(1).max(50).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+  actions: z.array(MacroActionSchema).optional(),
+});
+
+async function withRetry<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const e = err as { statusCode?: number; error?: string };
+      if (e?.statusCode === 409 || e?.error === 'conflict') {
+        lastErr = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}
+
+const macrosRoutes: FastifyPluginAsync = async (fastify) => {
+  // List macros for a production
+  fastify.get<{ Params: { id: string } }>('/api/v1/productions/:id/macros', async (req, reply) => {
+    try {
+      const doc = await getDb().get(req.params.id);
+      return reply.send(doc.macros ?? []);
+    } catch {
+      return reply.status(404).send({ error: 'Production not found', statusCode: 404 });
+    }
+  });
+
+  // Create a macro
+  fastify.post<{ Params: { id: string } }>('/api/v1/productions/:id/macros', async (req, reply) => {
+    const body = MacroInput.parse(req.body);
+    const macro: Macro = {
+      id: `macro-${randomUUID()}`,
+      slot: body.slot,
+      label: body.label,
+      color: body.color,
+      actions: body.actions,
+    };
+
+    await withRetry(async () => {
+      const doc = await getDb().get(req.params.id);
+      const updated: ProductionDoc = {
+        ...doc,
+        macros: [...(doc.macros ?? []), macro],
+        updatedAt: new Date().toISOString(),
+      };
+      await getDb().insert(updated);
+    });
+
+    return reply.status(201).send(macro);
+  });
+
+  // Update a macro
+  fastify.patch<{ Params: { id: string; macroId: string } }>(
+    '/api/v1/productions/:id/macros/:macroId',
+    async (req, reply) => {
+      const body = MacroPatch.parse(req.body);
+      let updated: Macro | undefined;
+
+      await withRetry(async () => {
+        const doc = await getDb().get(req.params.id);
+        const idx = (doc.macros ?? []).findIndex((m) => m.id === req.params.macroId);
+        if (idx === -1) return; // handled after loop
+
+        updated = {
+          ...(doc.macros ?? [])[idx],
+          ...(body.slot !== undefined && { slot: body.slot }),
+          ...(body.label !== undefined && { label: body.label }),
+          ...(body.color !== undefined && { color: body.color }),
+          ...(body.actions !== undefined && { actions: body.actions }),
+        };
+
+        const updatedDoc: ProductionDoc = {
+          ...doc,
+          macros: (doc.macros ?? []).map((m, i) => (i === idx ? updated! : m)),
+          updatedAt: new Date().toISOString(),
+        };
+        await getDb().insert(updatedDoc);
+      });
+
+      if (!updated) {
+        return reply.status(404).send({ error: 'Macro not found', statusCode: 404 });
+      }
+      return reply.send(updated);
+    },
+  );
+
+  // Delete a macro
+  fastify.delete<{ Params: { id: string; macroId: string } }>(
+    '/api/v1/productions/:id/macros/:macroId',
+    async (req, reply) => {
+      let found = false;
+
+      await withRetry(async () => {
+        const doc = await getDb().get(req.params.id);
+        found = (doc.macros ?? []).some((m) => m.id === req.params.macroId);
+        if (!found) return;
+
+        const updatedDoc: ProductionDoc = {
+          ...doc,
+          macros: (doc.macros ?? []).filter((m) => m.id !== req.params.macroId),
+          updatedAt: new Date().toISOString(),
+        };
+        await getDb().insert(updatedDoc);
+      });
+
+      if (!found) {
+        return reply.status(404).send({ error: 'Macro not found', statusCode: 404 });
+      }
+      return reply.status(204).send();
+    },
+  );
+};
+
+export default macrosRoutes;

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -42,6 +42,7 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
       sources: [],
       pipeline: { stromConfig: null, status: 'stopped' },
       graphics: [],
+      macros: [],
       tally: { pgm: null, pvw: null },
       createdAt: now,
       updatedAt: now,
@@ -108,14 +109,26 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
         .catch(() => null);
 
       // Start Strom flow if a template is configured
+      let mixerBlockId: string | undefined;
       if (doc.templateId) {
         stromFlowId = await activateStromFlow(doc, strom);
+
+        // Resolve mixer block ID from template for DSK/transition operations
+        const tmpl = await getDb().get(doc.templateId).catch(() => null);
+        if (tmpl) {
+          const mixerBlock = (tmpl as unknown as { flow?: { blocks?: Array<Record<string, unknown>> } })
+            .flow?.blocks?.find((b) => b['category'] === 'mixer');
+          if (mixerBlock && typeof mixerBlock['id'] === 'string') {
+            mixerBlockId = mixerBlock['id'];
+          }
+        }
       }
 
       const updated: ProductionDoc = {
         ...doc,
         status: 'active',
         ...(stromFlowId !== undefined && { stromFlowId }),
+        ...(mixerBlockId !== undefined && { mixerBlockId }),
         updatedAt: new Date().toISOString(),
       };
       const response = await getDb().insert(updated);

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,37 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { getDb } from '../db/index.js';
+import { StromClient } from '../lib/strom.js';
+import { getStromToken } from '../lib/strom-token.js';
+import { config } from '../config.js';
+
+const statsRoutes: FastifyPluginAsync = async (fastify) => {
+  // Get streaming stats for a production (Strom RTP + WebRTC stats passthrough)
+  fastify.get<{ Params: { id: string } }>(
+    '/api/v1/productions/:id/stats/streaming',
+    async (req, reply) => {
+      try {
+        const doc = await getDb().get(req.params.id);
+        if (!doc.stromFlowId) {
+          return reply.send({ active: false });
+        }
+        const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+        const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+        try {
+          const [rtpStats, webrtcStats] = await Promise.all([
+            strom.flows.rtpStats(doc.stromFlowId),
+            strom.flows.webrtcStats(doc.stromFlowId),
+          ]);
+          return reply.send({ active: true, rtpStats: rtpStats.stats, webrtcStats: webrtcStats.stats });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          fastify.log.warn({ err }, 'Failed to fetch streaming stats from Strom');
+          return reply.send({ active: true, rtpStats: null, webrtcStats: null, error: message });
+        }
+      } catch {
+        return reply.status(404).send({ error: 'Production not found', statusCode: 404 });
+      }
+    },
+  );
+};
+
+export default statsRoutes;

--- a/src/routes/templates.ts
+++ b/src/routes/templates.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { getTemplatesDb } from '../db/index.js';
-import type { StromFlowTemplate } from '../db/types.js';
+import type { StromFlowTemplate, AudioElement } from '../db/types.js';
 
 // Flow content uses open-ended schemas to accommodate the full Strom block
 // shape (block_definition_id, position, computed_external_pads, etc.) as
@@ -25,6 +25,13 @@ const TemplateInputSlotSchema = z.object({
   addressProperty: z.string().min(1),
 });
 
+const AudioElementSchema = z.object({
+  id: z.string().min(1),
+  blockId: z.string().min(1),
+  elementId: z.string().min(1),
+  label: z.string().min(1),
+});
+
 const TemplateInput = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
@@ -34,6 +41,7 @@ const TemplateInput = z.object({
     links: z.array(FlowLinkSchema).default([]),
   }),
   inputs: z.array(TemplateInputSlotSchema).default([]),
+  audioElements: z.array(AudioElementSchema).default([]),
 });
 
 const TemplatePatch = z.object({
@@ -45,6 +53,7 @@ const TemplatePatch = z.object({
     links: z.array(FlowLinkSchema).optional(),
   }).optional(),
   inputs: z.array(TemplateInputSlotSchema).optional(),
+  audioElements: z.array(AudioElementSchema).optional(),
 });
 
 function toApi(doc: StromFlowTemplate) {
@@ -71,6 +80,7 @@ const templatesRoutes: FastifyPluginAsync = async (fastify) => {
       description: body.description,
       flow: body.flow,
       inputs: body.inputs,
+      audioElements: body.audioElements as AudioElement[],
       createdAt: now,
       updatedAt: now,
     };
@@ -106,6 +116,7 @@ const templatesRoutes: FastifyPluginAsync = async (fastify) => {
           },
         }),
         ...(body.inputs !== undefined && { inputs: body.inputs }),
+        ...(body.audioElements !== undefined && { audioElements: body.audioElements as AudioElement[] }),
         updatedAt: new Date().toISOString(),
       };
       const response = await getTemplatesDb().insert(updated as never);

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,9 @@ import productionsRoutes from './routes/productions.js';
 import sourcesRoutes from './routes/sources.js';
 import templatesRoutes from './routes/templates.js';
 import pipelineRoutes from './routes/pipeline.js';
+import macrosRoutes from './routes/macros.js';
+import audioRoutes from './routes/audio.js';
+import statsRoutes from './routes/stats.js';
 import controllerWs from './ws/controller.js';
 
 export async function buildServer() {
@@ -43,6 +46,9 @@ export async function buildServer() {
   await fastify.register(sourcesRoutes);
   await fastify.register(templatesRoutes);
   await fastify.register(pipelineRoutes);
+  await fastify.register(macrosRoutes);
+  await fastify.register(audioRoutes);
+  await fastify.register(statsRoutes);
   await fastify.register(controllerWs);
 
   return fastify;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import websocket from '@fastify/websocket';
+import { ZodError } from 'zod';
 import { config } from './config.js';
 import healthRoutes from './routes/health.js';
 import productionsRoutes from './routes/productions.js';
@@ -36,6 +37,9 @@ export async function buildServer() {
 
   // Error handler
   fastify.setErrorHandler((error: Error & { statusCode?: number }, _req, reply) => {
+    if (error instanceof ZodError) {
+      return reply.status(400).send({ error: 'Validation error', issues: error.issues, statusCode: 400 });
+    }
     const statusCode = error.statusCode ?? 500;
     fastify.log.error(error);
     reply.status(statusCode).send({ error: error.message, statusCode });

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -3,6 +3,9 @@ import type { WebSocket } from '@fastify/websocket';
 import { getDb } from '../db/index.js';
 import type { ProductionDoc } from '../db/types.js';
 import { getTally, setTally, subscribe, unsubscribe, broadcast } from '../services/tally.service.js';
+import { StromClient } from '../lib/strom.js';
+import { getStromToken } from '../lib/strom-token.js';
+import { config } from '../config.js';
 
 type InboundMessage =
   | { type: 'CUT'; sourceId: string }
@@ -11,7 +14,9 @@ type InboundMessage =
   | { type: 'GO_LIVE' }
   | { type: 'CUT_STREAM' }
   | { type: 'GRAPHIC_ON'; overlayId: string }
-  | { type: 'GRAPHIC_OFF'; overlayId: string };
+  | { type: 'GRAPHIC_OFF'; overlayId: string }
+  | { type: 'DSK_TOGGLE'; layer: number; visible?: boolean }
+  | { type: 'MACRO_EXEC'; macroId: string };
 
 async function handleMessage(
   productionId: string,
@@ -87,6 +92,92 @@ async function handleMessage(
       };
       await db.insert(updated);
       broadcast(productionId, { type: 'GRAPHIC', overlayId: msg.overlayId, active });
+      break;
+    }
+    case 'DSK_TOGGLE': {
+      if (!doc.stromFlowId || !doc.mixerBlockId) {
+        ws.send(JSON.stringify({ type: 'ERROR', error: 'Pipeline not active or mixer block not resolved' }));
+        break;
+      }
+      const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+      const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+      const result = await strom.mixer.toggleDsk(doc.stromFlowId, doc.mixerBlockId, {
+        layer: msg.layer,
+        visible: msg.visible,
+      });
+      broadcast(productionId, { type: 'DSK_STATE', layer: result.layer, visible: result.visible });
+      break;
+    }
+    case 'MACRO_EXEC': {
+      const macro = (doc.macros ?? []).find((m) => m.id === msg.macroId);
+      if (!macro) {
+        ws.send(JSON.stringify({ type: 'ERROR', error: 'Macro not found' }));
+        break;
+      }
+      const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+      const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+      let failedAt = -1;
+      let failError = '';
+      for (let i = 0; i < macro.actions.length; i++) {
+        const action = macro.actions[i];
+        try {
+          if (action.type === 'CUT' && action.sourceId) {
+            const tally = getTally(productionId);
+            const newTally = { pgm: action.sourceId, pvw: tally.pgm };
+            setTally(productionId, newTally);
+            const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
+            await getDb().insert(updated);
+            broadcast(productionId, { type: 'TALLY', ...newTally });
+          } else if (action.type === 'TRANSITION' && action.sourceId) {
+            const tally = getTally(productionId);
+            const newTally = { pgm: action.sourceId, pvw: tally.pgm };
+            setTally(productionId, newTally);
+            const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
+            await getDb().insert(updated);
+            broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: action.transitionType, durationMs: action.durationMs });
+          } else if (action.type === 'TAKE') {
+            const tally = getTally(productionId);
+            const newTally = { pgm: tally.pvw, pvw: tally.pgm };
+            setTally(productionId, newTally);
+            const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
+            await getDb().insert(updated);
+            broadcast(productionId, { type: 'TALLY', ...newTally });
+          } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
+            const updated: ProductionDoc = {
+              ...doc,
+              graphics: doc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: true } : g),
+              updatedAt: new Date().toISOString(),
+            };
+            await getDb().insert(updated);
+            broadcast(productionId, { type: 'GRAPHIC', overlayId: action.overlayId, active: true });
+          } else if (action.type === 'GRAPHIC_OFF' && action.overlayId) {
+            const updated: ProductionDoc = {
+              ...doc,
+              graphics: doc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: false } : g),
+              updatedAt: new Date().toISOString(),
+            };
+            await getDb().insert(updated);
+            broadcast(productionId, { type: 'GRAPHIC', overlayId: action.overlayId, active: false });
+          } else if (action.type === 'DSK_TOGGLE') {
+            if (!doc.stromFlowId || !doc.mixerBlockId) {
+              throw new Error('Pipeline not active or mixer block not resolved');
+            }
+            await strom.mixer.toggleDsk(doc.stromFlowId, doc.mixerBlockId, {
+              layer: action.layer ?? 0,
+              visible: action.visible,
+            });
+          }
+        } catch (err) {
+          failedAt = i;
+          failError = err instanceof Error ? err.message : String(err);
+          break;
+        }
+      }
+      if (failedAt !== -1) {
+        ws.send(JSON.stringify({ type: 'MACRO_ERROR', macroId: msg.macroId, failedActionIndex: failedAt, error: failError }));
+      } else {
+        broadcast(productionId, { type: 'MACRO_EXECUTED', macroId: msg.macroId });
+      }
       break;
     }
     default: {

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -121,48 +121,51 @@ async function handleMessage(
       for (let i = 0; i < macro.actions.length; i++) {
         const action = macro.actions[i];
         try {
+          // Re-fetch the document before each write to get the current _rev and
+          // avoid CouchDB 409 conflicts or overwriting changes from prior actions.
+          const currentDoc = await getDb().get(productionId);
           if (action.type === 'CUT' && action.sourceId) {
             const tally = getTally(productionId);
             const newTally = { pgm: action.sourceId, pvw: tally.pgm };
             setTally(productionId, newTally);
-            const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
+            const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
           } else if (action.type === 'TRANSITION' && action.sourceId) {
             const tally = getTally(productionId);
             const newTally = { pgm: action.sourceId, pvw: tally.pgm };
             setTally(productionId, newTally);
-            const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
+            const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: action.transitionType, durationMs: action.durationMs });
           } else if (action.type === 'TAKE') {
             const tally = getTally(productionId);
             const newTally = { pgm: tally.pvw, pvw: tally.pgm };
             setTally(productionId, newTally);
-            const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
+            const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
             const updated: ProductionDoc = {
-              ...doc,
-              graphics: doc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: true } : g),
+              ...currentDoc,
+              graphics: currentDoc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: true } : g),
               updatedAt: new Date().toISOString(),
             };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'GRAPHIC', overlayId: action.overlayId, active: true });
           } else if (action.type === 'GRAPHIC_OFF' && action.overlayId) {
             const updated: ProductionDoc = {
-              ...doc,
-              graphics: doc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: false } : g),
+              ...currentDoc,
+              graphics: currentDoc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: false } : g),
               updatedAt: new Date().toISOString(),
             };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'GRAPHIC', overlayId: action.overlayId, active: false });
           } else if (action.type === 'DSK_TOGGLE') {
-            if (!doc.stromFlowId || !doc.mixerBlockId) {
+            if (!currentDoc.stromFlowId || !currentDoc.mixerBlockId) {
               throw new Error('Pipeline not active or mixer block not resolved');
             }
-            await strom.mixer.toggleDsk(doc.stromFlowId, doc.mixerBlockId, {
+            await strom.mixer.toggleDsk(currentDoc.stromFlowId, currentDoc.mixerBlockId, {
               layer: action.layer ?? 0,
               visible: action.visible,
             });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Use forks pool so vi.mock works properly with ESM
+    pool: 'forks',
+    // Provide env vars required by config.ts
+    env: {
+      COUCHDB_URL: 'http://localhost:5984',
+      COUCHDB_NAME: 'open-live-test',
+      CORS_ORIGIN: 'http://localhost:5173',
+      STROM_URL: 'http://localhost:7000',
+      LOG_LEVEL: 'silent',
+    },
+  },
+});


### PR DESCRIPTION
Part of Eyevinn/open-live-studio#1

## Summary

Implements all backend changes required for the controller redesign epic. Spec: `docs/specs/controller-redesign.md`, ADR: `docs/decisions/ADR-001-macro-storage.md`.

- **Macro CRUD** (`/api/v1/productions/:id/macros`) — create, list, update, delete macros per production. Macros embedded in `ProductionDoc.macros[]` per ADR-001. Zod-validated (slot 0-7, label 1-50 chars, hex color). 3-retry on CouchDB 409 conflict.
- **DSK_TOGGLE WebSocket message** — calls `strom.mixer.toggleDsk()` via the production's `stromFlowId` + `mixerBlockId`. `mixerBlockId` is now resolved from the template's mixer block during `/activate`.
- **MACRO_EXEC WebSocket message** — fail-fast sequential execution of macro actions (CUT, TRANSITION, TAKE, GRAPHIC_ON/OFF, DSK_TOGGLE). Broadcasts `MACRO_EXECUTED` on success, `MACRO_ERROR` with failed action index on failure.
- **Audio passthrough** (`/api/v1/productions/:id/audio/:elementId`) — GET/PATCH Strom element properties with 5-second timeout.
- **Streaming stats** (`/api/v1/productions/:id/stats/streaming`) — parallel `rtpStats` + `webrtcStats` from Strom; returns `{ active: false }` when pipeline is not running; degrades gracefully on Strom error.
- **Template `audioElements[]`** — new field on `StromFlowTemplate` for mapping audio elements by label (for the frontend audio panel).

## Test plan

- [ ] `POST /api/v1/productions/:id/macros` creates macro with correct id prefix
- [ ] `PATCH /api/v1/productions/:id/macros/:macroId` updates fields
- [ ] `DELETE /api/v1/productions/:id/macros/:macroId` returns 404 for unknown id
- [ ] WS `DSK_TOGGLE` returns ERROR when pipeline not active
- [ ] WS `MACRO_EXEC` broadcasts `MACRO_ERROR` when action fails mid-sequence
- [ ] `GET /api/v1/productions/:id/stats/streaming` returns `{ active: false }` when stopped
- [ ] TypeScript strict mode: `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)