### PR TITLE
fix: add pnpm overrides to patch transitive vulnerable dependencies (closes #131)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "@fastify/websocket": "^11.0.2",
-    "fastify": "^5.3.2",
+    "fastify": "^5.9.0",
     "fastify-type-provider-zod": "^4.0.2",
     "nano": "^10.1.4",
     "ws": "^8.20.0",
@@ -31,5 +31,15 @@
     "tsx": "^4.19.3",
     "typescript": "^5.8.3",
     "vitest": "^4.1.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "axios": ">=1.16.0",
+      "follow-redirects": ">=1.16.0",
+      "form-data": ">=4.0.6",
+      "fast-uri": ">=3.1.2",
+      "ws": ">=8.21.0",
+      "qs": ">=6.15.2"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides` to `package.json` to pin transitive dependencies to patched minimum versions.
- Bumps `fastify` from `^5.3.2` to `^5.9.0` to fix the body-schema validation bypass.

## Packages pinned

| Package | Floor version | Vulnerability |
|---------|--------------|---------------|
| `axios` | `>=1.16.0` | SSRF via NO_PROXY bypass, prototype pollution, credential leak to redirect — directly exploitable via `nano` → CouchDB path |
| `follow-redirects` | `>=1.16.0` | Credential leak on redirect |
| `form-data` | `>=4.0.6` | CRLF injection in multipart boundary |
| `fast-uri` | `>=3.1.2` | Host confusion + path traversal (via `@fastify/swagger`) |
| `ws` | `>=8.21.0` | Memory exhaustion DoS + uninitialized memory disclosure |
| `qs` | `>=6.15.2` | Remote DoS |

## After merging

Run `pnpm install` to regenerate `pnpm-lock.yaml` with the pinned transitive versions, then verify with `pnpm audit --prod`.

Closes #131