### PR TITLE
fix(whip,whep): disable RTX to avoid a gst-plugins-base crash

### DIFF
--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -565,7 +565,13 @@ export async function activateStromFlow(
         id: inputId,
         block_definition_id: 'builtin.whip_input',
         name: `WHIP Input (V${padIndex})`,
-        properties: { endpoint_id: endpointId },
+        // do_retransmission: false — works around a gst-plugins-base crash in
+        // RTX + RTP header-extension aggregation. On a DISCONT buffer the
+        // depayloader resets hdrext_buffers but not hdrext_delayed, then
+        // asserts the latter is NULL and aborts the process:
+        // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/43de6c053f3658c528269a42638b2d52f5adc0cb/subprojects/gst-plugins-base/gst-libs/gst/rtp/gstrtpbasedepayload.c#L896-897
+        // Property exposed by Eyevinn/strom#663; revert once upstream is fixed.
+        properties: { endpoint_id: endpointId, do_retransmission: false },
         position: { x: COL_INPUT, y: yPos },
       });
       flow.links.push({ from: `${inputId}:video_out`, to: `${offsetId}:in` });
@@ -737,6 +743,9 @@ export async function activateStromFlow(
           name: outputDoc.name,
           properties: {
             endpoint_id: endpointId,
+            // See the WHIP Input block above: RTX trips a gst-plugins-base
+            // assertion, so it stays off on both legs until that is fixed.
+            do_retransmission: false,
             ...(mainAudioSource && { num_audio_tracks: 1 + (monitorAudioSource ? 1 : 0) + auxCount }),
           },
           position: { x: COL_OUTPUT, y: ROW_START + outputBlockIndex * ROW_H },


### PR DESCRIPTION
> **Correction (2026-08-27): the premise of this PR is not supported by the current evidence.** See "Status" below before merging.

## Status

The investigation in [Eyevinn/strom#685](https://github.com/Eyevinn/strom/issues/685) (2026-08-25) established the actual mechanism, and it does not involve RTX:

- The assertion that actually fires in production is **`gstrtpbasedepayload.c:942`** (`gst_buffer_list_length (priv->hdrext_buffers) == 0`), not L897 as this PR originally stated.
- The trigger is `rtph264depay` calling `gst_rtp_base_depayload_delayed()` on an interrupted FU-A and then producing no output buffer in access-unit merge mode, leaving the header cache non-empty. **RTX and TWCC are not in that path.**
- Packet loss actively *prevents* the crash: a forward sequence gap sets DISCONT, which resets the cache before the assertion is reached. The crash needs *contiguous* sequence numbers.
- `whepserversink` is send-only and instantiates no depayloader, so the WHEP half of this change cannot affect the crash at all.

[Eyevinn/strom#663](https://github.com/Eyevinn/strom/pull/663), which exposes the property this PR sets, says the same thing in its own description: turning RTX off "has not been observed to stop the assertion," the default stays `true`, and it ships as an escape hatch rather than a verified mitigation.

The real mitigation identified in #685 is `gst_rtp_base_depayload_set_aggregate_hdrext_enabled(depay, FALSE)` on Strom's depayloaders — a Strom-side change, not an Open Live one.

**Recommendation: close this PR** unless we want `do_retransmission: false` on its own merits, which would need a separate justification. Setting it on the WHEP output in particular has a real cost (losing RTX resilience on the viewer leg) for no effect on this crash.

## Upstream

Already reported: the assertion is tracked as [gstreamer#5057](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/5057), where our reproduction has been posted. No new upstream ticket is needed.

## Original description (retained for history)

RTX combined with RTP header-extension aggregation was believed to trip an assertion in `gst_rtp_base_depayload_handle_buffer`, aborting the process. This PR set `do_retransmission: false` on the WHIP input and WHEP output blocks as a workaround. The dependency, Eyevinn/strom#663, has since merged, but the causal link this change assumed did not hold up.