### PR TITLE
fix(security): wire log-redact helpers and pino redact paths

### DIFF
--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -3,6 +3,7 @@ import type { ProductionDoc, SourceDoc, GraphicDoc, OutputDoc } from '../db/type
 import { getSourcesDb, getGraphicsDb } from '../db/index.js';
 import { StromClient } from './strom.js';
 import { DEFAULT_FLOW, type FlowTopology } from './default-flow.js';
+import { redactSensitive, safeFlowProjection } from './log-redact.js';
 
 /**
  * Generates a Strom flow from a template + source assignments,
@@ -827,13 +828,18 @@ export async function activateStromFlow(
     await strom.flows.start(flowId);
   } catch (err) {
     // Log a sanitized flow projection — never log block properties (may contain SRT URIs, tokens, passphrases)
-    const safeFlow = {
-      blockCount: flow.blocks.length,
-      blocks: flow.blocks.map((b) => ({ id: b['id'], block_definition_id: b['block_definition_id'] })),
-      linkCount: flow.links.length,
-    };
-    console.error('[flow-generator] Flow start failed. Flow topology (properties redacted):',
-      JSON.stringify(safeFlow, null, 2));
+    // #69: wire log-redact helpers (were previously dead code)
+    console.error(
+      '[flow-generator] Flow start failed:',
+      JSON.stringify(
+        redactSensitive({
+          err: err instanceof Error ? err.message : String(err),
+          flow: safeFlowProjection(flow as unknown as Record<string, unknown>),
+        }),
+        null,
+        2,
+      ),
+    );
     // Start failed — clean up the created flow so the endpoint isn't left registered
     try {
       await strom.flows.delete(flowId);

--- a/src/lib/log-redact.ts
+++ b/src/lib/log-redact.ts
@@ -2,7 +2,7 @@
  * Redacts sensitive values from log objects to prevent credential leakage.
  */
 
-const SENSITIVE_KEYS = /srt_uri|passphrase|streamid|authorization|token|pat|secret/i;
+const SENSITIVE_KEYS = /srt_uri|passphrase|streamid|authorization|token|pat|secret|address|password|key/i;
 
 export function redactSensitive(obj: unknown): unknown {
   if (Array.isArray(obj)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,21 @@ export async function buildServer() {
   const fastify = Fastify({
     logger: {
       level: config.logLevel,
+      // #69: defence-in-depth — never log credential-like fields even if handlers pass them
+      redact: {
+        paths: [
+          '*.passphrase',
+          '*.address',
+          '*.key',
+          '*.password',
+          '*.token',
+          '*.pat',
+          '*.secret',
+          '*.authorization',
+          '*.srt_uri',
+        ],
+        censor: '[REDACTED]',
+      },
     },
     disableRequestLogging: true,
     // Prevent memory exhaustion via oversized request bodies (1 MB limit)


### PR DESCRIPTION
## Summary
Closes #69.

- Import/use `safeFlowProjection` + `redactSensitive` on flow start failure logs
- Pino `redact` paths for credential-like fields on Fastify logger
- Broaden sensitive key regex

## Test plan
- [x] `npm run typecheck`
- [ ] Force flow start failure — logs show IDs/types only, not SRT properties