### PR TITLE
fix: add Helmet middleware for HTTP security headers (closes #17)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
 import websocket from '@fastify/websocket';
 import { ZodError } from 'zod';
 import { config } from './config.js';
@@ -25,6 +26,13 @@ export async function buildServer() {
       level: config.logLevel,
     },
     disableRequestLogging: true,
+  });
+
+  await fastify.register(helmet, {
+    contentSecurityPolicy: {
+      directives: { defaultSrc: ["'none'"], connectSrc: ["'self'"] },
+    },
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
   });
 
   await fastify.register(cors, {


### PR DESCRIPTION
## Summary

- Imported `@fastify/helmet` (already present in `dependencies`) into `src/server.ts`
- Registered the Helmet plugin before CORS so security headers are applied to every response
- Configured `contentSecurityPolicy` with `defaultSrc: 'none'` and `connectSrc: 'self'` (appropriate for a pure API server)
- Set `crossOriginResourcePolicy: cross-origin` to stay consistent with the existing `CORS origin: '*'` setting

This adds `X-Frame-Options`, `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`, `Referrer-Policy`, and `Content-Security-Policy` headers to all responses, closing the OWASP A05 finding.

Closes #17