### PR TITLE
fix(sources): add cross-field superRefine to SourcePatch schema

### DIFF
--- a/src/routes/sources.ts
+++ b/src/routes/sources.ts
@@ -38,6 +38,28 @@ const SourcePatch = z.object({
   status: z.enum(['active', 'inactive']).optional(),
   liveCamera: z.boolean().optional(),
   latency: z.number().int().min(20).max(8000).optional(),
+}).superRefine((data, ctx) => {
+  // Cross-field validation only applies when both address and streamType are present in
+  // the same patch body. The combined-with-existing-document case is validated procedurally
+  // in the route handler, which has access to the stored source document.
+  if (data.address === undefined || data.streamType === undefined) {
+    return;
+  }
+  if (data.streamType === 'html') {
+    // html sources use a browser URL — validate for SSRF (file://, javascript:, private IPs, etc.)
+    try {
+      graphicUrl(data.address);
+    } catch (err) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['address'], message: err instanceof Error ? err.message : 'Invalid HTML source URL' });
+    }
+  } else if (data.streamType === 'srt' || data.streamType === 'efp') {
+    // SRT/EFP sources: must be a valid srt:// URI pointing to a non-private host
+    try {
+      srtUrl(data.address);
+    } catch (err) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['address'], message: err instanceof Error ? err.message : 'Invalid SRT source address' });
+    }
+  }
 });
 
 /** Masks passphrase values in SRT URIs so credentials are never returned to clients. */


### PR DESCRIPTION
## Summary
- Add a `.superRefine()` to the `SourcePatch` zod schema so that when **both** `address` and `streamType` are supplied in the same PATCH body, address-format validation runs at the schema layer.
- Provides defence-in-depth for security issue #167 (previously cross-field validation for PATCH was only procedural).

## Changes
- `src/routes/sources.ts`: `SourcePatch.superRefine()` mirrors `SourceInput.superRefine()` — reuses the existing `graphicUrl()` validator for `html` sources and `srtUrl()` for `srt`/`efp` sources. It early-returns when either `address` or `streamType` is absent, so the existing procedural handler check (which validates the effective address/streamType against the stored document) is untouched and still covers the combined-with-existing-document case.

## Test Plan
- [x] Unit tests pass (pre-existing failures in `activation.test.ts`/`macros.test.ts` are unrelated — they require a live external "Strom" service; `url-validation` and other suites unaffected)
- [ ] Integration tests pass
- [x] Manual verification: `npx tsc --noEmit` passes clean

## Checklist
- [x] Code-quality checks passed
- [x] No hardcoded SRT ports
- [x] GStreamer pipelines have watchdogs (if applicable) — N/A
- [x] EFP sequence validation present (if applicable) — N/A
- [ ] docs/repo-patterns.md updated if non-obvious issue encountered

Closes #167

🤖 Generated with Claude Code