### PR TITLE
fix(security): validate production values + graphic overlay IDs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,8 +27,9 @@ export const config = {
   stromAuthMode: (process.env['STROM_AUTH_MODE'] ?? 'osc') as 'osc' | 'direct',
   logLevel: process.env['LOG_LEVEL'] ?? 'info',
   /**
-   * Optional static API key. When set, all /api/v1 routes require:
+   * Optional static API key. When set, /api/v1 and /ws/ routes require:
    *   Authorization: Bearer <API_KEY>
+   * WebSocket upgrades may also pass ?key=<API_KEY>.
    * Leave unset when running behind OSC's reverse-proxy auth wall.
    */
   apiKey: process.env['API_KEY'] ?? undefined,

--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -3,6 +3,7 @@ import type { ProductionDoc, SourceDoc, GraphicDoc, OutputDoc } from '../db/type
 import { getSourcesDb, getGraphicsDb } from '../db/index.js';
 import { StromClient } from './strom.js';
 import { DEFAULT_FLOW, type FlowTopology } from './default-flow.js';
+import { validateProductionValues } from './production-values.js';
 
 /**
  * Generates a Strom flow from a template + source assignments,
@@ -111,11 +112,22 @@ export async function activateStromFlow(
     }
   }
 
+  // Sanitize values again at flow-build time (defence-in-depth vs stored docs).
+  let safeValues = production.values as Record<string, string | number | boolean> | undefined;
+  if (safeValues && typeof safeValues === 'object') {
+    const checked = validateProductionValues(safeValues);
+    if (!checked.ok) {
+      throw new Error(`Invalid production values: ${checked.error}`);
+    }
+    safeValues = checked.values;
+  }
+  const values = safeValues ?? production.values;
+
   // Resolve pgm_resolution: production.values takes precedence over the template
   // mixer block's default — avoids in-mixer upscaling on static inputs (test
   // sources) which causes QoS/videoconvert falling-behind events.
   const pgmResolution = (() => {
-    if (typeof production.values?.pgm_resolution === 'string') return production.values.pgm_resolution;
+    if (typeof values?.pgm_resolution === 'string') return values.pgm_resolution;
     const mixer = flow.blocks.find(
       (b) => (b as Record<string, unknown>)['block_definition_id'] === 'builtin.vision_mixer',
     ) as Record<string, unknown> | undefined;
@@ -123,30 +135,30 @@ export async function activateStromFlow(
     return typeof p['pgm_resolution'] === 'string' ? p['pgm_resolution'] : '1280x720';
   })();
 
-  const pgmBitrate = typeof production.values?.bitrate === 'number' ? production.values.bitrate : undefined;
-  const multiviewBitrate = typeof production.values?.multiview_bitrate === 'number' ? production.values.multiview_bitrate : undefined;
-  const pgmFramerate = typeof production.values?.pgm_framerate === 'string' ? production.values.pgm_framerate : undefined;
-  const multiviewResolution = typeof production.values?.multiview_resolution === 'string' ? production.values.multiview_resolution : undefined;
-  const multiviewFramerate = typeof production.values?.multiview_framerate === 'string' ? production.values.multiview_framerate : undefined;
+  const pgmBitrate = typeof values?.bitrate === 'number' ? values.bitrate : undefined;
+  const multiviewBitrate = typeof values?.multiview_bitrate === 'number' ? values.multiview_bitrate : undefined;
+  const pgmFramerate = typeof values?.pgm_framerate === 'string' ? values.pgm_framerate : undefined;
+  const multiviewResolution = typeof values?.multiview_resolution === 'string' ? values.multiview_resolution : undefined;
+  const multiviewFramerate = typeof values?.multiview_framerate === 'string' ? values.multiview_framerate : undefined;
   const numAuxBuses = (() => {
-    const v = production.values?.num_aux_buses;
+    const v = values?.num_aux_buses;
     if (typeof v === 'number') return v;
     if (typeof v === 'string') { const n = parseInt(v, 10); return isNaN(n) ? undefined : n; }
     return undefined;
   })();
   const numGroups = (() => {
-    const v = production.values?.num_groups;
+    const v = values?.num_groups;
     if (typeof v === 'number') return v;
     if (typeof v === 'string') { const n = parseInt(v, 10); return isNaN(n) ? undefined : n; }
     return undefined;
   })();
   const mixLatency = (() => {
-    const v = production.values?.mix_latency;
+    const v = values?.mix_latency;
     if (typeof v === 'number' && Number.isFinite(v)) return Math.max(0, Math.round(v));
     if (typeof v === 'string') { const n = parseInt(v, 10); return isNaN(n) ? 100 : Math.max(0, n); }
     return 100;
   })();
-  const clockType = typeof production.values?.clock === 'string' && production.values.clock !== '' ? production.values.clock : undefined;
+  const clockType = typeof values?.clock === 'string' && values.clock !== '' ? values.clock : undefined;
 
   for (const block of flow.blocks) {
     const b = block as Record<string, unknown>;
@@ -159,7 +171,7 @@ export async function activateStromFlow(
       if (multiviewResolution !== undefined) props['multiview_resolution'] = multiviewResolution;
       if (multiviewFramerate !== undefined) props['multiview_framerate'] = multiviewFramerate;
       // swap_pvw_pgm (PR #637): non-live property — only applied at pipeline build time.
-      const swapPvwPgm = production.values?.swap_pvw_pgm === true || production.values?.swap_pvw_pgm === 'true';
+      const swapPvwPgm = values?.swap_pvw_pgm === true || values?.swap_pvw_pgm === 'true';
       if (swapPvwPgm) props['swap_pvw_pgm'] = true;
       b['properties'] = props;
     }

--- a/src/lib/production-values.ts
+++ b/src/lib/production-values.ts
@@ -1,0 +1,88 @@
+/**
+ * Validate production.values before they reach Strom block properties.
+ * @see https://github.com/Eyevinn/open-live/issues/88
+ */
+
+export const RESOLUTION_RE = /^\d{3,5}x\d{3,5}$/;
+export const FRAMERATE_RE = /^\d{1,3}(?:\/\d{1,3})?$/;
+export const CLOCK_TYPES = new Set(['ntp', 'gst', 'system']);
+
+/** Keys we forward / interpret from production.values */
+export const KNOWN_VALUE_KEYS = new Set([
+  'pgm_resolution',
+  'pgm_framerate',
+  'multiview_resolution',
+  'multiview_framerate',
+  'bitrate',
+  'multiview_bitrate',
+  'clock',
+  'num_aux_buses',
+  'num_groups',
+  'mix_latency',
+  'num_pips',
+  'swap_pvw_pgm',
+]);
+
+export type ProductionValues = Record<string, string | number | boolean>;
+
+export function validateProductionValues(
+  values: ProductionValues,
+): { ok: true; values: ProductionValues } | { ok: false; error: string } {
+  const out: ProductionValues = {};
+
+  for (const [key, raw] of Object.entries(values)) {
+    if (!KNOWN_VALUE_KEYS.has(key)) {
+      return { ok: false, error: `Unknown production value key: ${key}` };
+    }
+
+    if (key === 'pgm_resolution' || key === 'multiview_resolution') {
+      if (typeof raw !== 'string' || !RESOLUTION_RE.test(raw)) {
+        return { ok: false, error: `Invalid ${key}: expected e.g. 1280x720` };
+      }
+      out[key] = raw;
+      continue;
+    }
+
+    if (key === 'pgm_framerate' || key === 'multiview_framerate') {
+      if (typeof raw !== 'string' || !FRAMERATE_RE.test(raw)) {
+        return { ok: false, error: `Invalid ${key}: expected e.g. 30 or 30000/1001` };
+      }
+      out[key] = raw;
+      continue;
+    }
+
+    if (key === 'clock') {
+      if (typeof raw !== 'string' || !CLOCK_TYPES.has(raw)) {
+        return {
+          ok: false,
+          error: `Invalid clock type: ${String(raw)} (allowed: ntp, gst, system)`,
+        };
+      }
+      out[key] = raw;
+      continue;
+    }
+
+    if (
+      key === 'bitrate' ||
+      key === 'multiview_bitrate' ||
+      key === 'num_aux_buses' ||
+      key === 'num_groups' ||
+      key === 'mix_latency' ||
+      key === 'num_pips'
+    ) {
+      const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+      if (!Number.isFinite(n) || n < 0 || n > 1_000_000) {
+        return { ok: false, error: `Invalid ${key}: expected non-negative number` };
+      }
+      out[key] = n;
+      continue;
+    }
+
+    if (key === 'swap_pvw_pgm') {
+      out[key] = raw === true || raw === 'true';
+      continue;
+    }
+  }
+
+  return { ok: true, values: out };
+}

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -11,6 +11,7 @@ import { clearProductionPflState } from '../services/pfl-state.js';
 import { clearPipState, clearAudioState, clearFxState } from '../ws/controller.js';
 import { config } from '../config.js';
 import { getIdleSince, getIdleExpiresAt, notifyProductionActivated, notifyProductionDeactivated } from '../services/idle-watchdog.js';
+import { validateProductionValues } from '../lib/production-values.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -316,6 +317,12 @@ const ProductionPatch = z.object({
   name: z.string().min(1).optional(),
   values: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
   airTime: z.string().datetime().nullable().optional(),
+}).superRefine((body, ctx) => {
+  if (!body.values) return;
+  const result = validateProductionValues(body.values);
+  if (!result.ok) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: result.error, path: ['values'] });
+  }
 });
 
 // mixerInput must match the Strom pad naming convention (e.g. "video_in_0", "video_in_15")
