### PR TITLE
fix: enforce hex color format on PipZone border.color (closes #68)

### DIFF
--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -67,7 +67,7 @@ const PipZoneSchema = z.object({
   rect: z.object({ x: z.number(), y: z.number(), w: z.number(), h: z.number() }).nullable(),
   capacity: z.number().nullable(),
   sources: z.array(z.number().int().min(0).max(15)),
-  border: z.object({ color: z.string().max(9), width: z.number().min(0).max(64) }).nullish(),
+  border: z.object({ color: z.string().regex(/^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/, 'Must be #RRGGBB or #RRGGBBAA'), width: z.number().int().min(0).max(64) }).nullish(),
 });
 
 const InboundMessageSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
## Summary

- Added a `.regex(/^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/, 'Must be #RRGGBB or #RRGGBBAA')` refinement to `PipZoneSchema.border.color` in `src/ws/controller.ts`
- Also tightened `width` to `.number().int()` (was `.number()`) to match the field's semantic intent

## Why

The `border.color` field previously accepted any string up to 9 characters. An authenticated WebSocket client could supply shell metacharacters, format strings, or other unexpected input that would be forwarded verbatim to Strom's pipeline configuration. The regex restricts the field to valid `#RRGGBB` or `#RRGGBBAA` hex color values, eliminating the injection surface.

Closes #68