### PR TITLE
fix: quote environment input and add validation in sync-fork workflow (closes #27)

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -19,6 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Validate environment
+        run: |
+          case "${{ inputs.environment }}" in
+            prod|dev|stage) ;;
+            *) echo "Invalid environment: ${{ inputs.environment }}"; exit 1 ;;
+          esac
+
       - name: Install OSC CLI
         run: npm install -g @osaas/cli
 
@@ -26,4 +33,4 @@ jobs:
         env:
           OSC_ACCESS_TOKEN: unused
           OSC_API_KEY: ${{ secrets.OSC_API_KEY }}
-        run: osc --env ${{ inputs.environment }} admin sync-fork eyevinn-open-live
+        run: osc --env "${{ inputs.environment }}" admin sync-fork eyevinn-open-live


### PR DESCRIPTION
## Summary

- Added an explicit allowlist validation step that rejects any `environment` value other than `prod`, `dev`, or `stage` — the workflow exits with an error before running the CLI command
- Wrapped `${{ inputs.environment }}` in double quotes in the `osc` run command so the value cannot escape the shell argument boundary even if validation were bypassed

The `type: choice` UI restriction is not enforced by the GitHub Actions API; a caller with repo write access can dispatch arbitrary string values, making unquoted expression interpolation a shell injection vector.

## Test plan

- [ ] Trigger the workflow normally with `prod` — passes validation and runs `osc`
- [ ] Trigger via API with an unexpected value (e.g. `invalid`) — validation step fails with a clear error message

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)