### PR TITLE
feat(ws): broadcast the PGM background input behind a PiP

### DIFF
--- a/docs/controller-websocket.md
+++ b/docs/controller-websocket.md
@@ -108,7 +108,7 @@ are emitted from `src/ws/controller.ts` and `src/services/meter-relay.ts`:
 
 | `type` | Fields | Emitted when |
 |---|---|---|
-| `TALLY` | `pgm: string \| null`, `pvw: string \| null`, `transitionType?: string`, `durationMs?: number` | Tally (PGM/PVW) changes; also sent on connect |
+| `TALLY` | `pgm: string \| null`, `pvw: string \| null`, `pgmBg: string \| null`, `transitionType?: string`, `durationMs?: number` | Tally (PGM/PVW) changes; also sent on connect |
 | `PIP_STATE` | `pgmPip: number \| null`, `pvwPip: number \| null`, `pips: PipConfig[]` | PiP program/preview/config changes; also sent on connect |
 | `FTB_STATE` | `active: boolean` | Fade-to-black state changes |
 | `ON_AIR` | `value: boolean` | Production goes on/off air (`GO_LIVE` / `CUT_STREAM`) |
@@ -134,6 +134,12 @@ are emitted from `src/ws/controller.ts` and `src/services/meter-relay.ts`:
 | `METER_DATA` | `elementId: string`, `peak`, `rms` | Audio meter tick (relayed from Strom); `elementId` is `main`, `monitor`, `ch{N}`, `aux{N}`, or `grp{N}` |
 | `LOUDNESS_DATA` | `elementId: 'main'`, `momentary`, `shortterm`, `integrated`, `loudness_range`, `true_peak` | EBU R128 loudness tick (relayed from Strom) |
 | `ERROR` | `error: string` | An inbound frame was invalid or an operation failed (sent to originating socket) |
+
+`pgmBg` is the mixer input a PiP on program is composited over. It is `null` unless
+`PIP_STATE.pgmPip` is set, so the two fields together distinguish an empty program
+(`pgmPip` null) from a PiP over a known input (both set) from a PiP over nothing
+(`pgmPip` set, `pgmBg` null). It is not tracked across the `MACRO_EXEC` cut,
+transition, and take paths, which leave it holding the value from before the macro.
 
 ### Connect-time snapshot
 

