### PR TITLE
fix(security): canonical port compare for WHIP/WHEP SSRF guard

### DIFF
--- a/src/routes/whep-proxy.ts
+++ b/src/routes/whep-proxy.ts
@@ -2,6 +2,12 @@ import type { FastifyPluginAsync } from 'fastify';
 import { getStromToken } from '../lib/strom-token.js';
 import { config } from '../config.js';
 
+/** Canonical port for comparison (#82 — empty string is not "any port"). */
+function effectivePort(u: URL): string {
+  if (u.port) return u.port;
+  return u.protocol === 'https:' ? '443' : '80';
+}
+
 /** Validates a proxy target URL is on the configured Strom host (prevents SSRF + token exfiltration). */
 function validateProxyTarget(targetUrl: string): void {
   let parsed: URL;
@@ -13,7 +19,7 @@ function validateProxyTarget(targetUrl: string): void {
   if (parsed.hostname !== strom.hostname) {
     throw new Error('Target URL host does not match configured Strom host');
   }
-  if (strom.port && parsed.port && parsed.port !== strom.port) {
+  if (effectivePort(parsed) !== effectivePort(strom)) {
     throw new Error('Target URL port does not match configured Strom port');
   }
 }

--- a/src/routes/whip.ts
+++ b/src/routes/whip.ts
@@ -2,6 +2,12 @@ import type { FastifyPluginAsync } from 'fastify'
 import { getStromToken } from '../lib/strom-token.js'
 import { config } from '../config.js'
 
+/** Canonical port for comparison (#82 — empty string is not "any port"). */
+function effectivePort(u: URL): string {
+  if (u.port) return u.port;
+  return u.protocol === 'https:' ? '443' : '80';
+}
+
 /**
  * Validates that a session URL belongs to the configured Strom host.
  * Prevents SSRF / SAT token exfiltration to an attacker-controlled host.
@@ -20,7 +26,7 @@ function validateSessionUrl(sessionUrl: string): void {
   if (parsed.hostname !== strom.hostname) {
     throw new Error('Session URL host does not match configured Strom host');
   }
-  if (strom.port && parsed.port && parsed.port !== strom.port) {
+  if (effectivePort(parsed) !== effectivePort(strom)) {
     throw new Error('Session URL port does not match configured Strom port');
   }
 }


### PR DESCRIPTION
## Summary
Closes #82.

Use effective port (default 80/443 when omitted) in WHIP session URL and WHEP proxy target validation so empty `parsed.port` cannot skip the check.

## Test plan
- [x] `npm run typecheck`
- [ ] STROM_URL with :7000 + session without port → rejected
- [ ] Matching host+effective port → allowed