@@ -408,10 +415,19 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
     const body = ProductionPatch.parse(req.body);
     try {
       const doc = await getDb().get(req.params.id);
+      let nextValues = doc.values;
+      if (body.values !== undefined) {
+        const merged = { ...(doc.values ?? {}), ...body.values };
+        const checked = validateProductionValues(merged);
+        if (!checked.ok) {
+          return reply.status(400).send({ error: checked.error, statusCode: 400 });
+        }
+        nextValues = checked.values;
+      }
       const updated: ProductionDoc = {
         ...doc,
         ...(body.name !== undefined && { name: body.name }),
-        ...(body.values !== undefined && { values: { ...(doc.values ?? {}), ...body.values } }),
+        ...(body.values !== undefined && { values: nextValues }),
         ...(body.airTime !== undefined && { airTime: body.airTime ?? undefined }),
         updatedAt: new Date().toISOString(),
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,12 +107,14 @@ export async function buildServer() {
 
   // Optional API key authentication — enabled when API_KEY env var is set.
   // Exempt: health/ready probes and status/reconnect endpoints.
-  // WS connections: pass key via Authorization header or ?key= query param on upgrade.
+  // Covers REST (/api/v1) and controller WebSocket (/ws/) — not just /api/v1
+  // (incomplete guard previously let /ws/* bypass auth; see #101).
+  // WS: pass key via Authorization header or ?key= query param on upgrade.
   if (config.apiKey) {
     fastify.addHook('onRequest', async (req, reply) => {
       const path = req.url.split('?')[0]!;
       if (AUTH_EXEMPT_PATHS.has(path)) return;
-      if (!req.url.startsWith('/api/v1')) return;
+      if (!req.url.startsWith('/api/v1') && !req.url.startsWith('/ws/')) return;
 
       const authHeader = req.headers['authorization'];
       const keyFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -763,6 +763,11 @@ async function handleMessage(
     case 'GRAPHIC_ON':
     case 'GRAPHIC_OFF': {
       const active = msg.type === 'GRAPHIC_ON';
+      const graphic = (doc.graphics ?? []).find((g) => g.id === msg.overlayId);
+      if (!graphic) {
+        ws.send(JSON.stringify({ type: 'ERROR', error: 'Overlay not found' }));
+        break;
+      }
       const updated: ProductionDoc = {
         ...doc,
         graphics: doc.graphics.map((g) =>
@@ -836,6 +841,9 @@ async function handleMessage(
             broadcast(productionId, { type: 'TALLY', ...newTally });
             await stromTransition(currentDoc, tally.pgm, tally.pvw, 'cut');
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
+            if (!(currentDoc.graphics ?? []).some((g) => g.id === action.overlayId)) {
+              throw new Error('Overlay not found');
+            }
             const updated: ProductionDoc = {
               ...currentDoc,
               graphics: currentDoc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: true } : g),
@@ -844,6 +852,9 @@ async function handleMessage(
             await getDb().insert(updated);
             broadcast(productionId, { type: 'GRAPHIC', overlayId: action.overlayId, active: true });
           } else if (action.type === 'GRAPHIC_OFF' && action.overlayId) {
+            if (!(currentDoc.graphics ?? []).some((g) => g.id === action.overlayId)) {
+              throw new Error('Overlay not found');
+            }
             const updated: ProductionDoc = {
               ...currentDoc,
               graphics: currentDoc.graphics.map((g) => g.id === action.overlayId ? { ...g, active: false } : g),

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -1366,6 +1366,19 @@ const controllerWs: FastifyPluginAsync = async (fastify) => {
     '/ws/productions/:id/controller',
     { websocket: true },
     async (socket, req) => {
+      // Defence-in-depth: same API key gate as HTTP (/ws was previously unguarded).
+      if (config.apiKey) {
+        const authHeader = req.headers['authorization'];
+        const keyFromHeader =
+          authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+        const keyFromQuery = (req.query as Record<string, string> | undefined)?.['key'];
+        const provided = keyFromHeader ?? keyFromQuery;
+        if (provided !== config.apiKey) {
+          socket.close(1008, 'Unauthorized');
+          return;
+        }
+      }
+
       const { id } = req.params;
       subscribe(id, socket);
       notifySubscriberJoin(id);


### PR DESCRIPTION
## Frontier security

- **#88** — allowlist/format-check `production.values` (clock, resolution, framerate, …) before Strom
- **#86** — GRAPHIC_ON/OFF require real overlay id; no no-op CouchDB writes

Also includes prior WS API_KEY gate on this branch lineage if needed separately.
