### PR TITLE
fix(dsk): don't pin a framerate on the DSK videoformat block

### DIFF
--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -665,8 +665,14 @@ export async function activateStromFlow(
         properties: { url: graphic.url },
         position: [COL_ELEM, dskY],
       });
+      // Resolution only — deliberately no framerate. cefsrc advertises
+      // framerate=0/1 (variable), and builtin.videoformat is
+      // videoscale -> videoconvert -> capsfilter with no videorate, so pinning
+      // a fixed framerate here cannot be satisfied: the capsfilter fails to
+      // negotiate, cefsrc's task pauses on not-negotiated, and the DSK renders
+      // nothing at all. The source-side format blocks above already pass
+      // resolution only. The mixer still emits pgm_framerate downstream.
       const fmtProps: Record<string, unknown> = { resolution: pgmResolution };
-      if (pgmFramerate !== undefined) fmtProps['framerate'] = pgmFramerate;
       flow.blocks.push({
         id: fmtId,
         block_definition_id: 'builtin.videoformat',


### PR DESCRIPTION
## Problem

Assigning a graphic to a DSK layer produced **no output at all**. Not a keying problem and not the toggle — no buffers ever reached the mixer, so the graphic simply never appeared.

`cefsrc` advertises `framerate=0/1` (variable). Strom's `builtin.videoformat` is `videoscale -> videoconvert -> capsfilter`, with its `videorate` currently commented out ("TEMPORARY: videorate removed to avoid frame duplication issues"), so the block cannot convert framerate at all.

The DSK format block was the only one we set `framerate` on:

```js
const fmtProps: Record<string, unknown> = { resolution: pgmResolution };
if (pgmFramerate !== undefined) fmtProps['framerate'] = pgmFramerate;
```

That asks the capsfilter for `25/1` when nothing upstream can produce anything but `0/1`. Negotiation fails, `gst_base_src_loop` pauses the `cefsrc` task on `GST_FLOW_NOT_NEGOTIATED`, and the DSK is silently dead. The rest of the pipeline keeps running normally, which makes this hard to spot — the flow looks healthy.

## Evidence

From `/api/flows/{id}/pad-caps` on a running flow:

```
e-dsk-0-…                       src:  BGRA 1920x1080 framerate=(fraction)0/1
b-dsk-fmt-0-…:videoconvert      sink: negotiated      src: NOT NEGOTIATED
b-dsk-fmt-0-…:capsfilter        NOT NEGOTIATED
…:glupload_dsk_0                NOT NEGOTIATED
…:glcolorconvert_dsk_0          NOT NEGOTIATED
…:queue_dsk_0                   NOT NEGOTIATED
```

A `sample` of the process shows the `cefsrc` threads parked at `gst_task_func + 344` (the paused-task branch) while healthy sources sit at `+ 288` inside `gst_base_src_loop`.

## Fix

Pass `resolution` only, which is what the source-side format blocks already do — `b-fmt-1` / `b-fmt-2` in a generated flow carry `{"resolution": "1920x1080"}` with no framerate. The DSK path was the inconsistent one. The vision mixer still emits `pgm_framerate` downstream, so program output framerate is unaffected.

## Testing

Verified end to end: with the framerate removed, both DSK layers negotiate and render over program. Checked with two fills — a static PNG with a known alpha channel (transparent surround, soft shadow, four alpha swatches, a 0→255 ramp) and a live HTML scoreboard — confirming per-pixel alpha keys correctly in both.

There is a related sharp edge worth flagging separately: `builtin.videoformat` still advertises a "Framerate" property whose description says it "creates videorate element", while `videorate` is disabled. Setting it on any variable-framerate source fails the same way. That is a Strom-side issue rather than something to fix here.