### PR TITLE
fix: implement per-route rate limits for activate and WHIP/WHEP endpoints (closes #83)

### DIFF
--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -450,7 +450,10 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
 
   // Activate a production — immediately returns 'activating', then polls Strom
   // for flow state in a fire-and-forget async loop.
-  fastify.post<{ Params: { id: string } }>('/api/v1/productions/:id/activate', async (req, reply) => {
+  fastify.post<{ Params: { id: string } }>(
+    '/api/v1/productions/:id/activate',
+    { config: { rateLimit: { max: 5, timeWindow: '1 minute' } } },
+    async (req, reply) => {
     try {
       const doc = await getDb().get(req.params.id);
 

--- a/src/routes/whep-proxy.ts
+++ b/src/routes/whep-proxy.ts
@@ -41,7 +41,10 @@ const whepProxyRoutes: FastifyPluginAsync = async (fastify) => {
     done(null, body)
   })
 
-  fastify.post<{ Querystring: { target: string } }>('/api/v1/whep-proxy', async (req, reply) => {
+  fastify.post<{ Querystring: { target: string } }>(
+    '/api/v1/whep-proxy',
+    { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } },
+    async (req, reply) => {
     const target = req.query.target
     if (!target) return reply.status(400).send({ error: 'Missing target query parameter' })
 

--- a/src/routes/whip.ts
+++ b/src/routes/whip.ts
@@ -59,6 +59,7 @@ const whipRoutes: FastifyPluginAsync = async (fastify) => {
   // POST — initial WHIP offer/answer
   fastify.post<{ Params: { id: string; mixerInput: string } }>(
     '/api/v1/productions/:id/whip/:mixerInput',
+    { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } },
     async (req, reply) => {
       const { id: productionId, mixerInput } = req.params
       const stromTarget = resolveStromWhipUrl(productionId, mixerInput)

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,8 +60,7 @@ export async function buildServer() {
     crossOriginResourcePolicy: { policy: 'cross-origin' },
   });
 
-  // Rate limiting — 200 requests per minute per IP on API routes
-  // Activation and WHIP/WHEP proxy get tighter limits (10/min) to prevent abuse
+  // Rate limiting — 200 requests per minute per IP on API routes; tight per-route limits on activate/WHIP/WHEP
   await fastify.register(rateLimit, {
     global: true,
     max: 200,


### PR DESCRIPTION
## Summary
Implements the per-route rate limits that were described in the comment at `server.ts` line 64 but never actually applied. The global limit (200 req/min) was the only enforcement in place.

- `src/routes/productions.ts`: activate route now limited to 5 requests/minute per IP
- `src/routes/whip.ts`: WHIP POST route now limited to 10 requests/minute per IP
- `src/routes/whep-proxy.ts`: WHEP-proxy POST route now limited to 10 requests/minute per IP
- `src/server.ts`: updated comment to accurately reflect that per-route limits are now in effect

Closes #83