### PR TITLE
feat(activation): async activation state machine with Strom polling and WHEP endpoint

### DIFF
--- a/src/__tests__/activation.test.ts
+++ b/src/__tests__/activation.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for async activation state machine and ICE servers route.
+ *
+ * CouchDB, Strom client, and flow-generator are mocked — no real services required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../server.js';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+const mockFind = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: mockFind }),
+  getSourcesDb: () => ({ get: mockGet }),
+  getTemplatesDb: () => ({ get: mockGet }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket controller (avoids startup side effects)
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Mock flow-generator
+// ---------------------------------------------------------------------------
+
+const mockActivateStromFlow = vi.fn();
+const mockDeactivateStromFlow = vi.fn();
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: (...args: unknown[]) => mockActivateStromFlow(...args),
+  deactivateStromFlow: (...args: unknown[]) => mockDeactivateStromFlow(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient
+// ---------------------------------------------------------------------------
+
+const mockStromFlowsGet = vi.fn();
+const mockStromMixerMultiviewEndpoint = vi.fn();
+const mockStromSystemIceServers = vi.fn();
+const mockStromSystemVersion = vi.fn();
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = {
+      version: mockStromSystemVersion,
+      iceServers: mockStromSystemIceServers,
+    };
+    flows = {
+      get: mockStromFlowsGet,
+      start: vi.fn().mockResolvedValue({}),
+      stop: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    mixer = {
+      multiviewEndpoint: mockStromMixerMultiviewEndpoint,
+    };
+  }
+  return {
+    ...actual,
+    StromClient: MockStromClient,
+  };
+});
+
+// Mock strom-token
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProductionDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'prod-test-1',
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Test Production',
+    status: 'inactive',
+    sources: [],
+    pipeline: { stromConfig: null, status: 'stopped' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /api/v1/productions/:id/activate
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/productions/:id/activate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it('returns 200 with status "activating" immediately', async () => {
+    const doc = makeProductionDoc({ templateId: 'tmpl-1' });
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+    // The async polling loop will call activateStromFlow — we just let it
+    // resolve slowly so it doesn't interfere with this test
+    mockActivateStromFlow.mockResolvedValue('flow-abc');
+    mockStromFlowsGet.mockResolvedValue({ flow: { id: 'flow-abc', state: 'idle' } });
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/activate',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('activating');
+    expect(body.id).toBe('prod-test-1');
+  });
+
+  it('returns 409 if production is already active', async () => {
+    const doc = makeProductionDoc({ status: 'active' });
+    mockGet.mockResolvedValue(doc);
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/activate',
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = JSON.parse(res.body);
+    expect(body.error).toContain("already 'active'");
+  });
+
+  it('returns 409 if production is already activating', async () => {
+    const doc = makeProductionDoc({ status: 'activating' });
+    mockGet.mockResolvedValue(doc);
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/activate',
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = JSON.parse(res.body);
+    expect(body.error).toContain("already 'activating'");
+  });
+
+  it('returns 500 if CouchDB write fails', async () => {
+    const doc = makeProductionDoc();
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockRejectedValue(new Error('CouchDB connection error'));
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/activate',
+    });
+
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: POST /api/v1/productions/:id/deactivate
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/productions/:id/deactivate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it('clears whepEndpoint, stromFlowId, and mixerBlockId on deactivate', async () => {
+    const doc = makeProductionDoc({
+      status: 'active',
+      stromFlowId: 'flow-abc',
+      mixerBlockId: 'mixer-1',
+      whepEndpoint: 'https://strom.example.com/whep/flow-abc/mixer-1',
+    });
+    mockGet.mockResolvedValue(doc);
+    mockDeactivateStromFlow.mockResolvedValue(undefined);
+    mockInsert.mockResolvedValue({ rev: '3-cde', ok: true, id: doc._id });
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/deactivate',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('inactive');
+
+    // Verify the doc written to CouchDB cleared the fields
+    const insertedDoc = mockInsert.mock.calls[0][0];
+    expect(insertedDoc.whepEndpoint).toBeUndefined();
+    expect(insertedDoc.stromFlowId).toBeUndefined();
+    expect(insertedDoc.mixerBlockId).toBeUndefined();
+  });
+
+  it('returns 200 even if production has no stromFlowId', async () => {
+    const doc = makeProductionDoc({ status: 'inactive' });
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/deactivate',
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/v1/ice-servers
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/ice-servers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it('returns 200 with iceServers array from Strom', async () => {
+    mockStromSystemIceServers.mockResolvedValue({
+      ice_servers: [
+        { urls: ['turn:turn.example.com:3478'], username: 'user', credential: 'pass' },
+        { urls: ['stun:stun.example.com:3478'] },
+      ],
+    });
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/ice-servers',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.iceServers).toHaveLength(2);
+    expect(body.iceServers[0].urls).toContain('turn:turn.example.com:3478');
+    expect(body.iceServers[0].username).toBe('user');
+    expect(body.iceServers[0].credential).toBe('pass');
+  });
+
+  it('returns 502 if Strom is unreachable', async () => {
+    mockStromSystemIceServers.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/ice-servers',
+    });
+
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body.statusCode).toBe(502);
+  });
+
+  it('returns 502 if Strom returns a StromClientError', async () => {
+    const { StromClientError } = await import('../lib/strom.js');
+    mockStromSystemIceServers.mockRejectedValue(new StromClientError(503, 'Service unavailable'));
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/ice-servers',
+    });
+
+    expect(res.statusCode).toBe(502);
+  });
+});

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -147,7 +147,7 @@ export interface Tally {
   pvw: string | null;
 }
 
