### PR TITLE
fix: validate production values record against allowlists before forwarding to Strom (closes #88)

### DIFF
--- a/src/__tests__/activation.test.ts
+++ b/src/__tests__/activation.test.ts
@@ -289,3 +289,58 @@ describe('GET /api/v1/ice-servers', () => {
     expect(res.statusCode).toBe(502);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests: PATCH /api/v1/productions/:id — values field validation
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/v1/productions/:id values validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it('rejects invalid pgm_resolution format', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/productions/prod-test-1',
+      payload: { values: { pgm_resolution: 'bad-value' } },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects invalid pgm_framerate format', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/productions/prod-test-1',
+      payload: { values: { pgm_framerate: 'not/valid/framerate' } },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects unknown clock type', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/productions/prod-test-1',
+      payload: { values: { clock: 'ntp;DROP TABLE--' } },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('accepts valid resolution, framerate, and clock values', async () => {
+    const doc = makeProductionDoc();
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/productions/prod-test-1',
+      payload: { values: { pgm_resolution: '1920x1080', pgm_framerate: '30000/1001', clock: 'ntp' } },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -4,6 +4,30 @@ import { getSourcesDb, getGraphicsDb } from '../db/index.js';
 import { StromClient } from './strom.js';
 import { DEFAULT_FLOW, type FlowTopology } from './default-flow.js';
 
+const RESOLUTION_RE = /^\d{3,5}x\d{3,5}$/;
+const FRAMERATE_RE = /^\d{1,3}\/\d{1,3}$|^\d{1,3}$/;
+const CLOCK_TYPES = new Set(['ntp', 'gst', 'system']);
+
+function validateProductionValues(values: Record<string, string | number | boolean> | undefined): void {
+  if (!values) return;
+  const { pgm_resolution, pgm_framerate, multiview_resolution, multiview_framerate, clock } = values as Record<string, unknown>;
+  if (typeof pgm_resolution === 'string' && !RESOLUTION_RE.test(pgm_resolution)) {
+    throw new Error(`Invalid pgm_resolution value: ${pgm_resolution}`);
+  }
+  if (typeof pgm_framerate === 'string' && !FRAMERATE_RE.test(pgm_framerate)) {
+    throw new Error(`Invalid pgm_framerate value: ${pgm_framerate}`);
+  }
+  if (typeof multiview_resolution === 'string' && !RESOLUTION_RE.test(multiview_resolution)) {
+    throw new Error(`Invalid multiview_resolution value: ${multiview_resolution}`);
+  }
+  if (typeof multiview_framerate === 'string' && !FRAMERATE_RE.test(multiview_framerate)) {
+    throw new Error(`Invalid multiview_framerate value: ${multiview_framerate}`);
+  }
+  if (typeof clock === 'string' && clock !== '' && !CLOCK_TYPES.has(clock)) {
+    throw new Error(`Invalid clock type: ${clock}`);
+  }
+}
+
 /**
  * Generates a Strom flow from a template + source assignments,
  * creates it in Strom, starts it, and returns the flow ID.
@@ -54,6 +78,8 @@ export async function activateStromFlow(
   stromUrl?: string,
   outputDocs?: OutputDoc[],
 ): Promise<ActivationResult> {
+  validateProductionValues(production.values);
+
   // Virtual source IDs for test streams — no DB lookup needed
   const VIRTUAL_SOURCES: Record<string, Pick<SourceDoc, 'streamType' | 'address' | 'name'>> = {
     'Whip': { streamType: 'whip', address: '', name: 'WHIP Input' },

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -312,9 +312,31 @@ const ProductionInput = z.object({
   name: z.string().min(1),
 });
 
+const RESOLUTION_RE = /^\d{3,5}x\d{3,5}$/;
+const FRAMERATE_RE = /^\d{1,3}\/\d{1,3}$|^\d{1,3}$/;
+const CLOCK_TYPES = ['ntp', 'gst', 'system'] as const;
+
 const ProductionPatch = z.object({
   name: z.string().min(1).optional(),
-  values: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+  values: z.record(z.union([z.string(), z.number(), z.boolean()]))
+    .superRefine((vals, ctx) => {
+      if (typeof vals['pgm_resolution'] === 'string' && !RESOLUTION_RE.test(vals['pgm_resolution'] as string)) {
+        ctx.addIssue({ code: 'custom', path: ['pgm_resolution'], message: 'Must match WIDTHxHEIGHT (e.g. 1920x1080)' });
+      }
+      if (typeof vals['pgm_framerate'] === 'string' && !FRAMERATE_RE.test(vals['pgm_framerate'] as string)) {
+        ctx.addIssue({ code: 'custom', path: ['pgm_framerate'], message: 'Must be a framerate like 30 or 30000/1001' });
+      }
+      if (typeof vals['multiview_resolution'] === 'string' && !RESOLUTION_RE.test(vals['multiview_resolution'] as string)) {
+        ctx.addIssue({ code: 'custom', path: ['multiview_resolution'], message: 'Must match WIDTHxHEIGHT (e.g. 1920x1080)' });
+      }
+      if (typeof vals['multiview_framerate'] === 'string' && !FRAMERATE_RE.test(vals['multiview_framerate'] as string)) {
+        ctx.addIssue({ code: 'custom', path: ['multiview_framerate'], message: 'Must be a framerate like 30 or 30000/1001' });
+      }
+      if (typeof vals['clock'] === 'string' && vals['clock'] !== '' && !(CLOCK_TYPES as readonly string[]).includes(vals['clock'] as string)) {
+        ctx.addIssue({ code: 'custom', path: ['clock'], message: `Must be one of: ${CLOCK_TYPES.join(', ')}` });
+      }
+    })
+    .optional(),
   airTime: z.string().datetime().nullable().optional(),
 });
 


### PR DESCRIPTION
## Summary

- Adds a `validateProductionValues()` function in `flow-generator.ts` that validates string fields forwarded verbatim to Strom block properties against format-specific allowlists
  - `pgm_resolution` / `multiview_resolution`: must match `/^\d{3,5}x\d{3,5}$/`
  - `pgm_framerate` / `multiview_framerate`: must match `/^\d{1,3}\/\d{1,3}$|^\d{1,3}$/`
  - `clock`: must be one of `ntp`, `gst`, or `system`
- Adds equivalent `superRefine` validation to the `ProductionPatch` Zod schema in `productions.ts` so invalid values are rejected at the API boundary (400) before reaching the database
- Adds four vitest tests covering rejection of invalid values and acceptance of valid ones

## Test plan

- [ ] `PATCH /api/v1/productions/:id` with `{ values: { clock: "ntp;DROP TABLE--" } }` → 400
- [ ] `PATCH /api/v1/productions/:id` with `{ values: { pgm_resolution: "bad-value" } }` → 400
- [ ] `PATCH /api/v1/productions/:id` with `{ values: { pgm_resolution: "1920x1080", clock: "ntp" } }` → 200
- [ ] Run `pnpm test` — all new tests pass

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)