### PR TITLE
fix: use canonical port comparison in WHIP/WHEP URL validation to close SSRF bypass paths (closes #82)

### DIFF
--- a/src/routes/whep-proxy.ts
+++ b/src/routes/whep-proxy.ts
@@ -2,6 +2,12 @@ import type { FastifyPluginAsync } from 'fastify';
 import { getStromToken } from '../lib/strom-token.js';
 import { config } from '../config.js';
 
+/** Returns the effective TCP port for a URL, resolving protocol defaults when the port is omitted. */
+function effectivePort(u: URL): string {
+  if (u.port) return u.port;
+  return u.protocol === 'https:' ? '443' : '80';
+}
+
 /** Validates a proxy target URL is on the configured Strom host (prevents SSRF + token exfiltration). */
 function validateProxyTarget(targetUrl: string): void {
   let parsed: URL;
@@ -13,7 +19,7 @@ function validateProxyTarget(targetUrl: string): void {
   if (parsed.hostname !== strom.hostname) {
     throw new Error('Target URL host does not match configured Strom host');
   }
-  if (strom.port && parsed.port && parsed.port !== strom.port) {
+  if (effectivePort(parsed) !== effectivePort(strom)) {
     throw new Error('Target URL port does not match configured Strom port');
   }
 }

--- a/src/routes/whip.ts
+++ b/src/routes/whip.ts
@@ -2,6 +2,12 @@ import type { FastifyPluginAsync } from 'fastify'
 import { getStromToken } from '../lib/strom-token.js'
 import { config } from '../config.js'
 
+/** Returns the effective TCP port for a URL, resolving protocol defaults when the port is omitted. */
+function effectivePort(u: URL): string {
+  if (u.port) return u.port;
+  return u.protocol === 'https:' ? '443' : '80';
+}
+
 /**
  * Validates that a session URL belongs to the configured Strom host.
  * Prevents SSRF / SAT token exfiltration to an attacker-controlled host.
@@ -20,7 +26,7 @@ function validateSessionUrl(sessionUrl: string): void {
   if (parsed.hostname !== strom.hostname) {
     throw new Error('Session URL host does not match configured Strom host');
   }
-  if (strom.port && parsed.port && parsed.port !== strom.port) {
+  if (effectivePort(parsed) !== effectivePort(strom)) {
     throw new Error('Session URL port does not match configured Strom port');
   }
 }


### PR DESCRIPTION
## Summary

- Adds an `effectivePort()` helper that resolves implicit protocol defaults (`:80` for `http:`, `:443` for `https:`) so port comparison is always between two concrete strings
- Replaces the `strom.port && parsed.port && parsed.port !== strom.port` guard in both `validateSessionUrl` (whip.ts) and `validateProxyTarget` (whep-proxy.ts) with `effectivePort(parsed) !== effectivePort(strom)`
- Closes the two bypass paths identified in the issue: attacker omits port when STROM_URL has one (parsed.port → `''` → falsy), and vice versa

## Test plan

- [ ] STROM_URL with explicit port (e.g. `http://strom:7000`) — attacker URL without port now rejected (previously bypassed)
- [ ] STROM_URL without explicit port on https (e.g. `https://strom`) — attacker URL with `:443` now rejected (previously bypassed)
- [ ] Legitimate session URLs (same host + same effective port) still accepted

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)