### PR TITLE
fix: use timingSafeEqual for API key comparison to close timing side-channel (closes #138)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import rateLimit from '@fastify/rate-limit';
 import websocket from '@fastify/websocket';
 import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
+import { timingSafeEqual } from 'crypto';
 import { ZodError } from 'zod';
 import { config } from './config.js';
 import { isDbConnected } from './db/index.js';
@@ -163,7 +164,9 @@ export async function buildServer() {
       const keyFromQuery = (req.query as Record<string, string>)?.['key'];
       const provided = keyFromHeader ?? keyFromQuery;
 
-      if (provided !== config.apiKey) {
+      const a = Buffer.from(provided ?? '');
+      const b = Buffer.from(config.apiKey);
+      if (a.length !== b.length || !timingSafeEqual(a, b)) {
         return reply.status(401).send({ error: 'Unauthorized', statusCode: 401 });
       }
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -138,6 +138,11 @@ export async function buildServer() {
   // Exempt: health/ready probes and status/reconnect endpoints.
   // WS connections: pass key via Authorization header or ?key= query param on upgrade.
   if (config.apiKey) {
+    // Captured here, outside the closure: TS narrows `config.apiKey` from
+    // `string | undefined` to `string` at this `if`, but that narrowing does
+    // not carry into the callback passed to addHook below (a new, separate
+    // function scope), so `config.apiKey` inside it is still `string | undefined`.
+    const apiKey = config.apiKey;
     fastify.addHook('onRequest', async (req, reply) => {
       const path = req.url.split('?')[0]!;
       if (AUTH_EXEMPT_PATHS.has(path)) return;
@@ -165,7 +170,7 @@ export async function buildServer() {
       const provided = keyFromHeader ?? keyFromQuery;
 
       const a = Buffer.from(provided ?? '');
-      const b = Buffer.from(config.apiKey);
+      const b = Buffer.from(apiKey);
       if (a.length !== b.length || !timingSafeEqual(a, b)) {
         return reply.status(401).send({ error: 'Unauthorized', statusCode: 401 });
       }


### PR DESCRIPTION
## Summary

- Import `timingSafeEqual` from Node.js built-in `crypto`
- Replace the `provided !== config.apiKey` comparison with a constant-time check: convert both strings to `Buffer`, verify equal length first, then call `timingSafeEqual`

The native `!==` operator allows V8 to short-circuit on the first mismatched character, creating a measurable latency difference that a co-located attacker can exploit to enumerate the API key one character at a time. `timingSafeEqual` compares all bytes in constant time regardless of where the first mismatch occurs.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)