### PR TITLE
fix(db): assert doc type on cross-collection reads (#149)

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -5,8 +5,40 @@ import type { ProductionDoc, SourceDoc, ProductionConfigDoc, GraphicDoc, OutputD
 
 let db: Nano.DocumentScope<ProductionDoc>;
 
+// All document types share one physical CouchDB database and one nano handle,
+// which is re-typed per collection via `as unknown as ...`. There is no
+// database-level isolation, so a wrong-collection read (e.g. fetching a
+// `src-` doc through the productions handle) would otherwise return a
+// mismatched document silently. `withTypeGuard` wraps `.get()` to assert the
+// returned document's discriminator matches the collection it was fetched
+// from. It only throws on a genuine cross-type mismatch — documents with no
+// `type` field (legacy) are tolerated so existing data keeps working.
+function withTypeGuard<T extends { type?: string }>(
+  scope: Nano.DocumentScope<T>,
+  expectedType: T extends { type: infer U } ? U : string,
+): Nano.DocumentScope<T> {
+  const boundGet = scope.get.bind(scope) as (...args: unknown[]) => Promise<T>;
+  return new Proxy(scope, {
+    get(target, prop, receiver) {
+      if (prop === 'get') {
+        return async (...args: unknown[]): Promise<T> => {
+          const doc = await boundGet(...args);
+          const actualType = (doc as { type?: string }).type;
+          if (actualType !== undefined && actualType !== expectedType) {
+            throw new Error(
+              `Document type mismatch: expected '${String(expectedType)}' but read '${actualType}' for id '${String(args[0])}'`,
+            );
+          }
+          return doc;
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
 export function getDb(): Nano.DocumentScope<ProductionDoc> {
-  return db;
+  return withTypeGuard(db, 'production');
 }
 
 export function isDbConnected(): boolean {
@@ -14,19 +46,19 @@ export function isDbConnected(): boolean {
 }
 
 export function getSourcesDb(): Nano.DocumentScope<SourceDoc> {
-  return db as unknown as Nano.DocumentScope<SourceDoc>;
+  return withTypeGuard(db as unknown as Nano.DocumentScope<SourceDoc>, 'source');
 }
 
 export function getConfigsDb(): Nano.DocumentScope<ProductionConfigDoc> {
-  return db as unknown as Nano.DocumentScope<ProductionConfigDoc>;
+  return withTypeGuard(db as unknown as Nano.DocumentScope<ProductionConfigDoc>, 'production-config');
 }
 
 export function getGraphicsDb(): Nano.DocumentScope<GraphicDoc> {
-  return db as unknown as Nano.DocumentScope<GraphicDoc>;
+  return withTypeGuard(db as unknown as Nano.DocumentScope<GraphicDoc>, 'graphic');
 }
 
 export function getOutputsDb(): Nano.DocumentScope<OutputDoc> {
-  return db as unknown as Nano.DocumentScope<OutputDoc>;
+  return withTypeGuard(db as unknown as Nano.DocumentScope<OutputDoc>, 'output');
 }
 
 const DB_NAME = 'open-live';


### PR DESCRIPTION
## Summary
- Fixes **#149** ([SECURITY][LOW] — A04 Insecure Design): all document types share one CouchDB database and one nano handle re-typed per collection via `as unknown as Nano.DocumentScope<T>`. A code path reading the wrong collection (e.g. `getDb().get('src-<uuid>')`) silently returned a mismatched document — the `_id` prefix conventions were the only guard.

## Changes
- `src/db/index.ts`: add `withTypeGuard()` wrapping each collection handle's `.get()`. After a fetch it asserts the returned document's `type` discriminator matches the collection it was requested from, throwing on a genuine cross-type mismatch. This is the short-term mitigation the issue proposes; the long-term DB-per-collection split remains a separate future item.

## Design notes
- **Non-breaking:** documents with no `type` field (legacy) are tolerated — only a present-and-mismatched `type` throws.
- **No type regression:** the wrapper is a `Proxy` returning the same `DocumentScope<T>` type, so call-site types are unchanged; only runtime behaviour is added.
- Centralized in `db/index.ts` rather than touching all 42 `.get()` call sites.

## Test Plan
- [x] `pnpm typecheck` passes
- [x] `vitest run`: no new failures vs baseline `main` (both are 27 failed/1 passed — the suite requires a live CouchDB/Strom not present in CI; this change introduces none).
- [ ] Manual: reading a `src-` id through `getDb()` (productions handle) now throws a clear type-mismatch error instead of returning a `SourceDoc`.

## Checklist
- [x] Code-quality checks passed
- [x] No hardcoded SRT ports
- [ ] GStreamer pipelines have watchdogs (n/a)
- [ ] EFP sequence validation present (n/a)
- [x] docs updated if needed (n/a)

🤖 Generated with Claude Code