### PR TITLE
fix(security): API_KEY gate for /ws/ production controller

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,8 +27,9 @@ export const config = {
   stromAuthMode: (process.env['STROM_AUTH_MODE'] ?? 'osc') as 'osc' | 'direct',
   logLevel: process.env['LOG_LEVEL'] ?? 'info',
   /**
-   * Optional static API key. When set, all /api/v1 routes require:
+   * Optional static API key. When set, /api/v1 and /ws/ routes require:
    *   Authorization: Bearer <API_KEY>
+   * WebSocket upgrades may also pass ?key=<API_KEY>.
    * Leave unset when running behind OSC's reverse-proxy auth wall.
    */
   apiKey: process.env['API_KEY'] ?? undefined,

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,12 +107,14 @@ export async function buildServer() {
 
   // Optional API key authentication — enabled when API_KEY env var is set.
   // Exempt: health/ready probes and status/reconnect endpoints.
-  // WS connections: pass key via Authorization header or ?key= query param on upgrade.
+  // Covers REST (/api/v1) and controller WebSocket (/ws/) — not just /api/v1
+  // (incomplete guard previously let /ws/* bypass auth; see #101).
+  // WS: pass key via Authorization header or ?key= query param on upgrade.
   if (config.apiKey) {
     fastify.addHook('onRequest', async (req, reply) => {
       const path = req.url.split('?')[0]!;
       if (AUTH_EXEMPT_PATHS.has(path)) return;
-      if (!req.url.startsWith('/api/v1')) return;
+      if (!req.url.startsWith('/api/v1') && !req.url.startsWith('/ws/')) return;
 
       const authHeader = req.headers['authorization'];
       const keyFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -1366,6 +1366,19 @@ const controllerWs: FastifyPluginAsync = async (fastify) => {
     '/ws/productions/:id/controller',
     { websocket: true },
     async (socket, req) => {
+      // Defence-in-depth: same API key gate as HTTP (/ws was previously unguarded).
+      if (config.apiKey) {
+        const authHeader = req.headers['authorization'];
+        const keyFromHeader =
+          authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+        const keyFromQuery = (req.query as Record<string, string> | undefined)?.['key'];
+        const provided = keyFromHeader ?? keyFromQuery;
+        if (provided !== config.apiKey) {
+          socket.close(1008, 'Unauthorized');
+          return;
+        }
+      }
+
       const { id } = req.params;
       subscribe(id, socket);
       notifySubscriberJoin(id);


### PR DESCRIPTION
## Summary
HIGH: WebSocket controller under `/ws/` bypassed the API key hook (only `/api/v1` was checked).

## Approach
- Extend `onRequest` auth to `/ws/`
- Defence-in-depth: reject unauthorized sockets in the WS upgrade handler
- Document `?key=` / Bearer for WS

## Fixes
#101
