### PR TITLE
fix: verify overlayId exists before writing GRAPHIC_ON/GRAPHIC_OFF to CouchDB (closes #86)

### DIFF
--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -762,6 +762,11 @@ async function handleMessage(
     }
     case 'GRAPHIC_ON':
     case 'GRAPHIC_OFF': {
+      const graphic = doc.graphics.find((g) => g.id === msg.overlayId);
+      if (!graphic) {
+        ws.send(JSON.stringify({ type: 'ERROR', error: 'Overlay not found' }));
+        break;
+      }
       const active = msg.type === 'GRAPHIC_ON';
       const updated: ProductionDoc = {
         ...doc,


### PR DESCRIPTION
## Summary

- Adds an overlay existence check in the `GRAPHIC_ON`/`GRAPHIC_OFF` WebSocket message handler in `src/ws/controller.ts`
- If `msg.overlayId` does not match any graphic in `doc.graphics`, the handler sends an `ERROR` message back to the client and breaks without writing to CouchDB
- Valid overlay IDs proceed unchanged through the existing update path

## Why

Previously, sending a non-existent `overlayId` still triggered a CouchDB write (a no-op document update). This produced spurious audit log entries, wasted database writes, and could cause 409 conflict races under concurrent message handling. The fix mirrors the same pattern used by `MACRO_EXEC` and `DSK_TOGGLE` in this file.

Closes #86