### PR TITLE
fix(security): block private hosts in srtUrl and httpUrlOnly

### DIFF
--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -2,10 +2,61 @@
  * URL validation helpers for security-sensitive inputs.
  *
  * Rules:
- * - httpUrlOnly: allow only http/https schemes
+ * - httpUrlOnly: allow only http/https schemes; reject private/loopback hosts
  * - graphicUrl:  httpUrlOnly OR safe data: image URIs (no svg, no text/html)
- * - srtUrl:      srt:// scheme only
+ * - srtUrl:      srt:// scheme only; reject private/loopback hosts (listener :port OK)
  */
+
+/**
+ * Returns true if hostname targets private, loopback, link-local, or metadata ranges.
+ * Covers IPv4 private, IPv6 ULA (fc00::/7), link-local, IPv4-mapped IPv6, and localhost.
+ */
+export function isPrivateHost(hostname: string): boolean {
+  const host = hostname.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return false;
+  if (host === 'localhost' || host === '0.0.0.0' || host === '::' || host === '::1') {
+    return true;
+  }
+
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d or ::ffff:hex)
+  const v4Mapped = host.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i);
+  if (v4Mapped) return isPrivateHost(v4Mapped[1]!);
+  if (/^::ffff:/i.test(host)) {
+    // hex form ::ffff:7f00:1 → treat as private (mapped space)
+    return true;
+  }
+
+  // IPv6: loopback already handled; ULA fc00::/7, link-local fe80::/10
+  if (host.includes(':')) {
+    if (host === '::1' || host.startsWith('fe80:') || host.startsWith('fec0:')) return true;
+    // fc00::/7 → first hextet 0xfc00–0xfdff
+    const first = host.split(':')[0] ?? '';
+    if (/^f[cd][0-9a-f]{0,2}$/i.test(first) || first.toLowerCase() === 'fc' || first.toLowerCase() === 'fd') {
+      return true;
+    }
+    // broader: fc* / fd* prefix (ULA)
+    if (/^f[cd]/i.test(first)) return true;
+    return false;
+  }
+
+  // IPv4 dotted
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) {
+    // bare hostname "localhost" handled; other names allowed (public DNS)
+    return false;
+  }
+  const a = Number(m[1]);
+  const b = Number(m[2]);
+  if ([a, b, Number(m[3]), Number(m[4])].some((n) => n > 255)) return true; // invalid → reject
+  if (a === 0) return true; // 0.0.0.0/8
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true; // link-local / cloud metadata path often 169.254.169.254
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT optional harden
+  return false;
+}
 
 /**
  * Throws if the URL is not a safe http/https URL.
@@ -22,6 +73,9 @@ export function httpUrlOnly(url: string): void {
   }
   if (!parsed.hostname) {
     throw new Error('URL must have a hostname');
+  }
+  if (isPrivateHost(parsed.hostname)) {
+    throw new Error('URL must not target private, loopback, or link-local addresses');
   }
 }
 
@@ -53,6 +107,7 @@ const SRT_URL_RE = /^srt:\/\/[^!; ]*$/i;
 
 /**
  * Throws if the value is not a valid SRT URL.
+ * Listener-mode URIs (srt://:PORT) remain allowed; private/loopback hosts are rejected.
  */
 export function srtUrl(url: string): void {
   if (!url.startsWith('srt://')) {
@@ -60,5 +115,17 @@ export function srtUrl(url: string): void {
   }
   if (!SRT_URL_RE.test(url)) {
     throw new Error('SRT URL contains disallowed characters');
+  }
+
+  // Parse host via WHATWG URL by rewriting scheme (srt://:9000 stays empty host)
+  let hostname: string;
+  try {
+    hostname = new URL(url.replace(/^srt:\/\//i, 'http://')).hostname;
+  } catch {
+    throw new Error('Invalid SRT URL');
+  }
+  // Empty host = listener bind-all (srt://:6000?mode=listener) — allow
+  if (hostname && isPrivateHost(hostname)) {
+    throw new Error('SRT URL must not target private, loopback, or link-local addresses');
   }
 }


### PR DESCRIPTION
## Summary
- Add shared `isPrivateHost` covering IPv4 private/loopback/link-local, IPv6 ULA `fc00::/7`, and IPv4-mapped IPv6
- Apply to `srtUrl()` (listener `srt://:port` still allowed) and `httpUrlOnly()` / graphics paths

## Issues
- Closes #78 (SRT SSRF via GStreamer)
- Related: #58 (blocklist gaps), #65 (httpUrlOnly)

## Test plan
- [ ] `srt://127.0.0.1:9000` and `srt://10.0.0.1:9000` rejected
- [ ] `srt://:6000?mode=listener` still accepted
- [ ] `http://[fd12::1]/` and `http://localhost/` rejected by httpUrlOnly
- [ ] `pnpm typecheck` clean