### PR TITLE
fix: rate-limit /reconnect to 5/min and remove cleanLegacyFixtures from reconnect handler (closes #89)

### DIFF
--- a/src/routes/status.ts
+++ b/src/routes/status.ts
@@ -3,7 +3,6 @@ import { isDbReady, connectDb, isDbConnected } from '../db/index.js';
 import { StromClient } from '../lib/strom.js';
 import { getStromToken } from '../lib/strom-token.js';
 import { config } from '../config.js';
-import { cleanLegacyFixtures } from '../db/seed.js';
 
 const statusRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/v1/ping', async (_req, reply) => {
@@ -19,13 +18,15 @@ const statusRoutes: FastifyPluginAsync = async (fastify) => {
     }
   });
 
-  fastify.post('/api/v1/reconnect', async (_req, reply) => {
+  fastify.post(
+    '/api/v1/reconnect',
+    { config: { rateLimit: { max: 5, timeWindow: '1 minute' } } },
+    async (_req, reply) => {
     const result: { db: boolean; strom: boolean } = { db: isDbConnected(), strom: false };
 
     if (!result.db) {
       try {
         await connectDb();
-        await cleanLegacyFixtures();
         fastify.log.info('[reconnect] Database connection restored');
         result.db = true;
       } catch (err: any) {
@@ -44,7 +45,8 @@ const statusRoutes: FastifyPluginAsync = async (fastify) => {
 
     const ok = result.db && result.strom;
     return reply.status(ok ? 200 : 503).send({ ok, ...result });
-  });
+  },
+  );
 
   fastify.get('/api/v1/status', async (_req, reply) => {
     const [db, strom] = await Promise.all([


### PR DESCRIPTION
## Summary

- `src/routes/status.ts`: adds a per-route rate limit of 5 requests/minute to `POST /api/v1/reconnect` via `@fastify/rate-limit`'s route-level config
- `src/routes/status.ts`: removes the `cleanLegacyFixtures()` call from the reconnect handler

## Why

The `/reconnect` endpoint is auth-exempt and was only limited by the global 200 req/min cap. Each call triggered `connectDb()` (a new Nano connection + CouchDB database list) and `cleanLegacyFixtures()` (up to five CouchDB reads and potential document destroys), making it a cheap DoS vector.

`cleanLegacyFixtures()` already runs at startup in `main.ts` — there is no need to repeat it on every reconnect. The reconnect path now only re-establishes the DB connection when disconnected, as intended.

The per-route limit of 5/min is appropriate for a recovery endpoint that should rarely be called and never in rapid bursts.

Closes #89