### PR TITLE
fix: remove data:text/html from graphicUrl() allowed MIME types (closes #70)

### DIFF
--- a/src/__tests__/url-validation.test.ts
+++ b/src/__tests__/url-validation.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { graphicUrl, httpUrlOnly, srtUrl } from '../lib/url-validation.js';
+
+describe('graphicUrl', () => {
+  it('accepts https:// URLs', () => {
+    expect(() => graphicUrl('https://example.com/overlay.png')).not.toThrow();
+  });
+
+  it('accepts http:// URLs', () => {
+    expect(() => graphicUrl('http://example.com/overlay')).not.toThrow();
+  });
+
+  it('accepts data:image/png URIs', () => {
+    expect(() => graphicUrl('data:image/png;base64,abc123')).not.toThrow();
+  });
+
+  it('accepts data:image/jpeg URIs', () => {
+    expect(() => graphicUrl('data:image/jpeg;base64,abc123')).not.toThrow();
+  });
+
+  it('accepts data:image/gif URIs', () => {
+    expect(() => graphicUrl('data:image/gif;base64,abc123')).not.toThrow();
+  });
+
+  it('accepts data:image/webp URIs', () => {
+    expect(() => graphicUrl('data:image/webp;base64,abc123')).not.toThrow();
+  });
+
+  it('rejects data:text/html URIs (JS execution risk in CEF)', () => {
+    expect(() =>
+      graphicUrl('data:text/html,<html><script>alert(1)</script></html>')
+    ).toThrow();
+  });
+
+  it('rejects data:text/html with encoded payload', () => {
+    expect(() =>
+      graphicUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')
+    ).toThrow();
+  });
+
+  it('rejects file:// URLs', () => {
+    expect(() => graphicUrl('file:///etc/passwd')).toThrow();
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(() => graphicUrl('javascript:alert(1)')).toThrow();
+  });
+
+  it('rejects data:application/* URIs', () => {
+    expect(() => graphicUrl('data:application/json,{}')).toThrow();
+  });
+
+  it('rejects data:text/plain URIs', () => {
+    expect(() => graphicUrl('data:text/plain,hello')).toThrow();
+  });
+});
+
+describe('httpUrlOnly', () => {
+  it('accepts https:// URLs', () => {
+    expect(() => httpUrlOnly('https://example.com')).not.toThrow();
+  });
+
+  it('accepts http:// URLs', () => {
+    expect(() => httpUrlOnly('http://example.com')).not.toThrow();
+  });
+
+  it('rejects ftp:// URLs', () => {
+    expect(() => httpUrlOnly('ftp://example.com')).toThrow();
+  });
+
+  it('rejects invalid URLs', () => {
+    expect(() => httpUrlOnly('not-a-url')).toThrow();
+  });
+});
+
+describe('srtUrl', () => {
+  it('accepts valid srt:// URLs', () => {
+    expect(() => srtUrl('srt://example.com:9000')).not.toThrow();
+  });
+
+  it('rejects non-srt URLs', () => {
+    expect(() => srtUrl('http://example.com')).toThrow();
+  });
+});

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -25,14 +25,14 @@ export function httpUrlOnly(url: string): void {
   }
 }
 
-const ALLOWED_DATA_MIME = /^data:(text\/html|image\/(png|jpeg|gif|webp))[;,]/i;
+const ALLOWED_DATA_MIME = /^data:image\/(png|jpeg|gif|webp)[;,]/i;
 const BLOCKED_SCHEMES = /^(file|javascript|ftp|gopher|chrome|about|data:application):/i;
 
 /**
  * Throws if the value is not a safe graphic URL.
- * Accepts: http/https URLs, data:text/html (inline HTML overlays rendered by Strom's headless browser),
- *          or data:image/(png|jpeg|gif|webp) base64 URIs.
- * Rejects: file://, javascript:, data:application/*, etc.
+ * Accepts: http/https URLs or data:image/(png|jpeg|gif|webp) base64 URIs.
+ * Rejects: data:text/html (JS execution risk in CEF), file://, javascript:, data:application/*, etc.
+ * HTML overlay sources must be served from a trusted https:// URL, not inline data URIs.
  */
 export function graphicUrl(url: string): void {
   if (BLOCKED_SCHEMES.test(url)) {
@@ -40,7 +40,7 @@ export function graphicUrl(url: string): void {
   }
   if (url.startsWith('data:')) {
     if (!ALLOWED_DATA_MIME.test(url)) {
-      throw new Error('Only data:text/html or data:image/(png|jpeg|gif|webp) URIs are allowed for graphics');
+      throw new Error('Only data:image/(png|jpeg|gif|webp) URIs are allowed for graphics; HTML overlays must use an https:// URL');
     }
     return;
   }


### PR DESCRIPTION
## Summary

- Removed `text/html` from `ALLOWED_DATA_MIME` in `src/lib/url-validation.ts`, restricting data URI support to image-only MIME types (`png`, `jpeg`, `gif`, `webp`)
- Updated the JSDoc comment and error message to reflect that HTML overlay sources must use an `https://` URL rather than an inline data URI
- Added `src/__tests__/url-validation.test.ts` with 18 test cases covering all accept/reject paths, including a direct regression test for `data:text/html`

## Why

`data:text/html` URIs were explicitly permitted, allowing an authenticated user to supply a graphic overlay URL containing JavaScript that executes inside Strom's CEF (Chromium Embedded Framework) renderer. Because CEF runs with network access on the Strom host, this enabled SSRF and potential credential exfiltration — a meaningful escalation beyond a simple content injection. Restricting data URIs to image types eliminates script execution risk entirely.

HTML overlay sources that previously used inline `data:text/html` must be migrated to an `https://` URL served from a trusted web server.

Closes #70