### PR TITLE
fix: enable trustProxy and use req.ip for rate limiting and audit log (closes #139)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,11 @@ export async function buildServer() {
     disableRequestLogging: true,
     // Prevent memory exhaustion via oversized request bodies (1 MB limit)
     bodyLimit: 1_048_576,
+    // Trust the X-Forwarded-For header from the ingress proxy so that req.ip
+    // resolves to the real client IP rather than the proxy's address.
+    // Without this, the header is treated as user-controlled input, allowing
+    // spoofed IPs to bypass rate limiting.
+    trustProxy: true,
   });
 
   // CORS must be registered before Helmet so its onRequest hook runs first
@@ -69,7 +74,7 @@ export async function buildServer() {
     // Skip health/ready probes — they are high-frequency and come from the cluster
     allowList: (req: { url: string }) => req.url === '/health' || req.url === '/ready',
     skipOnError: false,
-    keyGenerator: (req: { headers: Record<string, string | string[] | undefined>; ip: string }) => (req.headers['x-forwarded-for'] as string ?? req.ip).split(',')[0]!.trim(),
+    keyGenerator: (req: { ip: string }) => req.ip,
     errorResponseBuilder: (_req, context) => ({
       error: 'Too many requests',
       statusCode: 429,
@@ -130,7 +135,7 @@ export async function buildServer() {
   fastify.addHook('onResponse', async (req, reply) => {
     if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) return;
     if (!req.url.startsWith('/api/v1')) return;
-    const ip = ((req.headers['x-forwarded-for'] as string | undefined) ?? req.ip ?? '').split(',')[0]!.trim();
+    const ip = req.ip ?? '';
     fastify.log.info({
       audit: true,
       method: req.method,


### PR DESCRIPTION
## Summary

- Add `trustProxy: true` to the Fastify constructor so the framework validates the `X-Forwarded-For` chain and resolves `req.ip` to the real client IP
- Replace the manual `x-forwarded-for` header extraction in the rate-limit `keyGenerator` with `req.ip` — Fastify now handles the chain correctly
- Replace the same pattern in the audit-log `onResponse` hook with `req.ip`

Without `trustProxy`, any client could send a spoofed `X-Forwarded-For` header to make the rate limiter count each request against a different fictitious IP, rendering the limit ineffective. Spoofed IPs also polluted the audit log.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)