### PR TITLE
fix(ws): record the PGM background before the Strom calls, not inside them

### DIFF
--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -312,6 +312,20 @@ const pvwBeforePipByProduction = new Map<string, string | null>()
  */
 const pgmBgByProduction = new Map<string, string | null>()
 
+/**
+ * The real input sitting behind a PiP that is on program, or null.
+ *
+ * While a PiP occupies PGM, `tally.pgm` is null and the background input is
+ * tracked only in `pgmBgByProduction`, which is never otherwise sent to a
+ * subscriber. Without it a client cannot tell "nothing on program" from "a PiP
+ * over input 3" — including on connect, where the distinction is otherwise
+ * unrecoverable, because the value is never re-broadcast.
+ *
+ * Read-only: nothing here changes mixer state or what airs.
+ */
+const pgmBgOf = (productionId: string): string | null =>
+  pgmBgByProduction.get(productionId) ?? null
+
 
 /** Wipe all per-production audio state. Called when the pipeline changes or production deactivates. */
 export function clearAudioState(productionId: string): void {
@@ -512,7 +526,7 @@ async function handleMessage(
       }
       const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
       await db.insert(updated).catch((err: any) => { if (err?.statusCode !== 409) throw err });
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
       await stromTransition(doc, fromPadCut, msg.mixerInput, 'cut');
       if (curPgmPipCut !== null && doc.stromFlowId && doc.mixerBlockId) {
         try {
@@ -544,7 +558,7 @@ async function handleMessage(
       }
       const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
       await db.insert(updated).catch((err: any) => { if (err?.statusCode !== 409) throw err });
-      broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: msg.transitionType, durationMs: msg.durationMs });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId), transitionType: msg.transitionType, durationMs: msg.durationMs });
       await stromTransition(doc, fromPadTrans, msg.mixerInput, toStromTransition(msg.transitionType), msg.durationMs);
       if (curPgmPipTrans !== null && doc.stromFlowId && doc.mixerBlockId) {
         try {
@@ -582,7 +596,15 @@ async function handleMessage(
       pvwPipByProduction.set(productionId, newPvwPip);
       const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
       await db.insert(updated).catch((err: any) => { if (err?.statusCode !== 409) throw err });
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      // `pgmBgByProduction` is not updated until the Strom block below, and only
+      // if those calls succeed, so derive the new background from what is in
+      // scope rather than reading a map that is still holding the old state.
+      //
+      // Falls back to the outgoing PGM input, matching the `to_input` the Strom
+      // transition below computes: when no PVW source was displaced, the mixer
+      // composites the PiP over whatever was already on program. Reporting null
+      // here would say "no background" while the mixer had one.
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: newPgmPip !== null ? (pvwBeforePipByProduction.get(productionId) ?? tally.pgm) : null });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: newPgmPip, pvwPip: newPvwPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
       const takeTransition = toStromTransition(msg.transitionType ?? 'cut');
       if (curPvwPip !== null) {
@@ -657,7 +679,7 @@ async function handleMessage(
       setTally(productionId, newTally);
       const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
       await db.insert(updated);
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: pgmPipByProduction.get(productionId) ?? null, pvwPip: null, pips: pipConfigsByProduction.get(productionId) ?? [] });
       if (doc.stromFlowId && doc.mixerBlockId) {
         const inputIndex = padToIndex(msg.mixerInput);
@@ -682,7 +704,7 @@ async function handleMessage(
       const newTally = { pgm: tally.pgm, pvw: null };
       setTally(productionId, newTally);
       await db.insert({ ...doc, tally: newTally, updatedAt: new Date().toISOString() }).catch((err: any) => { if (err?.statusCode !== 409) throw err });
-      broadcast(productionId, { type: 'TALLY', ...newTally });
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: pgmPipByProduction.get(productionId) ?? null, pvwPip: msg.pip, pips: pipConfigsByProduction.get(productionId) ?? [] });
       if (doc.stromFlowId && doc.mixerBlockId) {
         try {
@@ -815,7 +837,7 @@ async function handleMessage(
             setTally(productionId, newTally);
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
-            broadcast(productionId, { type: 'TALLY', ...newTally });
+            broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
             await stromTransition(currentDoc, tally.pgm, mixerInput, 'cut');
           } else if (action.type === 'TRANSITION' && action.sourceId) {
             const mixerInput = resolveInput(action.sourceId);
@@ -825,7 +847,7 @@ async function handleMessage(
             setTally(productionId, newTally);
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
-            broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: action.transitionType, durationMs: action.durationMs });
+            broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId), transitionType: action.transitionType, durationMs: action.durationMs });
             await stromTransition(currentDoc, tally.pgm, mixerInput, toStromTransition(action.transitionType ?? 'cut'), action.durationMs);
           } else if (action.type === 'TAKE') {
             const tally = getTally(productionId);
@@ -833,7 +855,7 @@ async function handleMessage(
             setTally(productionId, newTally);
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
-            broadcast(productionId, { type: 'TALLY', ...newTally });
+            broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: pgmBgOf(productionId) });
             await stromTransition(currentDoc, tally.pgm, tally.pvw, 'cut');
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
             const updated: ProductionDoc = {
@@ -1416,7 +1438,9 @@ const controllerWs: FastifyPluginAsync = async (fastify) => {
           setTally(id, tally);
         }
       }
