### PR TITLE
fix(productions): log only the message on SAT exchange failure

### DIFF
--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -281,7 +281,7 @@ async function runActivationFlow(
 
     // Best-effort flow cleanup
     if (stromFlowId) {
-      const stromToken = await getStromToken(config.stromToken).catch((err) => { log.error({ err }, "SAT exchange failed — proceeding without auth"); return undefined; });
+      const stromToken = await getStromToken(config.stromToken).catch((err) => { log.error({ errMsg: err instanceof Error ? err.message : String(err) }, "SAT exchange failed — proceeding without auth"); return undefined; });
       const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
       await deactivateStromFlow(stromFlowId, strom).catch(() => undefined);
     }
@@ -558,7 +558,7 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
       broadcast(doc._id, { type: 'GRP_STATE_RESET' });
       broadcast(doc._id, { type: 'PRODUCTION_DEACTIVATED' });
       if (doc.stromFlowId) {
-        const stromToken = await getStromToken(config.stromToken).catch((err) => { req.log.error({ err }, "SAT exchange failed — proceeding without auth"); return undefined; });
+        const stromToken = await getStromToken(config.stromToken).catch((err) => { req.log.error({ errMsg: err instanceof Error ? err.message : String(err) }, "SAT exchange failed — proceeding without auth"); return undefined; });
         const strom = new StromClient({ baseUrl: config.stromUrl, token: stromToken });
         await deactivateStromFlow(doc.stromFlowId, strom);
       }


### PR DESCRIPTION
## Summary
- Log only err.message (not the full error object) on SAT exchange failure to avoid leaking auth-adjacent data.

## Changes
- src/routes/productions.ts: replace full-object error logging with message-only at each SAT-exchange failure site.

Closes #102

## Test Plan
- [ ] tsc --noEmit clean
- [ ] Lint/build pass
- [ ] Manual: forcing a SAT exchange failure logs only the message

## Checklist
- [x] Code-quality checks passed
- [x] No hardcoded secrets

🤖 Generated with Claude Code