### PR TITLE
fix: resolve 422 on activation — Strom flow create is two-step

### DIFF
--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -50,9 +50,18 @@ export async function activateStromFlow(
     (block['properties'] as Record<string, unknown>)[slot.addressProperty] = source.address;
   }
 
-  // Create the flow in Strom — pass the raw flow content through as-is
+  // Step 1: Create an empty flow (POST only accepts name + description).
   const flowName = `${production.name}-${randomUUID().slice(0, 8)}`;
   const created = await strom.flows.create({
+    name: flowName,
+    description: `Production: ${production.name}`,
+  });
+
+  const flowId = created.flow.id;
+
+  // Step 2: Write the full flow content via PUT.
+  await strom.flows.update(flowId, {
+    id: flowId,
     name: flowName,
     description: `Production: ${production.name}`,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -62,8 +71,6 @@ export async function activateStromFlow(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     links: flow.links as any,
   });
-
-  const flowId = created.flow.id;
 
   // Start the flow
   await strom.flows.start(flowId);

--- a/src/lib/strom.ts
+++ b/src/lib/strom.ts
@@ -82,10 +82,10 @@ export interface FlowElement {
 }
 
 export interface FlowLink {
-  from_element: string
-  from_pad?: string
-  to_element: string
-  to_pad?: string
+  /** Format: "element_id" or "element_id:pad_name" */
+  from: string
+  /** Format: "element_id" or "element_id:pad_name" */
+  to: string
 }
 
 export interface BlockDefinition {
@@ -124,14 +124,27 @@ export interface CreateBlockRequest {
 
 export type FlowState = 'idle' | 'playing' | 'paused'
 
+/**
+ * A block instance in a flow — references a block definition by ID and
+ * provides property values for it. This is the runtime shape stored in
+ * Flow.blocks, distinct from BlockDefinition (the catalog entry).
+ */
+export interface BlockInstance {
+  id: string
+  block_definition_id: string
+  name?: string | null
+  properties: Record<string, unknown>
+  position: { x: number; y: number }
+}
+
 export interface Flow {
   id: string
   name: string
   description?: string
-  state: FlowState
-  elements: FlowElement[]
-  links: FlowLink[]
-  clock_type?: string
+  running?: boolean
+  elements?: FlowElement[]
+  blocks?: BlockInstance[]
+  links?: FlowLink[]
 }
 
 export interface FlowResponse {
@@ -142,13 +155,13 @@ export interface FlowListResponse {
   flows: Flow[]
 }
 
+/**
+ * POST /api/flows only accepts name + description.
+ * To set blocks/elements/links, PUT /api/flows/{id} with the full Flow body.
+ */
 export interface CreateFlowRequest {
   name: string
   description?: string
-  elements?: FlowElement[]
-  blocks?: BlockDefinition[]
-  links?: FlowLink[]
-  clock_type?: string
 }
 
 export interface UpdateFlowPropertiesRequest {

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -118,7 +118,7 @@ async function runActivationFlow(
 
       const { flow } = await strom.flows.get(stromFlowId);
 
-      if (flow.state === 'playing') {
+      if (flow.running === true) {
         // Step 4: Retrieve WHEP multiview endpoint
         let whepEndpoint: string | undefined;
         if (mixerBlockId) {


### PR DESCRIPTION
## Summary

- **Root cause**: `POST /api/flows` in Strom only accepts `{ name, description }`. The previous code sent `elements`, `blocks`, and `links` in the create request, which Strom rejects with `422: Invalid request body`.
- **Fix**: Two-step pattern — create empty flow via `POST`, then write full content via `PUT /api/flows/{id}`.
- **Type corrections**: `strom.ts` types corrected against `strom/openapi.json`:
  - `FlowLink` now uses `{ from: string, to: string }` (not invented `from_element`/`to_element`)
  - `Flow.running: boolean` replaces the invented `Flow.state` enum
  - `BlockInstance` type added for block instances (distinct from `BlockDefinition`)
  - `CreateFlowRequest` stripped to `{ name, description }` only
- **Docs**: Pattern added to `docs/repo-patterns.md`

## Files changed

- `src/lib/flow-generator.ts` — two-step create → PUT in `activateStromFlow`
- `src/lib/strom.ts` — `FlowLink`, `Flow`, `BlockInstance`, `CreateFlowRequest` corrected
- `src/routes/productions.ts` — `flow.state === 'playing'` → `flow.running === true`

## Test plan

- [ ] Click Activate on a production — status transitions to `activating` then `active`
- [ ] Flow appears in Strom UI with correct blocks, elements, and links
- [ ] WHEP multiview endpoint is retrieved and stored on the production doc
- [ ] Deactivate stops and deletes the Strom flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)