### PR TITLE
fix: require PUBLIC_BASE_URL in production to prevent host-header injection (closes #144)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,26 @@ async function main() {
     }
   }
 
+  // PUBLIC_BASE_URL is required in production to prevent X-Forwarded-Host injection.
+  // Without it, the activation endpoint derives the public WHIP URL from the raw
+  // X-Forwarded-Host header, which an attacker can forge to redirect camera streams
+  // to an attacker-controlled server (CVE category: host-header injection).
+  if (!config.publicBaseUrl) {
+    if (process.env['NODE_ENV'] === 'production') {
+      throw new Error(
+        'PUBLIC_BASE_URL must be set in production deployments. ' +
+        'Without it the activation endpoint derives WHIP endpoint URLs from the ' +
+        'X-Forwarded-Host request header, enabling host-header injection attacks.'
+      );
+    } else {
+      console.warn(
+        '[security] PUBLIC_BASE_URL is not set. WHIP endpoint URLs will be derived ' +
+        'from request headers (X-Forwarded-Host / Host). Set PUBLIC_BASE_URL to the ' +
+        'externally reachable URL of this service before deploying to production.'
+      );
+    }
+  }
+
   const app = await buildServer();
 
   try {


### PR DESCRIPTION
## Summary

Adds a startup guard in `main.ts` that prevents the server from starting in production when `PUBLIC_BASE_URL` is not configured.

**Why this matters:** When `PUBLIC_BASE_URL` is absent, the `POST /api/v1/productions/:id/activate` handler falls back to deriving the public-facing URL from the `X-Forwarded-Host` request header. An attacker can forge this header, causing an attacker-controlled URL to be persisted in CouchDB as the WHIP endpoint. All camera clients that subsequently read the production document will send their WHIP SDP offers to the attacker's server, enabling credential capture and stream hijacking.

**Changes:**
- In `src/main.ts`: when `PUBLIC_BASE_URL` is unset and `NODE_ENV === 'production'`, the process throws a descriptive error and exits before the server starts accepting traffic
- In non-production environments a `console.warn` is emitted so developers are aware of the configuration gap without blocking local dev

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)