### PR TITLE
fix: add silent audiotestsrc per test pattern source to unblock audio mixer (closes #154)

### DIFF
--- a/src/__tests__/flow-generator.test.ts
+++ b/src/__tests__/flow-generator.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for activateStromFlow in flow-generator.ts.
+ *
+ * Strom client and CouchDB are mocked — no real services required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+vi.mock('../db/index.js', () => ({
+  getSourcesDb: () => ({ get: vi.fn().mockRejectedValue(new Error('not found')) }),
+  getGraphicsDb: () => ({ get: vi.fn().mockRejectedValue(new Error('not found')) }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStromClient() {
+  const capturedFlows: Record<string, unknown>[] = [];
+  const client = {
+    flows: {
+      create: vi.fn().mockImplementation((flow: Record<string, unknown>) => {
+        capturedFlows.push(flow);
+        return Promise.resolve({ flow: { id: 'flow-test-123' } });
+      }),
+      start: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    capturedFlows,
+  };
+  return client;
+}
+
+function makeProduction(sources: Array<{ sourceId: string; mixerInput: string }>, values?: Record<string, unknown>) {
+  return {
+    _id: 'prod-test-only',
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Test Production',
+    status: 'inactive',
+    sources,
+    graphicAssignments: [],
+    values: values ?? {},
+    pipeline: { stromConfig: null, status: 'stopped' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('activateStromFlow — test pattern sources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adds one audiotestsrc per test pattern and sets num_channels correctly (test-only production)', async () => {
+    const { activateStromFlow } = await import('../lib/flow-generator.js');
+    const strom = makeStromClient();
+
+    const production = makeProduction([
+      { sourceId: '__test1__', mixerInput: 'video_in_1' },
+      { sourceId: '__test2__', mixerInput: 'video_in_2' },
+    ]);
+
+    await activateStromFlow(production as never, strom as never);
+
+    expect(strom.flows.create).toHaveBeenCalledOnce();
+    const flow = strom.capturedFlows[0]!;
+    const elements = flow['elements'] as Array<Record<string, unknown>>;
+    const blocks = flow['blocks'] as Array<Record<string, unknown>>;
+    const links = flow['links'] as Array<Record<string, unknown>>;
+
+    // Each test pattern should have one audiotestsrc element
+    const audioTestSrcs = elements.filter((e) => e['element_type'] === 'audiotestsrc');
+    expect(audioTestSrcs).toHaveLength(2);
+    for (const e of audioTestSrcs) {
+      expect((e['properties'] as Record<string, unknown>)['wave']).toBe('silence');
+    }
+
+    // Audio mixer must have num_channels = 2 (one per test pattern)
+    const audioMixer = blocks.find((b) => b['block_definition_id'] === 'builtin.mixer');
+    expect(audioMixer).toBeDefined();
+    expect((audioMixer!['properties'] as Record<string, unknown>)['num_channels']).toBe(2);
+
+    // Each audiotestsrc must be linked into the audio mixer
+    const audioMixerId = audioMixer!['id'] as string;
+    const linksToAudioMixer = links.filter(
+      (l) => typeof l['to'] === 'string' && (l['to'] as string).startsWith(`${audioMixerId}:input_`),
+    );
+    expect(linksToAudioMixer).toHaveLength(2);
+  });
+
+  it('includes test patterns in audio channel count even alongside other virtual sources', async () => {
+    const { activateStromFlow } = await import('../lib/flow-generator.js');
+    const strom = makeStromClient();
+
+    // Both test1 and test2 virtual sources — no DB lookup needed
+    const production = makeProduction([
+      { sourceId: '__test1__', mixerInput: 'video_in_1' },
+      { sourceId: '__test2__', mixerInput: 'video_in_2' },
+      { sourceId: 'Whip', mixerInput: 'video_in_3' },
+    ]);
+
+    await activateStromFlow(production as never, strom as never);
+
+    const flow = strom.capturedFlows[0]!;
+    const elements = flow['elements'] as Array<Record<string, unknown>>;
+    const blocks = flow['blocks'] as Array<Record<string, unknown>>;
+
+    // Two test patterns → two audiotestsrc elements
+    const audioTestSrcs = elements.filter((e) => e['element_type'] === 'audiotestsrc');
+    expect(audioTestSrcs).toHaveLength(2);
+
+    // num_channels = 3 (test1 + test2 + WHIP)
+    const audioMixer = blocks.find((b) => b['block_definition_id'] === 'builtin.mixer');
+    expect((audioMixer!['properties'] as Record<string, unknown>)['num_channels']).toBe(3);
+  });
+
+  it('returns flow successfully without throwing for a test-pattern-only production', async () => {
+    const { activateStromFlow } = await import('../lib/flow-generator.js');
+    const strom = makeStromClient();
+
+    const production = makeProduction([
+      { sourceId: '__test1__', mixerInput: 'video_in_1' },
+    ]);
+
+    await expect(activateStromFlow(production as never, strom as never)).resolves.toMatchObject({
+      flowId: 'flow-test-123',
+    });
+  });
+});

--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -376,15 +376,15 @@ export async function activateStromFlow(
     mixerBlock['properties'] = props;
   }
 
-  // Set num_channels on the audio mixer = number of SRT/EFP/WHIP sources
-  // (test1/test2 sources don't carry audio; html sources do via cefdemux).
+  // Set num_channels on the audio mixer = number of audio-bearing sources.
+  // test1/test2 sources get a silent audiotestsrc below, so they count here too.
   // num_channels is a UInt — set it to exactly the number of audio-bearing sources.
   if (audioMixerBlock) {
-    const srtEfpCount = sortedAssignments.filter((a) => {
+    const audioSourceCount = sortedAssignments.filter((a) => {
       const src = sourceMap.get(a.sourceId) ?? (VIRTUAL_SOURCES[a.sourceId] as SourceDoc | undefined);
-      return src && src.streamType !== 'test1' && src.streamType !== 'test2';
+      return src != null;
     }).length;
-    const numChannels = Math.max(1, srtEfpCount);
+    const numChannels = Math.max(1, audioSourceCount);
     const props = (audioMixerBlock['properties'] ?? {}) as Record<string, unknown>;
     props['num_channels'] = numChannels;
     // ch{N}_aux{M}_pre is a build-time topology property — must be set here at flow
@@ -468,8 +468,11 @@ export async function activateStromFlow(
 
     const TEST_PATTERNS: Record<string, string> = { test1: 'Pinwheel', test2: 'Colors' }
     if (source.streamType === 'test1' || source.streamType === 'test2') {
+      const audioChannel = audioChannelIndex++;
       const elemId = `e-test-${padIndex}-${endpointSuffix}`;
       const fmtId = `b-fmt-${padIndex}-${endpointSuffix}`;
+      const audioElemId = `e-test-audio-${padIndex}-${endpointSuffix}`;
+      const audioOffsetId = `b-audio-offset-${padIndex}-${endpointSuffix}`;
       flow.elements.push({
         id: elemId,
         element_type: 'videotestsrc',
@@ -487,6 +490,33 @@ export async function activateStromFlow(
         { from: `${elemId}:src`, to: `${fmtId}:video_in` },
         { from: `${fmtId}:video_out`, to: `${offsetId}:in` },
       );
+      // Add a silent audio branch so every test pattern has a linked audio producer.
+      // Without this, the audio mixer ends up with channels that have no source,
+      // causing the aggregator to stall waiting for buffers that never arrive.
+      flow.elements.push({
+        id: audioElemId,
+        element_type: 'audiotestsrc',
+        properties: { wave: 'silence', 'is-live': true },
+        position: [COL_ELEM, yPos - 80],
+      });
+      flow.blocks.push({
+        id: audioOffsetId,
+        block_definition_id: 'builtin.time_offset',
+        name: `Offset A${padIndex}`,
+        properties: { offset_ms: 0.0 },
+        position: { x: COL_OFFSET, y: yPos - 80 },
+      });
+      sourceAudioOffsetBlockIds[assignment.mixerInput] = audioOffsetId;
+      flow.links.push({ from: `${audioElemId}:src`, to: `${audioOffsetId}:in` });
+      flow.links.push({ from: `${audioOffsetId}:out`, to: `${mixerBlockId}:audio_in_${padIndex}` });
+      if (audioMixerBlock && audioMixerBlockId) {
+        flow.links.push({ from: `${audioOffsetId}:out`, to: `${audioMixerBlockId}:input_${audioChannel + 1}` });
+        if (source.name) {
+          const props = (audioMixerBlock['properties'] ?? {}) as Record<string, unknown>;
+          props[`ch${audioChannel + 1}_label`] = source.name;
+          audioMixerBlock['properties'] = props;
+        }
+      }
     } else if (source.streamType === 'html') {
       const audioChannel = audioChannelIndex++;
       const elemId = `e-html-${padIndex}-${endpointSuffix}`;


### PR DESCRIPTION
## Summary

- Adds an `audiotestsrc` (`wave=silence`, `is-live=true`) branch per test pattern source (`test1`/`test2`), wired through a `time_offset` block into both the vision mixer's `audio_in_N` pad and the audio mixer's `input_N` channel.
- Updates the `num_channels` computation on the audio mixer to count test patterns as audio-bearing sources, keeping channel indices consistent with the source list.
- Adds a dedicated `flow-generator.test.ts` covering: test-pattern-only production (2× audiotestsrc, correct `num_channels`, links to mixer), mixed virtual-source production, and single test pattern resolving without throwing.

## Root cause

Test pattern sources produced no audio branch. `num_channels` on the audio mixer was `Math.max(1, 0) = 1`, but nothing was linked to that channel — the aggregator stalled waiting for buffers, preventing the flow from coming up.

Closes #154