### PR TITLE
fix(security): redact SAT exchange error logs to message only

### DIFF
--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -281,7 +281,13 @@ async function runActivationFlow(
 
     // Best-effort flow cleanup
     if (stromFlowId) {
-      const stromToken = await getStromToken(config.stromToken).catch((err) => { log.error({ err }, "SAT exchange failed — proceeding without auth"); return undefined; });
+      const stromToken = await getStromToken(config.stromToken).catch((err) => {
+        log.error(
+          { errMsg: err instanceof Error ? err.message : String(err) },
+          'SAT exchange failed — proceeding without auth',
+        );
+        return undefined;
+      });
       const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
       await deactivateStromFlow(stromFlowId, strom).catch(() => undefined);
     }
@@ -558,7 +564,13 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
       broadcast(doc._id, { type: 'GRP_STATE_RESET' });
       broadcast(doc._id, { type: 'PRODUCTION_DEACTIVATED' });
       if (doc.stromFlowId) {
-        const stromToken = await getStromToken(config.stromToken).catch((err) => { req.log.error({ err }, "SAT exchange failed — proceeding without auth"); return undefined; });
+        const stromToken = await getStromToken(config.stromToken).catch((err) => {
+          req.log.error(
+            { errMsg: err instanceof Error ? err.message : String(err) },
+            'SAT exchange failed — proceeding without auth',
+          );
+          return undefined;
+        });
         const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
         await deactivateStromFlow(doc.stromFlowId, strom);
       }


### PR DESCRIPTION
## Summary
Closes #102.

When OSC SAT exchange fails, stop logging the full `err` object. Serialize only `err.message` (or `String(err)`) as `errMsg` so request URLs / partial bodies that can embed auth-adjacent data do not land in log aggregation.

## Changes
- `src/routes/productions.ts` — both SAT exchange `.catch` sites (activation cleanup + deactivate)

## Test plan
- [ ] Force SAT failure (bad OSC PAT / unreachable token URL)
- [ ] Confirm logs show `errMsg` string only, not nested fetch error objects
- [ ] Activation still proceeds without auth on SAT failure (behavior unchanged)