### PR TITLE
fix(security): verify graphic overlays + rate-limit activate/WHIP/WHEP

### DIFF
--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -450,7 +450,11 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
 
   // Activate a production — immediately returns 'activating', then polls Strom
   // for flow state in a fire-and-forget async loop.
-  fastify.post<{ Params: { id: string } }>('/api/v1/productions/:id/activate', async (req, reply) => {
+  // #83: expensive path — tighter than global 200/min
+  fastify.post<{ Params: { id: string } }>(
+    '/api/v1/productions/:id/activate',
+    { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } },
+    async (req, reply) => {
     try {
       const doc = await getDb().get(req.params.id);
 

--- a/src/routes/whep-proxy.ts
+++ b/src/routes/whep-proxy.ts
@@ -41,7 +41,13 @@ const whepProxyRoutes: FastifyPluginAsync = async (fastify) => {
     done(null, body)
   })
 
-  fastify.post<{ Querystring: { target: string } }>('/api/v1/whep-proxy', async (req, reply) => {
+  // #83: tighter than global limit
+  const whepRateLimit = { config: { rateLimit: { max: 10, timeWindow: '1 minute' as const } } };
+
+  fastify.post<{ Querystring: { target: string } }>(
+    '/api/v1/whep-proxy',
+    whepRateLimit,
+    async (req, reply) => {
     const target = req.query.target
     if (!target) return reply.status(400).send({ error: 'Missing target query parameter' })
 
@@ -89,27 +95,32 @@ const whepProxyRoutes: FastifyPluginAsync = async (fastify) => {
 
     reply.header('Content-Type', 'application/sdp')
     return reply.status(201).send(answerSdp)
-  })
+    },
+  )
 
-  fastify.delete<{ Querystring: { target: string } }>('/api/v1/whep-proxy', async (req, reply) => {
-    const target = req.query.target
-    if (!target) return reply.status(400).send({ error: 'Missing target query parameter' })
+  fastify.delete<{ Querystring: { target: string } }>(
+    '/api/v1/whep-proxy',
+    whepRateLimit,
+    async (req, reply) => {
+      const target = req.query.target
+      if (!target) return reply.status(400).send({ error: 'Missing target query parameter' })
 
-    let targetUrl: string
-    try {
-      targetUrl = decodeURIComponent(target)
-      validateProxyTarget(targetUrl)
-    } catch (err) {
-      return reply.status(400).send({ error: err instanceof Error ? err.message : 'Invalid target URL' })
-    }
+      let targetUrl: string
+      try {
+        targetUrl = decodeURIComponent(target)
+        validateProxyTarget(targetUrl)
+      } catch (err) {
+        return reply.status(400).send({ error: err instanceof Error ? err.message : 'Invalid target URL' })
+      }
 
-    const token = await getStromToken(config.stromToken).catch(() => undefined)
-    const headers: Record<string, string> = {}
-    if (token) headers['Authorization'] = `Bearer ${token}`
+      const token = await getStromToken(config.stromToken).catch(() => undefined)
+      const headers: Record<string, string> = {}
+      if (token) headers['Authorization'] = `Bearer ${token}`
 
-    await fetch(targetUrl, { method: 'DELETE', headers }).catch(() => {/* ignore teardown errors */})
-    return reply.status(204).send()
-  })
+      await fetch(targetUrl, { method: 'DELETE', headers }).catch(() => {/* ignore teardown errors */})
+      return reply.status(204).send()
+    },
+  )
 }
 
 export default whepProxyRoutes

--- a/src/routes/whip.ts
+++ b/src/routes/whip.ts
@@ -57,8 +57,12 @@ const whipRoutes: FastifyPluginAsync = async (fastify) => {
   })
 
   // POST — initial WHIP offer/answer
+  // #83: tighter limit than global (pipeline / Strom signaling cost)
+  const whipRateLimit = { config: { rateLimit: { max: 10, timeWindow: '1 minute' as const } } };
+
   fastify.post<{ Params: { id: string; mixerInput: string } }>(
     '/api/v1/productions/:id/whip/:mixerInput',
+    whipRateLimit,
     async (req, reply) => {
       const { id: productionId, mixerInput } = req.params
       const stromTarget = resolveStromWhipUrl(productionId, mixerInput)
@@ -102,6 +106,7 @@ const whipRoutes: FastifyPluginAsync = async (fastify) => {
     Querystring: { session?: string }
   }>(
     '/api/v1/productions/:id/whip/:mixerInput',
+    whipRateLimit,
     async (req, reply) => {
       let target: string;
       if (req.query.session) {
@@ -133,6 +138,7 @@ const whipRoutes: FastifyPluginAsync = async (fastify) => {
     Querystring: { session?: string }
   }>(
     '/api/v1/productions/:id/whip/:mixerInput',
+    whipRateLimit,
     async (req, reply) => {
       let target: string;
       if (req.query.session) {

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -762,6 +762,12 @@ async function handleMessage(
     }
     case 'GRAPHIC_ON':
     case 'GRAPHIC_OFF': {
+      // #86: only mutate when overlayId matches a stored graphic
+      const graphic = (doc.graphics ?? []).find((g) => g.id === msg.overlayId);
+      if (!graphic) {
+        ws.send(JSON.stringify({ type: 'ERROR', error: 'Overlay not found' }));
+        break;
+      }
       const active = msg.type === 'GRAPHIC_ON';
       const updated: ProductionDoc = {
         ...doc,


### PR DESCRIPTION
## Summary
Closes #86 and #83.

- **#86** GRAPHIC_ON/OFF reject unknown overlayId (no spurious CouchDB write)
- **#83** 10/min rate limit on activate, WHIP, and WHEP-proxy routes

## Test plan
- [x] `npm run typecheck`
- [ ] GRAPHIC_ON bad id → ERROR Overlay not found
- [ ] 11th activate in a minute → 429