--- a/src/__tests__/ws-macro-pip.test.ts
+++ b/src/__tests__/ws-macro-pip.test.ts
@@ -164,6 +164,31 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
+// The PGM background must be recorded even when Strom is unconfigured
+// ---------------------------------------------------------------------------
+
+describe('pgmBg with no Strom flow configured', () => {
+  it('records the background behind the PiP so later tallies still carry it', async () => {
+    mockGet.mockResolvedValue({
+      ...makeProductionDoc([{ type: 'CUT', sourceId: 'cam3' }]),
+      stromFlowId: undefined,
+      mixerBlockId: undefined,
+    });
+
+    await send({ type: 'SELECT_PVW_PIP', pip: 0 });
+    await send({ type: 'TAKE' });
+    resetRecordings();
+
+    // `pgmBgByProduction` is what a connecting client is served from. The
+    // connect sync lives in the plugin rather than handleMessage, so observe
+    // the map through a later TALLY, which reads it instead of recomputing it.
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    expect(tallies()[0]).toMatchObject({ pgmBg: 'video_in_1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // No PiP involved — the pre-existing path must be untouched
 // ---------------------------------------------------------------------------
 

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -404,6 +404,20 @@ const pvwBeforePipByProduction = new Map<string, string | null>()
  */
 const pgmBgByProduction = new Map<string, string | null>()
 
+/**
+ * The real input sitting behind a PiP that is on program, or null.
+ *
+ * While a PiP occupies PGM, `tally.pgm` is null and the background input is
+ * tracked only in `pgmBgByProduction`, which is never otherwise sent to a
+ * subscriber. Without it a client cannot tell "nothing on program" from "a PiP
+ * over input 3" — including on connect, where the distinction is otherwise
+ * unrecoverable, because the value is never re-broadcast.
+ *
+ * Read-only: nothing here changes mixer state or what airs.
+ */
+const pgmBgOf = (productionId: string): string | null =>
+  pgmBgByProduction.get(productionId) ?? null
+
 
 /** Wipe all per-production audio state. Called when the pipeline changes or production deactivates. */
 export function clearAudioState(productionId: string): void {
@@ -653,7 +667,7 @@ export async function handleMessage(
         broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: null, pips: pipConfigsByProduction.get(productionId) ?? [] });
       }
       await persistMixerMutation(productionId, 'CUT', (d) => ({ ...d, tally: newTally }));
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
       await stromTransition(doc, fromPadCut, msg.mixerInput, 'cut');
       if (curPgmPipCut !== null && doc.stromFlowId && doc.mixerBlockId) {
         try {
@@ -684,7 +698,7 @@ export async function handleMessage(
         broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPipTrans, pips: pipConfigsByProduction.get(productionId) ?? [] });
       }
       await persistMixerMutation(productionId, 'TRANSITION', (d) => ({ ...d, tally: newTally }));
-      broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: msg.transitionType, durationMs: msg.durationMs });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId), transitionType: msg.transitionType, durationMs: msg.durationMs });
       await stromTransition(doc, fromPadTrans, msg.mixerInput, toStromTransition(msg.transitionType), msg.durationMs);
       if (curPgmPipTrans !== null && doc.stromFlowId && doc.mixerBlockId) {
         try {
@@ -721,7 +735,15 @@ export async function handleMessage(
       pgmPipByProduction.set(productionId, newPgmPip);
       pvwPipByProduction.set(productionId, newPvwPip);
       await persistMixerMutation(productionId, 'TAKE', (d) => ({ ...d, tally: newTally }));
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      // `pgmBgByProduction` is not updated until the Strom block below, and only
+      // if those calls succeed, so derive the new background from what is in
+      // scope rather than reading a map that is still holding the old state.
+      //
+      // Falls back to the outgoing PGM input, matching the `to_input` the Strom
+      // transition below computes: when no PVW source was displaced, the mixer
+      // composites the PiP over whatever was already on program. Reporting null
+      // here would say "no background" while the mixer had one.
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: newPgmPip !== null ? (pvwBeforePipByProduction.get(productionId) ?? tally.pgm) : null });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: newPgmPip, pvwPip: newPvwPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
       const takeTransition = toStromTransition(msg.transitionType ?? 'cut');
       if (curPvwPip !== null) {
@@ -795,7 +817,7 @@ export async function handleMessage(
       const newTally = { pgm: tally.pgm, pvw: msg.mixerInput };
       setTally(productionId, newTally);
       await persistMixerMutation(productionId, 'SET_PVW', (d) => ({ ...d, tally: newTally }));
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: pgmPipByProduction.get(productionId) ?? null, pvwPip: null, pips: pipConfigsByProduction.get(productionId) ?? [] });
       if (doc.stromFlowId && doc.mixerBlockId) {
         const inputIndex = padToIndex(msg.mixerInput);
@@ -820,7 +842,7 @@ export async function handleMessage(
       const newTally = { pgm: tally.pgm, pvw: null };
       setTally(productionId, newTally);
       await persistMixerMutation(productionId, 'SELECT_PVW_PIP', (d) => ({ ...d, tally: newTally }));
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: pgmPipByProduction.get(productionId) ?? null, pvwPip: msg.pip, pips: pipConfigsByProduction.get(productionId) ?? [] });
       if (doc.stromFlowId && doc.mixerBlockId) {
         try {
@@ -969,7 +991,7 @@ export async function handleMessage(
             const newTally = { pgm: mixerInput, pvw: tally.pgm };
             setTally(productionId, newTally);
             await persistMixerMutation(productionId, 'MACRO_EXEC:CUT', (d) => ({ ...d, tally: newTally }));
-            broadcast(productionId, { type: 'TALLY', ...newTally });
+            broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
             await stromTransition(currentDoc, tally.pgm, mixerInput, 'cut');
           } else if (action.type === 'TRANSITION' && action.sourceId) {
             const mixerInput = resolveInput(action.sourceId);
@@ -978,14 +1000,14 @@ export async function handleMessage(
             const newTally = { pgm: mixerInput, pvw: tally.pgm };
             setTally(productionId, newTally);
             await persistMixerMutation(productionId, 'MACRO_EXEC:TRANSITION', (d) => ({ ...d, tally: newTally }));
-            broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: action.transitionType, durationMs: action.durationMs });
+            broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId), transitionType: action.transitionType, durationMs: action.durationMs });
             await stromTransition(currentDoc, tally.pgm, mixerInput, toStromTransition(action.transitionType ?? 'cut'), action.durationMs);
           } else if (action.type === 'TAKE') {
             const tally = getTally(productionId);
             const newTally = { pgm: tally.pvw, pvw: tally.pgm };
             setTally(productionId, newTally);
             await persistMixerMutation(productionId, 'MACRO_EXEC:TAKE', (d) => ({ ...d, tally: newTally }));
-            broadcast(productionId, { type: 'TALLY', ...newTally });
+            broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
             await stromTransition(currentDoc, tally.pgm, tally.pvw, 'cut');
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
             await persistMixerMutation(productionId, 'MACRO_EXEC:GRAPHIC_ON', (d) => ({
@@ -1564,7 +1586,9 @@ const controllerWs: FastifyPluginAsync = async (fastify) => {
           setTally(id, tally);
         }
       }
-      socket.send(JSON.stringify({ type: 'TALLY', ...tally }));
+      // The connect case: without pgmBg a late joiner cannot tell an empty
+      // program from a PiP over a real input, and nothing re-broadcasts it.
+      socket.send(JSON.stringify({ type: 'TALLY', ...tally, pgmBg: pgmBgOf(id) }));
 
       const cachedAlpha = overlayAlphaByProduction.get(id);
       if (cachedAlpha !== undefined) {

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -407,13 +407,10 @@ const pgmBgByProduction = new Map<string, string | null>()
 /**
  * The real input sitting behind a PiP that is on program, or null.
  *
- * While a PiP occupies PGM, `tally.pgm` is null and the background input is
- * tracked only in `pgmBgByProduction`, which is never otherwise sent to a
- * subscriber. Without it a client cannot tell "nothing on program" from "a PiP
- * over input 3" — including on connect, where the distinction is otherwise
- * unrecoverable, because the value is never re-broadcast.
- *
- * Read-only: nothing here changes mixer state or what airs.
+ * While a PiP occupies PGM, `tally.pgm` is null, so without this a subscriber
+ * cannot tell "nothing on program" from "a PiP over input 3". The value is
+ * never re-broadcast on its own, so a client attaching mid-show has no other
+ * way to recover it.
  */
 const pgmBgOf = (productionId: string): string | null =>
   pgmBgByProduction.get(productionId) ?? null
@@ -739,14 +736,12 @@ export async function handleMessage(
       // scope, because `pgmBgByProduction` still holds the previous state here.
       const pvwBeforePip = pvwBeforePipByProduction.get(productionId) ?? null;
       // Falls back to the outgoing PGM input, matching the `to_input` the Strom
-      // transition below computes: when no PVW source was displaced, the mixer
-      // composites the PiP over whatever was already on program. Reporting null
-      // here would say "no background" while the mixer had one.
+      // transition below computes: with no PVW source displaced, the mixer
+      // composites the PiP over whatever was already on program.
       const newPgmBg = newPgmPip !== null ? (pvwBeforePip ?? tally.pgm) : null;
-      // Recorded before the Strom calls, not inside them. A client connecting
-      // later reads this map, so leaving it unset until Strom succeeds meant a
-      // reconnect during a PiP saw `pgm: null` with no background — the one case
-      // that cannot be reconstructed, and the reason this field exists.
+      // Set here rather than in the Strom block below: the connect handler
+      // reads this map, and it must hold the background the take just
+      // broadcast even when Strom is unconfigured or its call throws.
       if (newPgmPip !== null) pgmBgByProduction.set(productionId, newPgmBg);
       broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: newPgmBg });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: newPgmPip, pvwPip: newPvwPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
@@ -770,7 +765,6 @@ export async function handleMessage(
               transition_type: takeTransition,
               ...(msg.durationMs !== undefined ? { duration_ms: msg.durationMs } : {}),
             });
-            // `pgmBgByProduction` was already set above, before these calls.
             pvwBeforePipByProduction.delete(productionId);
           } catch (err) {
             console.warn('[controller] Strom PiP transition error:', err);
@@ -1588,8 +1582,6 @@ const controllerWs: FastifyPluginAsync = async (fastify) => {
           setTally(id, tally);
         }
       }
-      // The connect case: without pgmBg a late joiner cannot tell an empty
-      // program from a PiP over a real input, and nothing re-broadcasts it.
       socket.send(JSON.stringify({ type: 'TALLY', ...tally, pgmBg: pgmBgOf(id) }));
 
       const cachedAlpha = overlayAlphaByProduction.get(id);

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -735,15 +735,20 @@ export async function handleMessage(
       pgmPipByProduction.set(productionId, newPgmPip);
       pvwPipByProduction.set(productionId, newPvwPip);
       await persistMixerMutation(productionId, 'TAKE', (d) => ({ ...d, tally: newTally }));
-      // `pgmBgByProduction` is not updated until the Strom block below, and only
-      // if those calls succeed, so derive the new background from what is in
-      // scope rather than reading a map that is still holding the old state.
-      //
+      // The background behind the PiP after this take. Derived from what is in
+      // scope, because `pgmBgByProduction` still holds the previous state here.
+      const pvwBeforePip = pvwBeforePipByProduction.get(productionId) ?? null;
       // Falls back to the outgoing PGM input, matching the `to_input` the Strom
       // transition below computes: when no PVW source was displaced, the mixer
       // composites the PiP over whatever was already on program. Reporting null
       // here would say "no background" while the mixer had one.
-      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: newPgmPip !== null ? (pvwBeforePipByProduction.get(productionId) ?? tally.pgm) : null });
+      const newPgmBg = newPgmPip !== null ? (pvwBeforePip ?? tally.pgm) : null;
+      // Recorded before the Strom calls, not inside them. A client connecting
+      // later reads this map, so leaving it unset until Strom succeeds meant a
+      // reconnect during a PiP saw `pgm: null` with no background — the one case
+      // that cannot be reconstructed, and the reason this field exists.
+      if (newPgmPip !== null) pgmBgByProduction.set(productionId, newPgmBg);
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: newPgmBg });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: newPgmPip, pvwPip: newPvwPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
       const takeTransition = toStromTransition(msg.transitionType ?? 'cut');
       if (curPvwPip !== null) {
@@ -757,7 +762,6 @@ export async function handleMessage(
           try {
             const strom = await makeStromClient();
             const fromInputIndex = tally.pgm ? (padToIndex(tally.pgm) ?? 0) : 0;
-            const pvwBeforePip = pvwBeforePipByProduction.get(productionId) ?? null;
             const toInputIndex = pvwBeforePip !== null ? (padToIndex(pvwBeforePip) ?? fromInputIndex) : fromInputIndex;
             await strom.mixer.selectPreview(doc.stromFlowId, doc.mixerBlockId, { source: { pip: curPvwPip } });
             await strom.mixer.transition(doc.stromFlowId, doc.mixerBlockId, {
@@ -766,9 +770,7 @@ export async function handleMessage(
               transition_type: takeTransition,
               ...(msg.durationMs !== undefined ? { duration_ms: msg.durationMs } : {}),
             });
-            // Track the new Strom PGM background (pvwBeforePip) so CUT/TRANSITION
-            // can pass the correct from_input while the PiP remains on PGM.
-            pgmBgByProduction.set(productionId, pvwBeforePip);
+            // `pgmBgByProduction` was already set above, before these calls.
             pvwBeforePipByProduction.delete(productionId);
           } catch (err) {
             console.warn('[controller] Strom PiP transition error:', err);


### PR DESCRIPTION
_Generated by Claude Code with human review._

While a PiP occupies PGM, `tally.pgm` is null and the real background input lives only in the module-level `pgmBgByProduction` map, which no `broadcast(...)` ever reads. Any client recording tally therefore stores "no source on program" for the whole duration of every PiP — wrong in the worst direction, because it looks like data rather than absence.

`PIP_STATE` does not close the gap: `pgmPip` is a slot index and `pips[i].bg` is the PiP configuration's own background, neither of which is the mixer input the PiP is composited over. Connect is the case no replay reconstructs — a client attaching mid-show gets `TALLY {pgm: null, …}` and `PIP_STATE {pgmPip: N}`, with nothing carrying the background.

## What changed

`feat(ws): broadcast the PGM background input behind a PiP` adds `pgmBg` to all nine places the server emits `TALLY` — eight `broadcast()` calls plus the connect-time `socket.send` — so a consumer can distinguish three states rather than two:

| `pgmPip` | `pgmBg` | Meaning |
| --- | --- | --- |
| null | null | No PiP on program |
| set | set | PiP over a known input |
| set | null | PiP over nothing (empty PGM and empty PVW at take time) |

It rides on `TALLY` rather than `PIP_STATE` because `pgm: null` is the ambiguous field and it lives on `TALLY`, while `PIP_STATE` is emitted conditionally — TRANSITION only when a PiP was on program, CUT only when a PiP was on program *or* in preview, the three macro paths never — so a field carried there would go stale across exactly those transitions. That commit is additive: each payload gains one field, nothing else changes value, and no mixer state is touched.

On the take that moves a PiP to PGM the value falls back to the outgoing PGM input when no PVW source was displaced:

```js
const newPgmBg = newPgmPip !== null ? (pvwBeforePip ?? tally.pgm) : null;
```

matching the `to_input` the Strom transition computes a few lines below. `pvwBeforePip` is null whenever a PiP is selected into an empty preview, ordinary at the top of a show; without the fallback the broadcast reports no background while the mixer composites over the previous program input.

`fix(ws): record the PGM background before the Strom calls` moves the `pgmBgByProduction` write above the broadcast. The TAKE handler derives the broadcast value from `pvwBeforePipByProduction` but wrote the map inside `if (doc.stromFlowId && doc.mixerBlockId)`, after the Strom calls succeed, and the connect handler reads that map. With Strom unconfigured, or if `strom.mixer.transition` throws into its `catch`, a client attaching during a PiP is sent `pgmBg: null` — precisely the case the field exists for.

`pvwBeforePipByProduction` is now read once and reused for both the broadcast value and the transition's `to_input`. The two reads sat either side of `await makeStromClient()`, so a CUT or TRANSITION interleaving at that await could change the map between them. The `to_input` expression is unchanged; only its operand is now the captured local.

The remaining two commits document `pgmBg` in `docs/controller-websocket.md` and tighten the comments added above.

## Decision needed

When the take displaced no PVW source, the map now holds the outgoing PGM input rather than `null`, so a later CUT while the PiP is still on PGM passes that input as `from_input` instead of letting it collapse to `toIndex` at `controller.ts:254`. That is a real change to a live mixer parameter, not just a reporting field.

I read it as a fix: `pgmPipByProduction` is already set unconditionally above, so the handler is committed to the take regardless of what Strom did, and `null` was never more accurate than the real input. @birme read it the same way on review. Happy to drop that commit and accept the connect-time divergence instead if you would rather the map keep its current value.

## A gap this does not close

The three macro paths (`controller.ts:991`, `:1000`, `:1007`) update `tally` but never touch `pgmPipByProduction` or `pgmBgByProduction` and never emit `PIP_STATE`, so after a macro CUT over a PiP the new field reports the old background alongside a real `pgm` — a fourth combination the table does not cover.

That is pre-existing rather than introduced here, and larger than the reporting symptom: those paths also never restore the PiP into preview the way the interactive CUT does, which is what actually reaches the mixer. #179 and #180 fix it. The table should not be read as exhaustive until they land.

## Testing

- `npx vitest run` — 120/120 passing, including the "pgmBg with no Strom flow configured" case that ships with commit 2. Reverting commit 2 makes it fail, reporting `pgmBg: null` where the take broadcast `video_in_1`.
- `npx tsc --noEmit` clean.
- Verified against a live production driven through ordinary cuts and a PiP take: `pgmBg` appears in the `TALLY` broadcast and matches what was on air.

Not exercised at runtime: the `pvwBeforePip ?? tally.pgm` fallback. It is derived from the adjacent `to_input` computation rather than observed, so the reasoning is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
