### PR TITLE
fix(security): warn when API_KEY unset; compose default key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,12 @@ STROM_AUTH_TOKEN=your-token-here
 
 LOG_LEVEL=info
 
-# Optional: static API key for self-hosted deployments not behind OSC's reverse-proxy auth.
+# Static API key for self-hosted deployments not behind OSC's reverse-proxy auth.
 # When set, all /api/v1 routes require: Authorization: Bearer <API_KEY>
-# Leave unset when running on OSC (auth is handled by the OSC proxy).
-# API_KEY=change-me-before-use
+# Leave unset only when running on OSC (auth is handled by the OSC proxy).
+# docker-compose defaults to change-me-before-use so the reference stack is not open.
+# Without API_KEY the server logs a warning (error log when NODE_ENV=production).
+API_KEY=change-me-before-use
 
 # Optional: restrict CORS allowed origins (comma-separated, or * for wildcard).
 # Default is * for backward compatibility. Tighten for production deployments.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       COUCHDB_NAME: open-live
       CORS_ORIGIN: http://localhost:5173
       LOG_LEVEL: info
+      # Set API_KEY for network-accessible deploys (see security #56). Placeholder prompts operators.
+      API_KEY: ${API_KEY:-change-me-before-use}
     depends_on:
       - couchdb
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,6 +96,17 @@ async function main() {
   }
 
   startIdleWatchdog(app.log);
+
+  if (!config.apiKey) {
+    const msg =
+      'API_KEY is not set — all /api/v1 routes are unauthenticated. Set API_KEY for any network-accessible deployment.';
+    if (process.env['NODE_ENV'] === 'production') {
+      app.log.error(msg);
+    } else {
+      app.log.warn(msg);
+    }
+  }
+
   await app.listen({ port: config.port, host: '0.0.0.0' });
 }
 


### PR DESCRIPTION
## Summary
API auth was opt-in: unset `API_KEY` meant fully open `/api/v1` (especially with `docker compose up`).

- Startup **warn** when `API_KEY` is missing; **error** log when `NODE_ENV=production`
- `docker-compose.yml` sets `API_KEY: \${API_KEY:-change-me-before-use}`
- `.env.example` documents the required pattern

## Issues
Closes #56

## Test plan
- [ ] Start without API_KEY — log warns unauthenticated
- [ ] `docker compose` default rejects unauthenticated clients with wrong key once key set
- [ ] OSC-style unset still works for local without compose default when running binary directly