### PR TITLE
fix: coalesce concurrent SAT token exchange requests to prevent burst PAT exhaustion (closes #85)

### DIFF
--- a/src/lib/strom-token.ts
+++ b/src/lib/strom-token.ts
@@ -17,6 +17,8 @@ interface SatCache {
 }
 
 let cache: SatCache | null = null
+// Coalesce concurrent token exchange requests to avoid burst PAT exhaustion
+let inflightExchange: Promise<string> | null = null
 
 function isExpiringSoon(cache: SatCache): boolean {
   return Date.now() >= cache.expiresAt - REFRESH_BUFFER_MS
@@ -43,7 +45,14 @@ export async function getStromToken(pat: string | undefined): Promise<string | u
     return cache.token
   }
 
-  const res = await fetch(TOKEN_EXCHANGE_URL, {
+  // Coalesce: if an exchange is already in-flight, wait for it instead of
+  // issuing a duplicate request. This prevents burst activations from
+  // exhausting OSC per-PAT rate limits after a SAT expiry.
+  if (inflightExchange) {
+    return inflightExchange
+  }
+
+  inflightExchange = fetch(TOKEN_EXCHANGE_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -52,13 +61,18 @@ export async function getStromToken(pat: string | undefined): Promise<string | u
     },
     body: JSON.stringify({ serviceId: STROM_SERVICE_ID }),
   })
+    .then(async (res) => {
+      if (!res.ok) {
+        const body = await res.text()
+        throw new Error(`SAT exchange failed: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`)
+      }
+      const data = (await res.json()) as { token: string; expiry: number }
+      cache = { token: data.token, expiresAt: data.expiry * 1000 }
+      return cache.token
+    })
+    .finally(() => {
+      inflightExchange = null
+    })
 
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`SAT exchange failed: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`)
-  }
-
-  const data = (await res.json()) as { token: string; expiry: number }
-  cache = { token: data.token, expiresAt: data.expiry * 1000 }
-  return cache.token
+  return inflightExchange
 }


### PR DESCRIPTION
## Summary

- Adds an `inflightExchange` promise guard to `getStromToken` in `src/lib/strom-token.ts`
- Concurrent callers that arrive after SAT expiry now await the single shared in-flight promise instead of each independently POSTing to the OSC token service
- Once the exchange completes the shared promise is cleared so future expirations trigger a fresh exchange

## Why

When multiple productions activate simultaneously right after a SAT expires, each parallel call to `getStromToken` independently fires a `POST` to `token.svc.prod.osaas.io`. If OSC enforces per-PAT rate limits, the burst can exhaust them and cause all subsequent Strom calls to fail with 401. Promise coalescing ensures only one exchange is ever in flight at a time.

## Test

No automated tests exist for this module yet. Manual verification: trigger parallel `getStromToken` calls after cache expiry and confirm only one network request is made.

Closes #85