### PR TITLE
fix(security): rate-limit reconnect and skip fixture cleanup

### DIFF
--- a/src/routes/status.ts
+++ b/src/routes/status.ts
@@ -3,7 +3,6 @@ import { isDbReady, connectDb, isDbConnected } from '../db/index.js';
 import { StromClient } from '../lib/strom.js';
 import { getStromToken } from '../lib/strom-token.js';
 import { config } from '../config.js';
-import { cleanLegacyFixtures } from '../db/seed.js';
 
 const statusRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/v1/ping', async (_req, reply) => {
@@ -19,13 +18,17 @@ const statusRoutes: FastifyPluginAsync = async (fastify) => {
     }
   });
 
-  fastify.post('/api/v1/reconnect', async (_req, reply) => {
+  // Auth-exempt reconnect is a DoS surface if unbounded (#89):
+  // tight per-route limit + no cleanLegacyFixtures (startup-only in main.ts).
+  fastify.post(
+    '/api/v1/reconnect',
+    { config: { rateLimit: { max: 5, timeWindow: '1 minute' } } },
+    async (_req, reply) => {
     const result: { db: boolean; strom: boolean } = { db: isDbConnected(), strom: false };
 
     if (!result.db) {
       try {
         await connectDb();
-        await cleanLegacyFixtures();
         fastify.log.info('[reconnect] Database connection restored');
         result.db = true;
       } catch (err: any) {
@@ -45,6 +48,7 @@ const statusRoutes: FastifyPluginAsync = async (fastify) => {
     const ok = result.db && result.strom;
     return reply.status(ok ? 200 : 503).send({ ok, ...result });
   });
+
 
   fastify.get('/api/v1/status', async (_req, reply) => {
     const [db, strom] = await Promise.all([


### PR DESCRIPTION
## Summary
Closes #89.

- Cap `POST /api/v1/reconnect` at **5 req/min** (auth-exempt DoS surface).
- Stop calling `cleanLegacyFixtures()` on every reconnect (still runs at startup in `main.ts`).
- Reconnect still reconnects DB + probes Strom version.

## Why
Unauthenticated clients could hit global 200/min and force repeated CouchDB list/destroy work via fixture cleanup.

## Test plan
- [x] `npm run typecheck`
- [ ] `POST /api/v1/reconnect` when DB up → 200/503 as before
- [ ] 6th call within a minute → 429