### PR TITLE
fix(audio): don't let an unrouted group drain block preroll

### DIFF
--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -794,7 +794,9 @@ export async function activateStromFlow(
       flow.elements.push({
         id: drainId,
         element_type: 'fakesink',
-        properties: { sync: false },
+        // async: false — this drain may never receive a buffer (group bus with
+        // nothing routed to it), so it must not block pipeline preroll.
+        properties: { sync: false, async: false },
         position: [encX, drainBaseY + ROW_H * (i - 1)],
       } as unknown as typeof flow.elements[number]);
       flow.links.push({ from: `${audioMixerBlockId}:group_out_${i}`, to: `${drainId}:sink` });


### PR DESCRIPTION
## Problem

Each unused audio group bus gets a `fakesink` drain, created with `sync: false` but leaving `async` at its default (`true`).

A group with nothing routed to it may never receive a buffer. An async sink that never prerolls holds the pipeline in its state change, so an idle group bus can stall the flow rather than simply sitting quiet.

## Fix

Set `async: false` on the drains, keeping them out of preroll accounting. They are pure drains — nothing downstream depends on their timing, so there is no reason for them to participate in preroll at all.

One line plus a comment explaining why, since `sync: false, async: false` on a fakesink otherwise looks like belt-and-braces rather than a deliberate requirement.