### PR TITLE
fix: add HSTS header to helmet registration (closes #145)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -86,6 +86,11 @@ export async function buildServer() {
     // reads are already selectively permitted via CORS preflight; a global
     // cross-origin CRP would additionally expose responses to no-cors fetches.
     crossOriginResourcePolicy: { policy: 'same-origin' },
+    strictTransportSecurity: {
+      maxAge: 31536000,
+      includeSubDomains: true,
+      preload: true,
+    },
   });
 
   // Rate limiting — 200 requests per minute per IP on API routes


### PR DESCRIPTION
## Summary

Adds `strictTransportSecurity` to the `@fastify/helmet` registration in `src/server.ts`, so all API responses include a `Strict-Transport-Security` header.

- `maxAge: 31536000` (1 year)
- `includeSubDomains: true`
- `preload: true`

Without this header, browsers do not automatically upgrade HTTP connections to HTTPS, leaving the `Authorization: Bearer <API_KEY>` header and TURN credentials from `GET /api/v1/ice-servers` potentially exposed over plaintext HTTP.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)