### PR TITLE
fix(security): block private/link-local hosts in httpUrlOnly

### DIFF
--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -2,13 +2,58 @@
  * URL validation helpers for security-sensitive inputs.
  *
  * Rules:
- * - httpUrlOnly: allow only http/https schemes
+ * - httpUrlOnly: http/https + non-empty host + no private/link-local/metadata IPs (#65)
  * - graphicUrl:  httpUrlOnly OR safe data: image URIs (no svg, no text/html)
  * - srtUrl:      srt:// scheme only
  */
 
 /**
- * Throws if the URL is not a safe http/https URL.
+ * True if hostname is loopback, link-local, private RFC1918, CGNAT, or AWS IMDS.
+ * Hostname may be a literal IPv4/IPv6 address or a blocked special name.
+ */
+export function isBlockedHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (
+    h === 'localhost' ||
+    h.endsWith('.localhost') ||
+    h === 'metadata' ||
+    h === 'metadata.google.internal' ||
+    h === '0.0.0.0'
+  ) {
+    return true;
+  }
+
+  // IPv4 literal
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(h)) {
+    const parts = h.split('.').map((p) => Number(p));
+    if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+      return true; // invalid → reject
+    }
+    const [a, b] = parts as [number, number, number, number];
+    if (a === 0) return true;
+    if (a === 10) return true; // 10.0.0.0/8
+    if (a === 127) return true; // loopback
+    if (a === 169 && b === 254) return true; // link-local + IMDS
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 192 && b === 168) return true; // 192.168.0.0/16
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
+  }
+
+  // IPv6 literal (common forms)
+  if (h.includes(':')) {
+    if (h === '::1' || h === '::') return true;
+    if (h.startsWith('fe80:') || h.startsWith('fc') || h.startsWith('fd')) return true;
+    // IPv4-mapped ::ffff:127.0.0.1 etc.
+    const mapped = h.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+    if (mapped?.[1] && isBlockedHostname(mapped[1])) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Throws if the URL is not a safe http/https URL (no private SSRF targets).
  */
 export function httpUrlOnly(url: string): void {
   let parsed: URL;
@@ -23,16 +68,19 @@ export function httpUrlOnly(url: string): void {
   if (!parsed.hostname) {
     throw new Error('URL must have a hostname');
   }
+  if (isBlockedHostname(parsed.hostname)) {
+    throw new Error('URL host is not allowed (private, loopback, or link-local address)');
+  }
 }
 
-const ALLOWED_DATA_MIME = /^data:(text\/html|image\/(png|jpeg|gif|webp))[;,]/i;
+// #70: ban data:text/html (JS in Strom cefsrc). Raster images only.
+const ALLOWED_DATA_MIME = /^data:image\/(png|jpeg|gif|webp)[;,]/i;
 const BLOCKED_SCHEMES = /^(file|javascript|ftp|gopher|chrome|about|data:application):/i;
 
 /**
  * Throws if the value is not a safe graphic URL.
- * Accepts: http/https URLs, data:text/html (inline HTML overlays rendered by Strom's headless browser),
- *          or data:image/(png|jpeg|gif|webp) base64 URIs.
- * Rejects: file://, javascript:, data:application/*, etc.
+ * Accepts: http/https (public hosts only), or data:image/(png|jpeg|gif|webp).
+ * Rejects: data:text/html, private IPs, file://, javascript:, etc.
  */
 export function graphicUrl(url: string): void {
   if (BLOCKED_SCHEMES.test(url)) {
@@ -40,11 +88,10 @@ export function graphicUrl(url: string): void {
   }
   if (url.startsWith('data:')) {
     if (!ALLOWED_DATA_MIME.test(url)) {
-      throw new Error('Only data:text/html or data:image/(png|jpeg|gif|webp) URIs are allowed for graphics');
+      throw new Error('Only data:image/(png|jpeg|gif|webp) URIs are allowed for graphics');
     }
     return;
   }
-  // Otherwise must be a safe http/https URL
   httpUrlOnly(url);
 }
 


### PR DESCRIPTION
## Summary
Closes #65.

Reject private RFC1918, loopback, link-local/IMDS, CGNAT, and special hostnames in `httpUrlOnly()` (used by graphic/HTML URLs). Also ban `data:text/html` in `graphicUrl`.

## Test plan
- [x] `npm run typecheck`
- [ ] `http://127.0.0.1/` → rejected
- [ ] `http://169.254.169.254/` → rejected
- [ ] public https URL → ok