### PR TITLE
fix(security): TTL + no-store for ICE/TURN credential cache

### DIFF
--- a/src/routes/ice-servers.ts
+++ b/src/routes/ice-servers.ts
@@ -13,27 +13,40 @@ import { config } from '../config.js';
  * Response 200: { iceServers: IceServer[] }
  * Response 502: Strom unreachable and no cached config available
  *
- * Stale-on-error: serves the last successful response when Strom is temporarily
- * unreachable (e.g. brief DNS failure after a network reconnect). ICE server
- * config changes rarely so a stale response is far better than a 502.
+ * Stale-on-error with TTL (#90): serve last successful response only while
+ * younger than CACHE_TTL_MS. TURN credentials are time-limited; infinite
+ * cache is unsafe. Cache-Control: no-store on all responses.
  */
 
-let cachedIceServers: IceServer[] | null = null
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let cachedIceServers: IceServer[] | null = null;
+let cacheTimestamp = 0;
+
+function cacheFresh(): boolean {
+  return cachedIceServers != null && Date.now() - cacheTimestamp <= CACHE_TTL_MS;
+}
 
 const iceServersRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/v1/ice-servers', async (_req, reply) => {
+    reply.header('Cache-Control', 'no-store');
+
     try {
       const stromToken = await getStromToken(config.stromToken).catch(() => undefined);
       const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
 
       const { ice_servers } = await strom.system.iceServers();
       cachedIceServers = ice_servers;
+      cacheTimestamp = Date.now();
       return reply.send({ iceServers: ice_servers });
     } catch (err) {
-      if (cachedIceServers) {
-        fastify.log.warn({ err }, 'Strom unreachable fetching ICE servers — serving cached response');
+      if (cacheFresh()) {
+        fastify.log.warn({ err }, 'Strom unreachable fetching ICE servers — serving TTL-fresh cached response');
         return reply.send({ iceServers: cachedIceServers });
       }
+      // Drop expired cache so we do not keep serving stale TURN credentials.
+      cachedIceServers = null;
+      cacheTimestamp = 0;
       if (err instanceof StromClientError) {
         fastify.log.error({ err }, 'Strom returned an error fetching ICE servers');
         return reply.status(502).send({ error: 'Strom returned an error fetching ICE servers', statusCode: 502 });


### PR DESCRIPTION
## Summary
Closes #90.

- ICE server cache TTL **5 minutes** (stale-on-error only while fresh)
- `Cache-Control: no-store` on responses
- Expired cache cleared (no infinite TURN credential reuse)

## Test plan
- [x] `npm run typecheck`
- [ ] GET ice-servers while Strom up → 200 + no-store
- [ ] After TTL, Strom down → 502 not stale forever