-      socket.send(JSON.stringify({ type: 'TALLY', ...tally }));
+      // The connect case: without pgmBg a late joiner cannot tell an empty
+      // program from a PiP over a real input, and nothing re-broadcasts it.
+      socket.send(JSON.stringify({ type: 'TALLY', ...tally, pgmBg: pgmBgOf(id) }));
 
       const cachedAlpha = overlayAlphaByProduction.get(id);
       if (cachedAlpha !== undefined) {

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -596,15 +596,20 @@ async function handleMessage(
       pvwPipByProduction.set(productionId, newPvwPip);
       const updated: ProductionDoc = { ...doc, tally: newTally, updatedAt: new Date().toISOString() };
       await db.insert(updated).catch((err: any) => { if (err?.statusCode !== 409) throw err });
-      // `pgmBgByProduction` is not updated until the Strom block below, and only
-      // if those calls succeed, so derive the new background from what is in
-      // scope rather than reading a map that is still holding the old state.
-      //
+      // The background behind the PiP after this take. Derived from what is in
+      // scope, because `pgmBgByProduction` still holds the previous state here.
+      const pvwBeforePip = pvwBeforePipByProduction.get(productionId) ?? null;
       // Falls back to the outgoing PGM input, matching the `to_input` the Strom
       // transition below computes: when no PVW source was displaced, the mixer
       // composites the PiP over whatever was already on program. Reporting null
       // here would say "no background" while the mixer had one.
-      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: newPgmPip !== null ? (pvwBeforePipByProduction.get(productionId) ?? tally.pgm) : null });
+      const newPgmBg = newPgmPip !== null ? (pvwBeforePip ?? tally.pgm) : null;
+      // Recorded before the Strom calls, not inside them. A client connecting
+      // later reads this map, so leaving it unset until Strom succeeds meant a
+      // reconnect during a PiP saw `pgm: null` with no background — the one case
+      // that cannot be reconstructed, and the reason this field exists.
+      if (newPgmPip !== null) pgmBgByProduction.set(productionId, newPgmBg);
+      broadcast(productionId, { type: 'TALLY', ...newTally, pgmBg: newPgmBg });
       broadcast(productionId, { type: 'PIP_STATE', pgmPip: newPgmPip, pvwPip: newPvwPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
       const takeTransition = toStromTransition(msg.transitionType ?? 'cut');
       if (curPvwPip !== null) {
@@ -618,7 +623,6 @@ async function handleMessage(
           try {
             const strom = await makeStromClient();
             const fromInputIndex = tally.pgm ? (padToIndex(tally.pgm) ?? 0) : 0;
-            const pvwBeforePip = pvwBeforePipByProduction.get(productionId) ?? null;
             const toInputIndex = pvwBeforePip !== null ? (padToIndex(pvwBeforePip) ?? fromInputIndex) : fromInputIndex;
             await strom.mixer.selectPreview(doc.stromFlowId, doc.mixerBlockId, { source: { pip: curPvwPip } });
             await strom.mixer.transition(doc.stromFlowId, doc.mixerBlockId, {
@@ -627,9 +631,7 @@ async function handleMessage(
               transition_type: takeTransition,
               ...(msg.durationMs !== undefined ? { duration_ms: msg.durationMs } : {}),
             });
-            // Track the new Strom PGM background (pvwBeforePip) so CUT/TRANSITION
-            // can pass the correct from_input while the PiP remains on PGM.
-            pgmBgByProduction.set(productionId, pvwBeforePip);
+            // `pgmBgByProduction` was already set above, before these calls.
             pvwBeforePipByProduction.delete(productionId);
           } catch (err) {
             console.warn('[controller] Strom PiP transition error:', err);


### PR DESCRIPTION
**Stacked on #156.** That PR adds the `pgmBg` field; this one makes it correct on connect. The diff below contains both commits until #156 merges — only the second, `fix(ws): record the PGM background before the Strom calls`, belongs to this PR.

## Problem

#156 adds `pgmBg` to every `TALLY` broadcast. Every live broadcast is correct. The connect-time sync — the case the field exists for — is not:

```
TAKE broadcast:  {"type":"TALLY","pgm":null,...,"pgmBg":"video_in_1"}
on connect:      {"type":"TALLY","pgm":null,...,"pgmBg":null}
                 {"type":"PIP_STATE","pgmPip":0,...}
```

`pgmPip` says a PiP is on program while `pgmBg` says there is no background. The server contradicts the tally it broadcast moments earlier.

The TAKE handler derives the broadcast value from `pvwBeforePipByProduction`, but only writes `pgmBgByProduction` inside `if (doc.stromFlowId && doc.mixerBlockId)`, after those calls succeed. The connect handler reads that map. So with Strom unconfigured — how most people will run a dev instance — or if `strom.mixer.transition` throws into its `catch`, a client attaching during a PiP is sent `pgmBg: null`.

That is precisely the case a subscriber cannot reconstruct, because the value is never re-broadcast, which was the entire justification for the field.

## Why the old placement was not a bug

It was correct for the map's original job, and its comment said so — track the background *"so CUT/TRANSITION can pass the correct `from_input`"*. If Strom never took the transition, there is no Strom-side background worth remembering for the next `from_input`.

#156 gives the map a second job: it is now also what connecting clients are told. The old placement does not satisfy the new one. This PR moves the assignment above the broadcast, derived from the same in-scope value, so the map and the wire cannot disagree.

## Risk

**`pvwBeforePipByProduction` is now read once and reused** for both the broadcast value and the transition's `to_input`, rather than read a second time inside the Strom block. The two reads were separated by `await makeStromClient()`, so a CUT or TRANSITION interleaving at that await could change the map between them and let the reported background disagree with the input the mixer actually cut to — the same class of divergence this PR closes.

The `to_input` expression itself is unchanged; only its operand is now the captured local, which holds the same value in the single-client case.

**One behavioural change, disclosed deliberately.** The value the map ends up holding differs in a single case: when the take displaced no PVW source, it now holds the outgoing PGM input rather than `null` — matching what the mixer actually composites over, and what the broadcast reports. A later CUT while the PiP is still on PGM therefore passes that input as `from_input` instead of letting it collapse to `to_index` at `controller.ts:162`.

I believe that is a fix rather than a regression: `pgmPipByProduction` is already set unconditionally above, so the handler is committed to the take having happened regardless of what Strom did, and `null` there was never more accurate than the real input. But it is a change on a live transition path, and it is the reason this is a separate PR rather than folded into #156 — happy to drop it if you would rather the map keep its current value and accept the divergence.

## Testing

- Verified against a live production: before this change the connect-time tally reported `pgmBg: null` during a PiP; after it reports the background input.
- `npx tsc --noEmit` clean.

