### PR TITLE
fix: add 5-minute TTL and Cache-Control: no-store to ICE server cache (closes #90)

### DIFF
--- a/src/routes/ice-servers.ts
+++ b/src/routes/ice-servers.ts
@@ -16,18 +16,27 @@ import { config } from '../config.js';
  * Stale-on-error: serves the last successful response when Strom is temporarily
  * unreachable (e.g. brief DNS failure after a network reconnect). ICE server
  * config changes rarely so a stale response is far better than a 502.
+ * Cache is invalidated after 5 minutes so expired TURN credentials are not
+ * served indefinitely.
  */
 
-let cachedIceServers: IceServer[] | null = null
+const CACHE_TTL_MS = 5 * 60 * 1000;
+let cachedIceServers: IceServer[] | null = null;
+let cacheTimestamp = 0;
 
 const iceServersRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/v1/ice-servers', async (_req, reply) => {
+    reply.header('Cache-Control', 'no-store');
+    if (Date.now() - cacheTimestamp > CACHE_TTL_MS) {
+      cachedIceServers = null;
+    }
     try {
       const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
       const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
 
       const { ice_servers } = await strom.system.iceServers();
       cachedIceServers = ice_servers;
+      cacheTimestamp = Date.now();
       return reply.send({ iceServers: ice_servers });
     } catch (err) {
       if (cachedIceServers) {


### PR DESCRIPTION
## Summary

- `src/routes/ice-servers.ts`: adds a 5-minute TTL to the in-memory ICE server cache so expired TURN credentials are not served indefinitely
- Adds `Cache-Control: no-store` response header to prevent downstream caching of TURN credentials by browsers or CDNs

## Why

TURN credentials are typically time-limited. Previously the stale-on-error cache had no TTL — once cached, credentials were served forever even when Strom recovered. With a 5-minute TTL the cache is cleared and a fresh fetch is attempted on the next request, ensuring credentials are refreshed promptly. `Cache-Control: no-store` prevents browser and proxy caches from independently holding onto the credentials beyond their intended lifetime.

Closes #90