### PR TITLE
fix(security): bind CouchDB admin port to 127.0.0.1 only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       COUCHDB_USER: ${COUCHDB_USER:-admin}
       COUCHDB_PASSWORD: ${COUCHDB_PASSWORD:?Set COUCHDB_PASSWORD in .env (see .env.example)}
     ports:
-      - "5984:5984"
+      - "127.0.0.1:5984:5984"  # loopback only — not 0.0.0.0 (see security #62)
     volumes:
       - couchdb_data:/opt/couchdb/data
 


### PR DESCRIPTION
## Summary
Bind CouchDB `5984` to loopback in `docker-compose.yml` so the admin API/Fauxton is not reachable from the LAN/internet when the host firewall is open.

open-live continues to use the internal Docker network (`couchdb:5984`).

## Issues
Closes #62

## Test plan
- [ ] `docker compose up` — `curl 127.0.0.1:5984` works from host
- [ ] From another host on LAN, port 5984 is not open on the docker host
- [ ] open-live container still connects via `COUCHDB_URL` service name