### PR TITLE
fix: replace hardcoded CouchDB credentials with env vars (closes #10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 PORT=3000
-COUCHDB_URL=http://admin:password@localhost:5984
+COUCHDB_USER=admin
+COUCHDB_PASSWORD=change-me-before-use
+COUCHDB_URL=http://admin:change-me-before-use@localhost:5984
 COUCHDB_NAME=open-live
 # Must be a specific origin (not *) since the studio sends credentials: include
 CORS_ORIGIN=http://localhost:5173

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   couchdb:
     image: couchdb:3
     environment:
-      COUCHDB_USER: admin
-      COUCHDB_PASSWORD: password
+      COUCHDB_USER: ${COUCHDB_USER:-admin}
+      COUCHDB_PASSWORD: ${COUCHDB_PASSWORD:?Set COUCHDB_PASSWORD in .env (see .env.example)}
     ports:
       - "5984:5984"
     volumes:
@@ -15,7 +15,7 @@ services:
       - "3000:3000"
     environment:
       PORT: "3000"
-      COUCHDB_URL: http://admin:password@couchdb:5984
+      COUCHDB_URL: http://${COUCHDB_USER:-admin}:${COUCHDB_PASSWORD}@couchdb:5984
       COUCHDB_NAME: open-live
       CORS_ORIGIN: http://localhost:5173
       LOG_LEVEL: info


### PR DESCRIPTION
## Summary

- `docker-compose.yml` now reads `COUCHDB_USER` and `COUCHDB_PASSWORD` from the environment (or a `.env` file) instead of embedding plain-text credentials
- `COUCHDB_PASSWORD` is declared required (`${COUCHDB_PASSWORD:?…}`) — docker-compose will refuse to start if it is unset, preventing accidental use of the trivially guessable default
- `.env.example` gains `COUCHDB_USER` and `COUCHDB_PASSWORD` entries with a safe placeholder so developers know what to set

## Test plan

- [ ] Copy `.env.example` to `.env`, set a strong `COUCHDB_PASSWORD`
- [ ] Run `docker compose up` — services start correctly
- [ ] Run `docker compose up` without `.env` — compose exits with a descriptive error about the missing variable

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)