### PR TITLE
fix: add .max(256) to all resource name fields to prevent storage exhaustion (closes #84)

### DIFF
--- a/src/routes/graphics.ts
+++ b/src/routes/graphics.ts
@@ -18,12 +18,12 @@ const safeGraphicUrl = z.string().min(1).max(524288).superRefine((s, ctx) => {
 });
 
 const GraphicInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   url: safeGraphicUrl,
 });
 
 const GraphicPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   url: safeGraphicUrl.optional(),
 });
 

--- a/src/routes/outputs.ts
+++ b/src/routes/outputs.ts
@@ -9,7 +9,7 @@ import { srtUrl } from '../lib/url-validation.js';
 const SRT_OUTPUT_TYPES = new Set(['mpegtssrt', 'efpsrt']);
 
 const OutputInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   outputType: z.enum(['mpegtssrt', 'efpsrt', 'whep']),
   url: z.string().optional(),
 }).superRefine((data, ctx) => {
@@ -23,7 +23,7 @@ const OutputInput = z.object({
 });
 
 const OutputPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   url: z.string().optional(),
 });
 

--- a/src/routes/production-configs.ts
+++ b/src/routes/production-configs.ts
@@ -5,12 +5,12 @@ import { getConfigsDb } from '../db/index.js';
 import type { ProductionConfigDoc } from '../db/types.js';
 
 const ConfigInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   values: z.record(z.union([z.string(), z.number(), z.boolean()])),
 });
 
 const ConfigPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   values: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -309,11 +309,11 @@ async function runActivationFlow(
 // ---------------------------------------------------------------------------
 
 const ProductionInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
 });
 
 const ProductionPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   values: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
   airTime: z.string().datetime().nullable().optional(),
 });

--- a/src/routes/sources.ts
+++ b/src/routes/sources.ts
@@ -7,7 +7,7 @@ import { updateProductionDoc } from './productions.js';
 import { graphicUrl, srtUrl } from '../lib/url-validation.js';
 
 const SourceInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   address: z.string(),
   streamType: z.enum(['srt', 'efp', 'whip', 'html']),
   status: z.enum(['active', 'inactive']).default('inactive'),
@@ -32,7 +32,7 @@ const SourceInput = z.object({
 });
 
 const SourcePatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   address: z.string().optional(),
   streamType: z.enum(['srt', 'efp', 'whip', 'html']).optional(),
   status: z.enum(['active', 'inactive']).optional(),


### PR DESCRIPTION
## Summary

Adds `.max(256)` to all `name` field Zod schemas across five route files: productions, sources, graphics, outputs, and production-configs.

## Why

Every `name` field previously accepted an unbounded string (`z.string().min(1)`). The production name flows directly into Strom's flow name — `${production.name}-${randomUUID().slice(0,8)}` — meaning an operator or compromised client could store a multi-megabyte name string that both exhausts CouchDB storage and sends an oversized value to Strom's pipeline config on activation.

256 characters is generous for a broadcast resource name and leaves no room for abuse.

## Changed files

- `src/routes/productions.ts` — `ProductionInput.name` and `ProductionPatch.name`
- `src/routes/sources.ts` — `SourceInput.name` and `SourcePatch.name`
- `src/routes/graphics.ts` — `GraphicInput.name` and `GraphicPatch.name`
- `src/routes/outputs.ts` — `OutputInput.name` and `OutputPatch.name`
- `src/routes/production-configs.ts` — `ConfigInput.name` and `ConfigPatch.name`

Closes #84