### PR TITLE
fix: require API key authentication for Swagger UI and OpenAPI spec endpoints (closes #81)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -112,7 +112,7 @@ export async function buildServer() {
     fastify.addHook('onRequest', async (req, reply) => {
       const path = req.url.split('?')[0]!;
       if (AUTH_EXEMPT_PATHS.has(path)) return;
-      if (!req.url.startsWith('/api/v1')) return;
+      if (!req.url.startsWith('/api/v1') && !req.url.startsWith('/documentation')) return;
 
       const authHeader = req.headers['authorization'];
       const keyFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;


### PR DESCRIPTION
## Summary
Extends the API key auth hook to also guard `/documentation*` routes. Previously, the hook only fired for `/api/v1` paths, leaving the Swagger UI and OpenAPI spec (JSON/YAML) accessible without authentication even when `API_KEY` is configured.

## Changes
- `src/server.ts`: updated the `onRequest` auth hook URL prefix check to also cover `/documentation`

Closes #81