### PR TITLE
fix(security): cap resource name length at 256

### DIFF
--- a/src/routes/graphics.ts
+++ b/src/routes/graphics.ts
@@ -18,12 +18,12 @@ const safeGraphicUrl = z.string().min(1).max(524288).superRefine((s, ctx) => {
 });
 
 const GraphicInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   url: safeGraphicUrl,
 });
 
 const GraphicPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   url: safeGraphicUrl.optional(),
 });
 

--- a/src/routes/outputs.ts
+++ b/src/routes/outputs.ts
@@ -9,7 +9,7 @@ import { srtUrl } from '../lib/url-validation.js';
 const SRT_OUTPUT_TYPES = new Set(['mpegtssrt', 'efpsrt']);
 
 const OutputInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   outputType: z.enum(['mpegtssrt', 'efpsrt', 'whep']),
   url: z.string().optional(),
 }).superRefine((data, ctx) => {
@@ -23,7 +23,7 @@ const OutputInput = z.object({
 });
 
 const OutputPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   url: z.string().optional(),
 });
 

--- a/src/routes/production-configs.ts
+++ b/src/routes/production-configs.ts
@@ -5,12 +5,12 @@ import { getConfigsDb } from '../db/index.js';
 import type { ProductionConfigDoc } from '../db/types.js';
 
 const ConfigInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   values: z.record(z.union([z.string(), z.number(), z.boolean()])),
 });
 
 const ConfigPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   values: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -309,11 +309,11 @@ async function runActivationFlow(
 // ---------------------------------------------------------------------------
 
 const ProductionInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
 });
 
 const ProductionPatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   values: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
   airTime: z.string().datetime().nullable().optional(),
 });

--- a/src/routes/sources.ts
+++ b/src/routes/sources.ts
@@ -7,7 +7,7 @@ import { updateProductionDoc } from './productions.js';
 import { graphicUrl, srtUrl } from '../lib/url-validation.js';
 
 const SourceInput = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(256),
   address: z.string(),
   streamType: z.enum(['srt', 'efp', 'whip', 'html']),
   status: z.enum(['active', 'inactive']).default('inactive'),
@@ -32,7 +32,7 @@ const SourceInput = z.object({
 });
 
 const SourcePatch = z.object({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(256).optional(),
   address: z.string().optional(),
   streamType: z.enum(['srt', 'efp', 'whip', 'html']).optional(),
   status: z.enum(['active', 'inactive']).optional(),


### PR DESCRIPTION
## Summary
Closes #84.

Add `.max(256)` to create/patch `name` fields on productions, sources, graphics, outputs, and production-configs.

## Test plan
- [x] `npm run typecheck`
- [ ] Create production with name length 256 → ok
- [ ] Create with 257 → 400 validation error