### PR TITLE
fix(security): coalesce concurrent SAT token exchanges

### DIFF
--- a/src/lib/strom-token.ts
+++ b/src/lib/strom-token.ts
@@ -5,6 +5,8 @@
  * - STROM_AUTH_MODE=osc (default): exchanges the PAT for a short-lived SAT
  *   via the OSC token service (required for OSC-hosted Strom instances).
  *   Caches the SAT and refreshes it 5 min before expiry.
+ *
+ * #85: coalesce concurrent exchanges so only one in-flight fetch runs at a time.
  */
 
 const TOKEN_EXCHANGE_URL = 'https://token.svc.prod.osaas.io/servicetoken'
@@ -17,9 +19,31 @@ interface SatCache {
 }
 
 let cache: SatCache | null = null
+let inflightExchange: Promise<string> | null = null
 
-function isExpiringSoon(cache: SatCache): boolean {
-  return Date.now() >= cache.expiresAt - REFRESH_BUFFER_MS
+function isExpiringSoon(c: SatCache): boolean {
+  return Date.now() >= c.expiresAt - REFRESH_BUFFER_MS
+}
+
+async function exchangePat(pat: string): Promise<string> {
+  const res = await fetch(TOKEN_EXCHANGE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      accept: 'application/json',
+      'x-pat-jwt': `Bearer ${pat}`,
+    },
+    body: JSON.stringify({ serviceId: STROM_SERVICE_ID }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`SAT exchange failed: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`)
+  }
+
+  const data = (await res.json()) as { token: string; expiry: number }
+  cache = { token: data.token, expiresAt: data.expiry * 1000 }
+  return cache.token
 }
 
 /**
@@ -43,22 +67,11 @@ export async function getStromToken(pat: string | undefined): Promise<string | u
     return cache.token
   }
 
-  const res = await fetch(TOKEN_EXCHANGE_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      accept: 'application/json',
-      'x-pat-jwt': `Bearer ${pat}`,
-    },
-    body: JSON.stringify({ serviceId: STROM_SERVICE_ID }),
-  })
-
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`SAT exchange failed: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`)
+  // #85: single-flight exchange under concurrent callers
+  if (!inflightExchange) {
+    inflightExchange = exchangePat(pat).finally(() => {
+      inflightExchange = null
+    })
   }
-
-  const data = (await res.json()) as { token: string; expiry: number }
-  cache = { token: data.token, expiresAt: data.expiry * 1000 }
-  return cache.token
+  return inflightExchange
 }


### PR DESCRIPTION
## Summary
Closes #85.

Only one PAT→SAT exchange in flight at a time; concurrent callers await the same promise.

## Test plan
- [x] `npm run typecheck`