### PR TITLE
fix: guard GO_LIVE and CUT_STREAM against unactivated productions (closes #87)

### DIFF
--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -749,12 +749,20 @@ async function handleMessage(
       break;
     }
     case 'GO_LIVE': {
+      if (!doc.stromFlowId) {
+        ws.send(JSON.stringify({ type: 'ERROR', error: 'Production is not activated' }));
+        break;
+      }
       const updated: ProductionDoc = { ...doc, status: 'active', updatedAt: new Date().toISOString() };
       await db.insert(updated);
       broadcast(productionId, { type: 'ON_AIR', value: true });
       break;
     }
     case 'CUT_STREAM': {
+      if (!doc.stromFlowId) {
+        ws.send(JSON.stringify({ type: 'ERROR', error: 'Production is not activated' }));
+        break;
+      }
       const updated: ProductionDoc = { ...doc, status: 'active', updatedAt: new Date().toISOString() };
       await db.insert(updated);
       broadcast(productionId, { type: 'ON_AIR', value: false });


### PR DESCRIPTION
## Summary

- `src/ws/controller.ts`: both `GO_LIVE` and `CUT_STREAM` handlers now check `doc.stromFlowId` before writing to CouchDB and broadcasting tally events
- If the production is not activated (no Strom flow running), an `ERROR` message is sent back to the WebSocket client and the state is not changed

## Why

Without this guard, any WebSocket client with a valid API key could send `GO_LIVE` when no pipeline was running, setting `doc.status = 'active'` while `doc.stromFlowId` remained undefined. This left the production in a permanently inconsistent state that could break subsequent `activate`/`deactivate` operations. The same logic flaw applied to `CUT_STREAM`.

Closes #87