### PR TITLE
fix(server): CRP same-origin for JSON API (#150)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,10 @@ export async function buildServer() {
     contentSecurityPolicy: {
       directives: { defaultSrc: ["'none'"], connectSrc: ["'self'"] },
     },
-    crossOriginResourcePolicy: { policy: 'cross-origin' },
+    // same-origin: this is a private JSON API, not a public CDN. cross-origin
+    // reads are already selectively permitted via CORS preflight; a global
+    // cross-origin CRP would additionally expose responses to no-cors fetches.
+    crossOriginResourcePolicy: { policy: 'same-origin' },
   });
 
   // Rate limiting — 200 requests per minute per IP on API routes


### PR DESCRIPTION
## Summary
- Fixes **#150** ([SECURITY][LOW] — A05 Security Misconfiguration): Helmet set `Cross-Origin-Resource-Policy: cross-origin` globally, which is over-permissive for a private JSON API and can undermine CORS isolation in edge cases (no-cors fetch, range requests, speculative loading).

## Changes
- `src/server.ts`: `crossOriginResourcePolicy` changed from `cross-origin` to `same-origin`. CORS continues to selectively permit configured origins via preflight; no configured integration reads API responses cross-origin in `no-cors` mode.

## Test Plan
- [x] `pnpm typecheck` passes
- [ ] Manual: inspect an API response — header is now `Cross-Origin-Resource-Policy: same-origin`.

## Checklist
- [x] Code-quality checks passed
- [x] No hardcoded SRT ports
- [ ] GStreamer pipelines have watchdogs (n/a)
- [ ] EFP sequence validation present (n/a)
- [x] docs updated if needed (n/a)

🤖 Generated with Claude Code