### PR TITLE
fix(server): guard /ws/ WebSocket paths with API key auth (#101)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -112,7 +112,10 @@ export async function buildServer() {
     fastify.addHook('onRequest', async (req, reply) => {
       const path = req.url.split('?')[0]!;
       if (AUTH_EXEMPT_PATHS.has(path)) return;
-      if (!req.url.startsWith('/api/v1')) return;
+      // Guard both the REST API and the WebSocket controller. The /ws/ prefix
+      // must be listed explicitly: without it, /ws/productions/:id/controller
+      // bypasses auth entirely and accepts live production commands unauthenticated.
+      if (!req.url.startsWith('/api/v1') && !req.url.startsWith('/ws/')) return;
 
       const authHeader = req.headers['authorization'];
       const keyFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;


### PR DESCRIPTION
## Summary
- Fixes **#101** ([SECURITY][HIGH] — Broken Access Control): the WebSocket controller at `/ws/productions/:id/controller` bypassed the API key auth guard because the `onRequest` hook returned early for any URL not starting with `/api/v1`.
- Any unauthenticated client could connect and send `CUT`, `TAKE`, `AUDIO_SET`, `DSK_TOGGLE`, etc. — full live production control — even with `API_KEY` configured.

## Changes
- `src/server.ts`: the auth hook now also guards the `/ws/` prefix. The existing `?key=` query-param path already carries the key on the WS upgrade (the browser WebSocket API can't set custom headers), so authenticated clients are unaffected.

## Test Plan
- [x] `pnpm typecheck` passes
- [ ] Manual: with `API_KEY=secret`, connect to `ws://host/ws/productions/<id>/controller` with no key → expect rejection; with `?key=secret` → expect accept.

## Checklist
- [x] Code-quality checks passed
- [x] No hardcoded SRT ports
- [ ] GStreamer pipelines have watchdogs (n/a)
- [ ] EFP sequence validation present (n/a)
- [x] docs/repo-patterns.md updated if non-obvious issue encountered (n/a — straightforward guard extension)

🤖 Generated with Claude Code