### PR TITLE
fix: enforce allowlist enum on transitionType in WebSocket messages (closes #67)

### DIFF
--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -70,10 +70,23 @@ const PipZoneSchema = z.object({
   border: z.object({ color: z.string().max(9), width: z.number().min(0).max(64) }).nullish(),
 });
 
+const TransitionTypeSchema = z.enum([
+  'cut', 'fade', 'dip_to_black',
+  'slide_left', 'slide_right', 'slide_up', 'slide_down',
+  'push_left', 'push_right', 'push_up', 'push_down',
+  'wipe_left', 'wipe_right', 'wipe_up', 'wipe_down',
+  'iris_open', 'iris_close', 'clock_wipe', 'blinds', 'checker',
+  'noise_dissolve', 'luma_wipe', 'barn_doors', 'star_wipe',
+  'pinwheel', 'crosshatch', 'hex_dissolve', 'warp_wipe', 'melt', 'heart_iris',
+  'glitch_cut', 'flash_dissolve', 'whip_pan_left', 'whip_pan_right',
+  'punch_zoom', 'pixelate_take', 'zoom_blur', 'spin', 'tv_roll',
+  'negative_flash', 'ripple',
+]);
+
 const InboundMessageSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('CUT'), mixerInput: mixerInputSchema, afvRampUpMs: rampMsSchema.optional(), afvRampDownMs: rampMsSchema.optional() }),
-  z.object({ type: z.literal('TRANSITION'), mixerInput: mixerInputSchema, transitionType: z.string().max(32), durationMs: rampMsSchema.optional(), afvRampUpMs: rampMsSchema.optional(), afvRampDownMs: rampMsSchema.optional() }),
-  z.object({ type: z.literal('TAKE'), pip: pipIndexSchema.optional(), transitionType: z.string().max(32).optional(), durationMs: rampMsSchema.optional(), afvRampUpMs: rampMsSchema.optional(), afvRampDownMs: rampMsSchema.optional() }),
+  z.object({ type: z.literal('TRANSITION'), mixerInput: mixerInputSchema, transitionType: TransitionTypeSchema, durationMs: rampMsSchema.optional(), afvRampUpMs: rampMsSchema.optional(), afvRampDownMs: rampMsSchema.optional() }),
+  z.object({ type: z.literal('TAKE'), pip: pipIndexSchema.optional(), transitionType: TransitionTypeSchema.optional(), durationMs: rampMsSchema.optional(), afvRampUpMs: rampMsSchema.optional(), afvRampDownMs: rampMsSchema.optional() }),
   z.object({ type: z.literal('SET_PVW'), mixerInput: mixerInputSchema }),
   z.object({ type: z.literal('FTB'), active: z.boolean().optional(), durationMs: rampMsSchema.optional() }),
   z.object({ type: z.literal('SET_OVL'), alpha: alphaSchema }),


### PR DESCRIPTION
## Summary

Replaces the permissive `z.string().max(32)` validator on `transitionType` in `TRANSITION` and `TAKE` WebSocket messages with a strict `z.enum([...])` containing all valid Strom transition names.

**What changed:**
- Added `TransitionTypeSchema` (Zod enum) in `src/ws/controller.ts` listing all valid Strom transition types
- `TRANSITION` message: `transitionType` now must be one of the known enum values
- `TAKE` message: `transitionType` (optional) now must be one of the known enum values when provided

Arbitrary strings can no longer reach the Strom pipeline API via the WebSocket handler. Any client sending an unrecognised transition type will receive a validation error before the message is forwarded to Strom.

Closes #67