### PR TITLE
fix(security): enable strict CORS preflight

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,10 @@ export async function buildServer() {
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: false,
     maxAge: 86400,
-    strictPreflight: false,
+    // Enforce CORS preflight for non-simple requests (default @fastify/cors).
+    // strictPreflight:false let non-standard header requests skip preflight
+    // negotiation; with allowlisted origin this is a meaningful CSRF-adjacent layer.
+    strictPreflight: true,
   });
 
   await fastify.register(helmet, {


### PR DESCRIPTION
## Summary
Closes #103.

Change `strictPreflight: false` to `true` (`@fastify/cors` default) so non-simple CORS requests require a successful preflight before the actual request.

Pairs with origin tightening in #54 when CORS allowlist is restricted; on its own it restores the browser preflight layer that was disabled.

## Changes
- `src/server.ts` — `strictPreflight: true`

## Test plan
- [ ] Browser simple GET still works from allowed origin
- [ ] Non-simple (e.g. `Content-Type: application/json` POST) sends OPTIONS preflight first
- [ ] Disallowed origin still blocked by origin config