### PR TITLE
fix: require API_KEY in production to prevent unauthenticated access (closes #143)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,11 @@ STROM_AUTH_TOKEN=your-token-here
 
 LOG_LEVEL=info
 
-# Optional: static API key for self-hosted deployments not behind OSC's reverse-proxy auth.
-# When set, all /api/v1 routes require: Authorization: Bearer <API_KEY>
-# Leave unset when running on OSC (auth is handled by the OSC proxy).
-# API_KEY=change-me-before-use
+# Required for self-hosted deployments: static API key protecting all /api/v1 routes.
+# All requests must include: Authorization: Bearer <API_KEY>
+# Leave unset ONLY when running on OSC (auth is handled by the OSC reverse proxy).
+# Starting with NODE_ENV=production without this set will cause a startup error.
+API_KEY=change-me-before-use
 
 # Optional: restrict CORS allowed origins (comma-separated, or * for wildcard).
 # Default is * for backward compatibility. Tighten for production deployments.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       COUCHDB_NAME: open-live
       CORS_ORIGIN: http://localhost:5173
       LOG_LEVEL: info
+      # Required for production deployments — set a strong random secret.
+      # Omit (or leave unset) only when running behind an external auth layer.
+      API_KEY: ${API_KEY:?Set API_KEY in .env (see .env.example)}
     depends_on:
       - couchdb
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,27 @@ async function reconcileProductionStatuses(
 }
 
 async function main() {
+  // API_KEY is required in production. Without it every route is unauthenticated,
+  // allowing any client that can reach port 3000 to create, modify, and delete
+  // productions. Omitting API_KEY is intentional only when running behind OSC's
+  // reverse-proxy auth wall or another trusted auth layer.
+  if (!config.apiKey) {
+    if (process.env['NODE_ENV'] === 'production') {
+      throw new Error(
+        'API_KEY must be set in production deployments. ' +
+        'Without it all API routes are unauthenticated. ' +
+        'Set API_KEY to a strong random secret, or set NODE_ENV to a value ' +
+        'other than "production" if this deployment intentionally relies on ' +
+        'an external auth layer (e.g. the OSC reverse proxy).'
+      );
+    } else {
+      console.warn(
+        '[security] API_KEY is not set — all /api/v1 routes are unauthenticated. ' +
+        'Set API_KEY before deploying to production.'
+      );
+    }
+  }
+
   const app = await buildServer();
 
   try {


### PR DESCRIPTION
## Summary

Closes the CRITICAL security gap where the default `docker-compose` deployment shipped with zero authentication — any client reaching port 3000 could create, modify, delete, and activate live broadcast productions with no credentials.

**Changes:**

- **`src/main.ts`**: startup guard — if `NODE_ENV=production` and `API_KEY` is not set, the process throws a descriptive error and exits before accepting traffic. In non-production environments a `console.warn` is emitted so developers are aware of the misconfiguration without blocking local dev.
- **`docker-compose.yml`**: `API_KEY` added with the `:?` substitution syntax (same pattern as `COUCHDB_PASSWORD`) so `docker-compose up` fails explicitly with a helpful message when `API_KEY` is missing from `.env`.
- **`.env.example`**: `API_KEY` uncommented and re-documented as required for self-hosted deployments. The comment explicitly notes it is optional only on OSC, where auth is handled by the OSC reverse proxy.

**Backward compatibility:** OSC deployments that deliberately omit `API_KEY` continue working as long as they do not set `NODE_ENV=production`. If they do set it, they should confirm that OSC handles auth before proceeding.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)