### PR TITLE
fix: validate dskInput against dsk_in_N pattern

### DIFF
--- a/src/__tests__/productions.test.ts
+++ b/src/__tests__/productions.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for productions routes — dskInput validation (issue #61).
+ *
+ * CouchDB and WS controller are mocked — no real services required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../server.js';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert }),
+  getSourcesDb: () => ({ get: mockGet }),
+  getOutputsDb: () => ({ get: vi.fn().mockResolvedValue(null) }),
+  getGraphicsDb: () => ({ get: vi.fn().mockResolvedValue(null) }),
+  getConfigsDb: () => ({ get: vi.fn().mockResolvedValue(null) }),
+  isDbConnected: () => true,
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket controller (avoids startup side effects)
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Helper: quick production doc lookup
+// ---------------------------------------------------------------------------
+
+const prodDoc = (overrides = {}) => ({
+  _id: 'prod-test-1',
+  type: 'production',
+  name: 'Test Production',
+  sources: [],
+  graphicAssignments: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGet.mockResolvedValue(prodDoc());
+  mockInsert.mockResolvedValue({ ok: true, id: 'prod-test-1', rev: '1-abc' });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/productions/:id/graphics', () => {
+  it('accepts valid dskInput format (dsk_in_N)', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/graphics',
+      payload: { graphicId: 'g-1', dskInput: 'dsk_in_0' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('accepts dsk_in with multi-digit index', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/graphics',
+      payload: { graphicId: 'g-2', dskInput: 'dsk_in_42' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('rejects dskInput with colons (would corrupt Strom flow link)', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/graphics',
+      payload: { graphicId: 'g-3', dskInput: 'dsk_in_0:bad' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects empty dskInput', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/graphics',
+      payload: { graphicId: 'g-4', dskInput: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects arbitrarily long dskInput (>20 chars)', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/graphics',
+      payload: { graphicId: 'g-5', dskInput: 'dsk_in_0123456789012345' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects dskInput with special characters', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/graphics',
+      payload: { graphicId: 'g-6', dskInput: 'dsk_in_<script>' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects non-dsk_in_ format strings', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/graphics',
+      payload: { graphicId: 'g-7', dskInput: 'video_in_0' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -321,7 +321,7 @@ const SourceAssignmentInput = z.object({
 
 const GraphicAssignmentInput = z.object({
   graphicId: z.string().min(1),
-  dskInput: z.string().min(1),
+  dskInput: z.string().regex(/^dsk_in_\d+$/).max(20),
 });
 
 const OutputAssignmentInput = z.object({


### PR DESCRIPTION
Closes #61

## Problem

The `dskInput` field on `POST /api/v1/productions/:id/graphics` accepted any non-empty string (`z.string().min(1)`). When this value contains a colon, the Strom flow link built in `flow-generator.ts` becomes syntactically invalid because the link format is `from:to:both_sides` — a colon in `dskInput` corrupts the flow topology.

CVSS 4.9 Medium — input validation leading to flow corruption.

## Fix

Change the `dskInput` Zod schema from `z.string().min(1)` to `z.string().regex(/^dsk_in_\d+$/).max(20)`.

This enforces the same `dsk_in_N` pattern already used as a consumer check at `flow-generator.ts:619`, but at the API entry point where the value is first received.

## Verification

- Added 7 vitest tests covering valid (dsk_in_0, dsk_in_42) and invalid (colons, empty, overlong, special chars, wrong format) inputs.
- All tests pass.
- Existing test suite failures in activation.test.ts and macros.test.ts are pre-existing (missing isDbConnected in mock) and reproduce on main.

## Change

1 file changed, 1 insertion, 1 deletion (src/routes/productions.ts).
1 file added (src/__tests__/productions.test.ts, 130 lines).
