### PR TITLE
fix: run container as non-root user in runtime stage (closes #45)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,13 @@ COPY src ./src
 RUN pnpm run build
 
 FROM node:22-alpine AS runtime
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 COPY --from=build /app/dist ./dist
+RUN chown -R appuser:appgroup /app
+USER appuser
 EXPOSE 3000
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Summary

- Added a dedicated non-root user (`appuser` in group `appgroup`) to the Dockerfile runtime stage using `addgroup`/`adduser`
- Set ownership of `/app` to `appuser:appgroup` after installing dependencies
- Added `USER appuser` directive before the `CMD` instruction

Without a `USER` directive the Node.js process runs as UID 0 (root) inside the container. If the service is compromised this gives the attacker full write access to the container filesystem and significantly raises the risk of container escape.

Closes #45