### PR TITLE
fix(security): ban data:text/html in graphicUrl validator

### DIFF
--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -25,14 +25,14 @@ export function httpUrlOnly(url: string): void {
   }
 }
 
-const ALLOWED_DATA_MIME = /^data:(text\/html|image\/(png|jpeg|gif|webp))[;,]/i;
+// #70: do not allow data:text/html (JS execution in Strom cefsrc). Raster images only.
+const ALLOWED_DATA_MIME = /^data:image\/(png|jpeg|gif|webp)[;,]/i;
 const BLOCKED_SCHEMES = /^(file|javascript|ftp|gopher|chrome|about|data:application):/i;
 
 /**
  * Throws if the value is not a safe graphic URL.
- * Accepts: http/https URLs, data:text/html (inline HTML overlays rendered by Strom's headless browser),
- *          or data:image/(png|jpeg|gif|webp) base64 URIs.
- * Rejects: file://, javascript:, data:application/*, etc.
+ * Accepts: http/https URLs, or data:image/(png|jpeg|gif|webp) base64 URIs.
+ * Rejects: data:text/html, file://, javascript:, data:application/*, svg, etc.
  */
 export function graphicUrl(url: string): void {
   if (BLOCKED_SCHEMES.test(url)) {
@@ -40,7 +40,7 @@ export function graphicUrl(url: string): void {
   }
   if (url.startsWith('data:')) {
     if (!ALLOWED_DATA_MIME.test(url)) {
-      throw new Error('Only data:text/html or data:image/(png|jpeg|gif|webp) URIs are allowed for graphics');
+      throw new Error('Only data:image/(png|jpeg|gif|webp) URIs are allowed for graphics');
     }
     return;
   }


### PR DESCRIPTION
## Summary
Closes #70.

`graphicUrl()` no longer allows `data:text/html` (JS in Strom cefsrc). Only `data:image/(png|jpeg|gif|webp)` and http(s).

## Test plan
- [x] `npm run typecheck`
- [ ] POST graphic with data:text/html → 400
- [ ] data:image/png → accepted