-export type ProductionStatus = 'active' | 'inactive';
+export type ProductionStatus = 'active' | 'inactive' | 'activating';
 
 export interface ProductionDoc {
   _id: string;
@@ -161,6 +161,8 @@ export interface ProductionDoc {
   templateId?: string;
   /** ID of the running Strom flow (set on activate, cleared on deactivate) */
   stromFlowId?: string;
+  /** WHEP multiview endpoint URL — set when flow reaches 'playing' state, cleared on deactivate */
+  whepEndpoint?: string;
   pipeline: Pipeline;
   graphics: GraphicOverlay[];
   macros: Macro[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,15 @@ import { connectDb, getDb } from './db/index.js';
 import { seedDefaultTemplate } from './db/seed.js';
 import { buildServer } from './server.js';
 import type { ProductionDoc } from './db/types.js';
+import type { FastifyBaseLogger } from 'fastify';
 
 /**
  * Startup recovery: reset any productions that were left in 'activating'
  * state (e.g. from a crash mid-polling loop) back to 'inactive'.
  */
-async function recoverStaleActivations(): Promise<void> {
+async function recoverStaleActivations(
+  log: FastifyBaseLogger,
+): Promise<void> {
   const db = getDb();
   const result = await db.find({ selector: { type: 'production', status: 'activating' } });
   for (const doc of result.docs as ProductionDoc[]) {
@@ -22,9 +25,9 @@ async function recoverStaleActivations(): Promise<void> {
         updatedAt: new Date().toISOString(),
       };
       await db.insert(updated);
-      console.info(`[startup] Reset stale 'activating' production ${doc._id} to 'inactive'`);
+      log.info({ productionId: doc._id }, "[startup] Reset stale 'activating' production to 'inactive'");
     } catch (err) {
-      console.error(`[startup] Failed to reset production ${doc._id}:`, err);
+      log.error({ err, productionId: doc._id }, '[startup] Failed to reset production to inactive');
     }
   }
 }
@@ -32,9 +35,9 @@ async function recoverStaleActivations(): Promise<void> {
 async function main() {
   await connectDb();
   await seedDefaultTemplate();
-  await recoverStaleActivations();
 
   const app = await buildServer();
+  await recoverStaleActivations(app.log);
   await app.listen({ port: config.port, host: '0.0.0.0' });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,38 @@
 import { config } from './config.js';
-import { connectDb } from './db/index.js';
+import { connectDb, getDb } from './db/index.js';
 import { seedDefaultTemplate } from './db/seed.js';
 import { buildServer } from './server.js';
+import type { ProductionDoc } from './db/types.js';
+
+/**
+ * Startup recovery: reset any productions that were left in 'activating'
+ * state (e.g. from a crash mid-polling loop) back to 'inactive'.
+ */
+async function recoverStaleActivations(): Promise<void> {
+  const db = getDb();
+  const result = await db.find({ selector: { type: 'production', status: 'activating' } });
+  for (const doc of result.docs as ProductionDoc[]) {
+    try {
+      const updated: ProductionDoc = {
+        ...doc,
+        status: 'inactive',
+        stromFlowId: undefined,
+        mixerBlockId: undefined,
+        whepEndpoint: undefined,
+        updatedAt: new Date().toISOString(),
+      };
+      await db.insert(updated);
+      console.info(`[startup] Reset stale 'activating' production ${doc._id} to 'inactive'`);
+    } catch (err) {
+      console.error(`[startup] Failed to reset production ${doc._id}:`, err);
+    }
+  }
+}
 
 async function main() {
   await connectDb();
   await seedDefaultTemplate();
+  await recoverStaleActivations();
 
   const app = await buildServer();
   await app.listen({ port: config.port, host: '0.0.0.0' });

--- a/src/routes/ice-servers.ts
+++ b/src/routes/ice-servers.ts
@@ -1,0 +1,39 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { StromClient, StromClientError } from '../lib/strom.js';
+import { getStromToken } from '../lib/strom-token.js';
+import { config } from '../config.js';
+
+/**
+ * GET /api/v1/ice-servers
+ *
+ * Proxies strom.system.iceServers() and returns the ICE server list in
+ * RTCIceServer shape. The frontend must never call Strom directly — Strom
+ * may be behind auth (STROM_TOKEN) and its URL is not exposed to the browser.
+ *
+ * Response 200: { iceServers: RTCIceServer[] }
+ * Response 502: Strom unreachable or returned an error
+ */
+const iceServersRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/api/v1/ice-servers', async (_req, reply) => {
+    try {
+      const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+      const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+
+      const { ice_servers } = await strom.system.iceServers();
+
+      // ice_servers from Strom is already compatible with RTCIceServer shape
+      // (urls, username?, credential?). Map from snake_case response key to
+      // camelCase response expected by the frontend.
+      return reply.send({ iceServers: ice_servers });
+    } catch (err) {
+      if (err instanceof StromClientError) {
+        fastify.log.error({ err }, 'Strom returned an error fetching ICE servers');
+        return reply.status(502).send({ error: 'Strom returned an error fetching ICE servers', statusCode: 502 });
+      }
+      fastify.log.error({ err }, 'Failed to fetch ICE servers from Strom');
+      return reply.status(502).send({ error: 'Strom unreachable', statusCode: 502 });
+    }
+  });
+};
+
+export default iceServersRoutes;

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -123,11 +123,18 @@ async function runActivationFlow(
         let whepEndpoint: string | undefined;
         if (mixerBlockId) {
           const resp = await strom.mixer.multiviewEndpoint(stromFlowId, mixerBlockId).catch(() => null);
+          // Guard: deactivate may have fired while multiviewEndpoint() was in-flight.
+          // Without this check, updateProductionDoc would write status:'active' after
+          // deactivate has already written status:'inactive'.
+          if (signal.aborted) {
+            await deactivateStromFlow(stromFlowId, strom).catch(() => {});
+            return;
+          }
           if (resp) whepEndpoint = resp.url;
         }
 
         if (signal.aborted) {
-          await deactivateStromFlow(stromFlowId, strom).catch(() => undefined);
+          await deactivateStromFlow(stromFlowId, strom).catch(() => {});
           return;
         }
 

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -3,10 +3,181 @@ import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
 import type { ProductionDoc, ProductionSourceAssignment } from '../db/types.js';
-import { StromClient } from '../lib/strom.js';
+import { StromClient, StromClientError } from '../lib/strom.js';
 import { getStromToken } from '../lib/strom-token.js';
 import { activateStromFlow, deactivateStromFlow } from '../lib/flow-generator.js';
 import { config } from '../config.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FLOW_POLL_INTERVAL_MS = 500;
+const FLOW_POLL_TIMEOUT_MS = 30_000;
+const MAX_DB_WRITE_RETRIES = 3;
+
+// ---------------------------------------------------------------------------
+// AbortController map — keyed by production ID, allows deactivate to cancel
+// an in-progress activation polling loop.
+// ---------------------------------------------------------------------------
+
+const activationAbortControllers = new Map<string, AbortController>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a partial update to ProductionDoc with retry-on-409.
+ * Re-reads the document before each retry to get the latest _rev.
+ */
+async function updateProductionDoc(
+  productionId: string,
+  patch: Partial<ProductionDoc>,
+): Promise<void> {
+  for (let attempt = 0; attempt < MAX_DB_WRITE_RETRIES; attempt++) {
+    try {
+      const doc = await getDb().get(productionId);
+      const updated: ProductionDoc = {
+        ...doc,
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      };
+      await getDb().insert(updated);
+      return;
+    } catch (err) {
+      // CouchDB 409 = revision conflict — retry after re-read
+      if (err instanceof Error && 'statusCode' in err && (err as { statusCode?: number }).statusCode === 409) {
+        if (attempt < MAX_DB_WRITE_RETRIES - 1) continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Async activation polling loop — runs fire-and-forget after the HTTP
+ * response has already been sent.
+ *
+ * Lifecycle:
+ *   1. Call activateStromFlow to create + start the Strom flow.
+ *   2. Persist stromFlowId + mixerBlockId (status stays 'activating').
+ *   3. Poll strom.flows.get(flowId) every FLOW_POLL_INTERVAL_MS.
+ *   4. On flow.state === 'playing': fetch WHEP URL, set status 'active'.
+ *   5. On timeout, error, or abort: best-effort cleanup, set status 'inactive'.
+ */
+async function runActivationFlow(
+  productionId: string,
+  signal: AbortSignal,
+  log: { error: (obj: unknown, msg: string) => void; info: (obj: unknown, msg: string) => void },
+): Promise<void> {
+  let stromFlowId: string | undefined;
+  let mixerBlockId: string | undefined;
+
+  try {
+    // Load the current production doc
+    const doc = await getDb().get(productionId);
+
+    const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+    const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+
+    // Step 1: Start the Strom flow
+    if (signal.aborted) return;
+    stromFlowId = await activateStromFlow(doc, strom);
+
+    // Resolve mixerBlockId from template
+    if (doc.templateId) {
+      const tmpl = await getDb().get(doc.templateId).catch(() => null);
+      if (tmpl) {
+        const mixerBlock = (tmpl as unknown as { flow?: { blocks?: Array<Record<string, unknown>> } })
+          .flow?.blocks?.find((b) => b['category'] === 'mixer');
+        if (mixerBlock && typeof mixerBlock['id'] === 'string') {
+          mixerBlockId = mixerBlock['id'];
+        }
+      }
+    }
+
+    // Step 2: Persist stromFlowId + mixerBlockId
+    if (signal.aborted) {
+      await deactivateStromFlow(stromFlowId, strom).catch(() => undefined);
+      return;
+    }
+    await updateProductionDoc(productionId, {
+      stromFlowId,
+      ...(mixerBlockId !== undefined && { mixerBlockId }),
+    });
+
+    // Step 3: Poll until flow reaches 'playing' or we time out
+    const deadline = Date.now() + FLOW_POLL_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      if (signal.aborted) {
+        await deactivateStromFlow(stromFlowId, strom).catch(() => undefined);
+        return;
+      }
+
+      const { flow } = await strom.flows.get(stromFlowId);
+
+      if (flow.state === 'playing') {
+        // Step 4: Retrieve WHEP multiview endpoint
+        let whepEndpoint: string | undefined;
+        if (mixerBlockId) {
+          const resp = await strom.mixer.multiviewEndpoint(stromFlowId, mixerBlockId).catch(() => null);
+          if (resp) whepEndpoint = resp.url;
+        }
+
+        if (signal.aborted) {
+          await deactivateStromFlow(stromFlowId, strom).catch(() => undefined);
+          return;
+        }
+
+        await updateProductionDoc(productionId, {
+          status: 'active',
+          whepEndpoint,
+        });
+
+        log.info({ productionId, stromFlowId, whepEndpoint }, 'Production activated — flow playing');
+        return;
+      }
+
+      // Wait before next poll
+      await new Promise<void>((resolve) => setTimeout(resolve, FLOW_POLL_INTERVAL_MS));
+    }
+
+    // Timeout reached
+    throw new Error(`Strom flow ${stromFlowId} did not reach 'playing' state within ${FLOW_POLL_TIMEOUT_MS}ms`);
+  } catch (err) {
+    if (signal.aborted) {
+      // Deactivate called during activation — cleanup already handled by deactivate handler
+      return;
+    }
+
+    log.error({ err, productionId, stromFlowId }, 'Activation flow failed — resetting to inactive');
+
+    // Best-effort flow cleanup
+    if (stromFlowId) {
+      const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
+      const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
+      await deactivateStromFlow(stromFlowId, strom).catch(() => undefined);
+    }
+
+    // Reset production to inactive, clearing all flow-related fields
+    await updateProductionDoc(productionId, {
+      status: 'inactive',
+      stromFlowId: undefined,
+      mixerBlockId: undefined,
+      whepEndpoint: undefined,
+    }).catch((resetErr) => {
+      log.error({ resetErr, productionId }, 'Failed to reset production to inactive after activation failure');
+    });
+  } finally {
+    activationAbortControllers.delete(productionId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
 
 const ProductionInput = z.object({
   name: z.string().min(1),
@@ -21,6 +192,10 @@ const SourceAssignmentInput = z.object({
   sourceId: z.string().min(1),
   mixerInput: z.string().min(1),
 });
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
 
 const productionsRoutes: FastifyPluginAsync = async (fastify) => {
   // List all productions
@@ -92,66 +267,63 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
     }
   });
 
-  // Activate a production — creates and starts a Strom flow
+  // Activate a production — immediately returns 'activating', then polls Strom
+  // for flow state in a fire-and-forget async loop.
   fastify.post<{ Params: { id: string } }>('/api/v1/productions/:id/activate', async (req, reply) => {
     try {
       const doc = await getDb().get(req.params.id);
 
-      const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
-      const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
-
-      let stromFlowId: string | undefined;
-      let stromVersion: string | null = null;
-
-      // Fetch Strom version (best-effort)
-      stromVersion = await strom.system.version()
-        .then((info) => info.version)
-        .catch(() => null);
-
-      // Start Strom flow if a template is configured
-      let mixerBlockId: string | undefined;
-      if (doc.templateId) {
-        stromFlowId = await activateStromFlow(doc, strom);
-
-        // Resolve mixer block ID from template for DSK/transition operations
-        const tmpl = await getDb().get(doc.templateId).catch(() => null);
-        if (tmpl) {
-          const mixerBlock = (tmpl as unknown as { flow?: { blocks?: Array<Record<string, unknown>> } })
-            .flow?.blocks?.find((b) => b['category'] === 'mixer');
-          if (mixerBlock && typeof mixerBlock['id'] === 'string') {
-            mixerBlockId = mixerBlock['id'];
-          }
-        }
+      // Guard: reject if already active or activating
+      if (doc.status === 'active' || doc.status === 'activating') {
+        return reply.status(409).send({
+          error: `Production is already '${doc.status}'`,
+          statusCode: 409,
+        });
       }
 
-      const updated: ProductionDoc = {
+      // Transition to 'activating' immediately and respond
+      const activatingDoc: ProductionDoc = {
         ...doc,
-        status: 'active',
-        ...(stromFlowId !== undefined && { stromFlowId }),
-        ...(mixerBlockId !== undefined && { mixerBlockId }),
+        status: 'activating',
         updatedAt: new Date().toISOString(),
       };
-      const response = await getDb().insert(updated);
+      const insertResponse = await getDb().insert(activatingDoc);
+
+      // Set up AbortController so deactivate can cancel the polling loop
+      const abortController = new AbortController();
+      activationAbortControllers.set(doc._id, abortController);
+
+      // Fire-and-forget — must never let a rejection escape to the global handler
+      void runActivationFlow(doc._id, abortController.signal, fastify.log).catch((err) => {
+        fastify.log.error({ err, productionId: doc._id }, 'Unhandled error in runActivationFlow');
+      });
 
       return reply.send({
-        id: updated._id,
-        name: updated.name,
-        status: updated.status,
-        stromFlowId: updated.stromFlowId,
-        stromVersion,
-        _rev: response.rev,
+        id: activatingDoc._id,
+        name: activatingDoc.name,
+        status: activatingDoc.status,
+        stromFlowId: activatingDoc.stromFlowId,
+        _rev: insertResponse.rev,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      fastify.log.error({ err }, 'Failed to activate production');
+      fastify.log.error({ err }, 'Failed to initiate production activation');
       return reply.status(500).send({ error: message, statusCode: 500 });
     }
   });
 
-  // Deactivate a production — stops and deletes the Strom flow
+  // Deactivate a production — stops and deletes the Strom flow, cancels any
+  // in-progress activation polling loop.
   fastify.post<{ Params: { id: string } }>('/api/v1/productions/:id/deactivate', async (req, reply) => {
     try {
       const doc = await getDb().get(req.params.id);
+
+      // Cancel any in-progress activation loop
+      const abortController = activationAbortControllers.get(doc._id);
+      if (abortController) {
+        abortController.abort();
+        activationAbortControllers.delete(doc._id);
+      }
 
       if (doc.stromFlowId) {
         const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
@@ -163,6 +335,8 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
         ...doc,
         status: 'inactive',
         stromFlowId: undefined,
+        mixerBlockId: undefined,
+        whepEndpoint: undefined,
         updatedAt: new Date().toISOString(),
       };
       const response = await getDb().insert(updated);
@@ -215,4 +389,5 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
   );
 };
 
+export { activationAbortControllers };
 export default productionsRoutes;

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import pipelineRoutes from './routes/pipeline.js';
 import macrosRoutes from './routes/macros.js';
 import audioRoutes from './routes/audio.js';
 import statsRoutes from './routes/stats.js';
+import iceServersRoutes from './routes/ice-servers.js';
 import controllerWs from './ws/controller.js';
 
 export async function buildServer() {
@@ -53,6 +54,7 @@ export async function buildServer() {
   await fastify.register(macrosRoutes);
   await fastify.register(audioRoutes);
   await fastify.register(statsRoutes);
+  await fastify.register(iceServersRoutes);
   await fastify.register(controllerWs);
 
   return fastify;


### PR DESCRIPTION
## Summary

- Rewrites `POST /api/v1/productions/:id/activate` to return immediately with `status: 'activating'` and run an async Strom flow polling loop, per ADR-002
- Adds server-side polling of `strom.flows.get()` every 500 ms (30 s timeout) with automatic WHEP endpoint retrieval via `strom.mixer.multiviewEndpoint()` on flow reaching `playing` state
- New `GET /api/v1/ice-servers` endpoint proxies `strom.system.iceServers()` for the frontend WHEP client (TURN credentials must not be hardcoded per `docs/repo-patterns.md`)
- `POST /deactivate` now clears `whepEndpoint`, `mixerBlockId`, and cancels any in-progress activation loop via `AbortController`
- Startup recovery resets stale `activating` productions to `inactive` (handles crash-during-polling)
- CouchDB writes use retry-on-409 pattern (up to 3 retries) to handle optimistic concurrency conflicts

## Data model changes

- `ProductionStatus`: added `'activating'` value (`src/db/types.ts`)
- `ProductionDoc`: added `whepEndpoint?: string` field (`src/db/types.ts`)
- No CouchDB migration required (schemaless; existing docs handled gracefully)

## Test plan

- [x] `POST /activate` returns 200 with `status: 'activating'` immediately
- [x] `POST /activate` returns 409 if production is already `active` or `activating`
- [x] `POST /activate` returns 500 if initial CouchDB write fails
- [x] `POST /deactivate` clears `whepEndpoint`, `stromFlowId`, `mixerBlockId`
- [x] `POST /deactivate` returns 200 when production has no `stromFlowId`
- [x] `GET /api/v1/ice-servers` returns 200 with `iceServers` array from Strom
- [x] `GET /api/v1/ice-servers` returns 502 if Strom is unreachable
- [x] `GET /api/v1/ice-servers` returns 502 if Strom returns a `StromClientError`
- All 28 tests pass (`npx vitest run`)

## References

- Spec: `docs/specs/activation-whep.md`
- ADR: `docs/decisions/ADR-002-async-activation-state-machine.md`
- Epic: Closes Eyevinn/open-live-studio#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)