### PR TITLE
fix(ws): take a preview PiP to program from a macro

### DIFF
--- a/src/__tests__/ws-macro-pip.test.ts
+++ b/src/__tests__/ws-macro-pip.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Harness and tests for PiP handling in macro-executed CUT, TRANSITION, and
+ * TAKE actions.
+ *
+ * The real `StromClient` runs against a throwaway HTTP server that records
+ * every request, so the assertions cover the URL, the verb, and the body the
+ * server actually puts on the wire — not a hand-written stand-in that could
+ * drift from the client without anything failing. CouchDB is mocked via
+ * vi.mock('../db/index.js'), as elsewhere in this suite.
+ *
+ * PiP state is established through real inbound messages (SELECT_PVW_PIP,
+ * TAKE) rather than by reaching into the module-level maps, so each case
+ * exercises the same state machine the server runs in production.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+// ---------------------------------------------------------------------------
+// Mock the CouchDB layer
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn().mockResolvedValue({ ok: true });
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../routes/productions.js', () => ({
+  updateProductionDoc: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture broadcasts, keep the real tally state machine
+// ---------------------------------------------------------------------------
+
+const broadcasts: Array<Record<string, unknown>> = [];
+
+vi.mock('../services/tally.service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/tally.service.js')>();
+  return {
+    ...actual,
+    broadcast: (_id: string, message: unknown) => {
+      broadcasts.push(message as Record<string, unknown>);
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// A throwaway Strom the real StromClient can talk to
+// ---------------------------------------------------------------------------
+
+interface StromRequest {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+const stromRequests: StromRequest[] = [];
+
+const stromServer: Server = createServer((req, res) => {
+  const chunks: Buffer[] = [];
+  req.on('data', (c: Buffer) => chunks.push(c));
+  req.on('end', () => {
+    const raw = Buffer.concat(chunks).toString('utf8');
+    stromRequests.push({
+      method: req.method ?? '',
+      path: req.url ?? '',
+      ...(raw ? { body: JSON.parse(raw) as unknown } : {}),
+    });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ success: true }));
+  });
+});
+
+await new Promise<void>((resolve) => {
+  stromServer.listen(0, '127.0.0.1', () => resolve());
+});
+process.env['STROM_URL'] = `http://127.0.0.1:${(stromServer.address() as AddressInfo).port}`;
+
+afterAll(() => {
+  stromServer.close();
+});
+
+// Imported after STROM_URL is set so config picks up the throwaway server.
+const { handleMessage, clearPipState } = await import('../ws/controller.js');
+const { setTally } = await import('../services/tally.service.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PROD = 'prod-pip-1';
+const PREVIEW = '/api/flows/flow-1/blocks/mixer-1/preview';
+const TRANSITION = '/api/flows/flow-1/blocks/mixer-1/transition';
+
+/** A minimal active ProductionDoc carrying one macro. */
+function makeProductionDoc(actions: Array<Record<string, unknown>>) {
+  return {
+    _id: PROD,
+    _rev: '1-abc',
+    type: 'production',
+    name: 'PiP Test',
+    status: 'active',
+    stromFlowId: 'flow-1',
+    mixerBlockId: 'mixer-1',
+    sources: [
+      { sourceId: 'cam1', mixerInput: 'video_in_0' },
+      { sourceId: 'cam2', mixerInput: 'video_in_1' },
+      { sourceId: 'cam3', mixerInput: 'video_in_2' },
+    ],
+    pipeline: { stromConfig: null, status: 'running' },
+    graphics: [],
+    macros: [{ id: 'macro-1', slot: 0, label: 'M', color: '#ffffff', actions }],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const ws = { send: vi.fn() } as unknown as import('@fastify/websocket').WebSocket;
+
+/** Send one inbound message through the controller. */
+function send(msg: Record<string, unknown>) {
+  return handleMessage(PROD, ws, JSON.stringify(msg), {});
+}
+
+/** Every PIP_STATE broadcast seen so far, in order. */
+function pipStates() {
+  return broadcasts.filter((m) => m.type === 'PIP_STATE');
+}
+
+/** Every TALLY broadcast seen so far, in order. */
+function tallies() {
+  return broadcasts.filter((m) => m.type === 'TALLY');
+}
+
+/** Requests the controller made to Strom, in order. */
+function requestsTo(path: string) {
+  return stromRequests.filter((r) => r.path === path);
+}
+
+/** Forget everything recorded so far — used after arranging PiP state. */
+function resetRecordings() {
+  broadcasts.length = 0;
+  stromRequests.length = 0;
+}
+
+beforeEach(() => {
+  clearPipState(PROD);
+  setTally(PROD, { pgm: 'video_in_0', pvw: 'video_in_1' });
+  resetRecordings();
+  mockGet.mockReset();
+  mockInsert.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// No PiP involved — the pre-existing path must be untouched
+// ---------------------------------------------------------------------------
+
+describe('macro CUT with no PiP anywhere', () => {
+  it('behaves exactly as before: no PIP_STATE, no pip-addressed preview select', async () => {
+    mockGet.mockResolvedValue(makeProductionDoc([{ type: 'CUT', sourceId: 'cam3' }]));
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    expect(pipStates()).toHaveLength(0);
+
+    // Only stromTransition's own preview select, addressed by input not pip.
+    for (const req of requestsTo(PREVIEW)) {
+      expect(req.body).toEqual({ source: { input: 2 } });
+    }
+
+    expect(requestsTo(TRANSITION)[0]?.body).toMatchObject({ from_input: 0, to_input: 2 });
+    expect(tallies()[0]).toMatchObject({ pgm: 'video_in_2', pvw: 'video_in_0' });
+  });
+});

--- a/src/__tests__/ws-macro-pip.test.ts
+++ b/src/__tests__/ws-macro-pip.test.ts
@@ -164,6 +164,61 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
+// Macro CUT / TRANSITION over a PiP that is on program
+// ---------------------------------------------------------------------------
+
+describe('macro CUT with a PiP on program', () => {
+  it('moves the PiP to preview, tells clients, and restores it in Strom', async () => {
+    mockGet.mockResolvedValue(makeProductionDoc([{ type: 'CUT', sourceId: 'cam3' }]));
+
+    // Put PiP 0 on program: select it into preview, then take.
+    await send({ type: 'SELECT_PVW_PIP', pip: 0 });
+    await send({ type: 'TAKE' });
+    resetRecordings();
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    // The PiP leaves program for preview, and every subscriber is told.
+    expect(pipStates()).toHaveLength(1);
+    expect(pipStates()[0]).toMatchObject({ pgmPip: null, pvwPip: 0 });
+
+    // The PiP is put back on Strom's preview bus.
+    expect(requestsTo(PREVIEW)).toContainEqual({
+      method: 'PUT',
+      path: PREVIEW,
+      body: { source: { pip: 0 } },
+    });
+
+    // from_input is the tracked background (video_in_1), not a collapsed to_input.
+    expect(requestsTo(TRANSITION)[0]?.body).toMatchObject({ from_input: 1, to_input: 2 });
+  });
+});
+
+describe('macro TRANSITION with a PiP on program', () => {
+  it('moves the PiP to preview and restores it in Strom', async () => {
+    mockGet.mockResolvedValue(
+      makeProductionDoc([
+        { type: 'TRANSITION', sourceId: 'cam3', transitionType: 'mix', durationMs: 500 },
+      ]),
+    );
+
+    await send({ type: 'SELECT_PVW_PIP', pip: 0 });
+    await send({ type: 'TAKE' });
+    resetRecordings();
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    expect(pipStates()).toHaveLength(1);
+    expect(pipStates()[0]).toMatchObject({ pgmPip: null, pvwPip: 0 });
+    expect(requestsTo(PREVIEW)).toContainEqual({
+      method: 'PUT',
+      path: PREVIEW,
+      body: { source: { pip: 0 } },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // No PiP involved — the pre-existing path must be untouched
 // ---------------------------------------------------------------------------
 

--- a/src/__tests__/ws-macro-pip.test.ts
+++ b/src/__tests__/ws-macro-pip.test.ts
@@ -219,6 +219,35 @@ describe('macro TRANSITION with a PiP on program', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Macro TAKE promoting a PiP that is sitting in preview
+// ---------------------------------------------------------------------------
+
+describe('macro TAKE with a PiP in preview', () => {
+  it('takes the PiP to program instead of reporting an empty bus', async () => {
+    mockGet.mockResolvedValue(makeProductionDoc([{ type: 'TAKE' }]));
+
+    // PiP 1 into preview only — nothing on program yet.
+    await send({ type: 'SELECT_PVW_PIP', pip: 1 });
+    resetRecordings();
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    // The regression: previously stromTransition early-returned on the null
+    // target and Strom was never called at all.
+    expect(requestsTo(TRANSITION)).toHaveLength(1);
+    expect(requestsTo(PREVIEW)).toContainEqual({
+      method: 'PUT',
+      path: PREVIEW,
+      body: { source: { pip: 1 } },
+    });
+
+    // The server records the PiP as being on program.
+    expect(pipStates()).toHaveLength(1);
+    expect(pipStates()[0]).toMatchObject({ pgmPip: 1, pvwPip: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // No PiP involved — the pre-existing path must be untouched
 // ---------------------------------------------------------------------------
 

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -456,7 +456,8 @@ async function applyAudioFollow(
 // Message handler
 // ---------------------------------------------------------------------------
 
-async function handleMessage(
+/** Exported for tests: drives one inbound message against a production. */
+export async function handleMessage(
   productionId: string,
   ws: WebSocket,
   raw: string,

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -879,33 +879,59 @@ export async function handleMessage(
             }
           } else if (action.type === 'TAKE') {
             const tally = getTally(productionId);
+            const curPvwPip = pvwPipByProduction.get(productionId) ?? null;
             const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
-            // tally.pgm is null while a PiP is on PGM, so pass the tracked
-            // background input. Strom takes from its own overlay state and
-            // reads from_input only when that state is missing.
-            const fromPad = (curPgmPip !== null && tally.pgm === null)
-              ? (pgmBgByProduction.get(productionId) ?? null)
-              : tally.pgm;
             const newTally = { pgm: tally.pvw, pvw: tally.pgm };
+            const newPgmPip = curPvwPip;
+            const newPvwPip = curPgmPip;
             setTally(productionId, newTally);
-            if (curPgmPip !== null) {
-              // PiP was on PGM → moves to PVW
-              pgmPipByProduction.set(productionId, null);
-              pvwPipByProduction.set(productionId, curPgmPip);
-              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
-              pgmBgByProduction.delete(productionId);
-              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
-            }
+            pgmPipByProduction.set(productionId, newPgmPip);
+            pvwPipByProduction.set(productionId, newPvwPip);
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
-            await stromTransition(currentDoc, fromPad, tally.pvw, 'cut');
-            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
-              try {
-                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
-              } catch (err) {
-                console.warn('[controller] Strom selectPreview (pip restore after macro take) error:', err);
+            broadcast(productionId, { type: 'PIP_STATE', pgmPip: newPgmPip, pvwPip: newPvwPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            if (curPvwPip !== null) {
+              // PiP is on PVW → moving to PGM
+              if (currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+                try {
+                  const fromInputIndex = tally.pgm ? (padToIndex(tally.pgm) ?? 0) : 0;
+                  const pvwBeforePip = pvwBeforePipByProduction.get(productionId) ?? null;
+                  const toInputIndex = pvwBeforePip !== null ? (padToIndex(pvwBeforePip) ?? fromInputIndex) : fromInputIndex;
+                  await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPvwPip } });
+                  await strom.mixer.transition(currentDoc.stromFlowId, currentDoc.mixerBlockId, {
+                    from_input: fromInputIndex,
+                    to_input: toInputIndex,
+                    transition_type: 'cut',
+                  });
+                  pgmBgByProduction.set(productionId, pvwBeforePip);
+                  pvwBeforePipByProduction.delete(productionId);
+                } catch (err) {
+                  console.warn('[controller] Strom PiP transition error (macro take):', err);
+                }
               }
+            } else if (curPgmPip !== null) {
+              // PiP is on PGM → taking to a real input; PiP moves to PVW
+              const pgmBg = pgmBgByProduction.get(productionId) ?? null;
+              pvwBeforePipByProduction.set(productionId, pgmBg);
+              pgmBgByProduction.delete(productionId);
+              if (currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+                try {
+                  const fromInputIndex = pgmBg ? (padToIndex(pgmBg) ?? 0) : 0;
+                  const toInputIndex = tally.pvw ? (padToIndex(tally.pvw) ?? fromInputIndex) : fromInputIndex;
+                  await strom.mixer.transition(currentDoc.stromFlowId, currentDoc.mixerBlockId, {
+                    from_input: fromInputIndex,
+                    to_input: toInputIndex,
+                    transition_type: 'cut',
+                  });
+                  await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+                } catch (err) {
+                  console.warn('[controller] Strom reverse-PiP transition error (macro take):', err);
+                }
+              }
+            } else {
+              pgmBgByProduction.delete(productionId);
+              await stromTransition(currentDoc, tally.pgm, tally.pvw, 'cut');
             }
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
             const updated: ProductionDoc = {

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -812,30 +812,101 @@ export async function handleMessage(
             const mixerInput = resolveInput(action.sourceId);
             if (!mixerInput) break;
             const tally = getTally(productionId);
+            const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
+            // tally.pgm is null while a PiP is on PGM, so pass the tracked
+            // background input. Strom takes from its own overlay state and
+            // reads from_input only when that state is missing.
+            const fromPad = (curPgmPip !== null && tally.pgm === null)
+              ? (pgmBgByProduction.get(productionId) ?? null)
+              : tally.pgm;
             const newTally = { pgm: mixerInput, pvw: tally.pgm };
             setTally(productionId, newTally);
+            const curPvwPip = pvwPipByProduction.get(productionId) ?? null;
+            if (curPgmPip !== null) {
+              // PiP was on PGM → moves to PVW
+              pgmPipByProduction.set(productionId, null);
+              pvwPipByProduction.set(productionId, curPgmPip);
+              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
+              pgmBgByProduction.delete(productionId);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            } else if (curPvwPip !== null) {
+              // PiP was in PVW — cutting a real source to PGM replaces PVW, so clear it
+              pvwPipByProduction.set(productionId, null);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: null, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            }
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
-            await stromTransition(currentDoc, tally.pgm, mixerInput, 'cut');
+            await stromTransition(currentDoc, fromPad, mixerInput, 'cut');
+            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+              try {
+                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+              } catch (err) {
+                console.warn('[controller] Strom selectPreview (pip restore after macro cut) error:', err);
+              }
+            }
           } else if (action.type === 'TRANSITION' && action.sourceId) {
             const mixerInput = resolveInput(action.sourceId);
             if (!mixerInput) break;
             const tally = getTally(productionId);
+            const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
+            // tally.pgm is null while a PiP is on PGM, so pass the tracked
+            // background input. Strom takes from its own overlay state and
+            // reads from_input only when that state is missing.
+            const fromPad = (curPgmPip !== null && tally.pgm === null)
+              ? (pgmBgByProduction.get(productionId) ?? null)
+              : tally.pgm;
             const newTally = { pgm: mixerInput, pvw: tally.pgm };
             setTally(productionId, newTally);
+            if (curPgmPip !== null) {
+              // PiP was on PGM → moves to PVW
+              pgmPipByProduction.set(productionId, null);
+              pvwPipByProduction.set(productionId, curPgmPip);
+              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
+              pgmBgByProduction.delete(productionId);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            }
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: action.transitionType, durationMs: action.durationMs });
-            await stromTransition(currentDoc, tally.pgm, mixerInput, toStromTransition(action.transitionType ?? 'cut'), action.durationMs);
+            await stromTransition(currentDoc, fromPad, mixerInput, toStromTransition(action.transitionType ?? 'cut'), action.durationMs);
+            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+              try {
+                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+              } catch (err) {
+                console.warn('[controller] Strom selectPreview (pip restore after macro transition) error:', err);
+              }
+            }
           } else if (action.type === 'TAKE') {
             const tally = getTally(productionId);
+            const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
+            // tally.pgm is null while a PiP is on PGM, so pass the tracked
+            // background input. Strom takes from its own overlay state and
+            // reads from_input only when that state is missing.
+            const fromPad = (curPgmPip !== null && tally.pgm === null)
+              ? (pgmBgByProduction.get(productionId) ?? null)
+              : tally.pgm;
             const newTally = { pgm: tally.pvw, pvw: tally.pgm };
             setTally(productionId, newTally);
+            if (curPgmPip !== null) {
+              // PiP was on PGM → moves to PVW
+              pgmPipByProduction.set(productionId, null);
+              pvwPipByProduction.set(productionId, curPgmPip);
+              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
+              pgmBgByProduction.delete(productionId);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            }
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
-            await stromTransition(currentDoc, tally.pgm, tally.pvw, 'cut');
+            await stromTransition(currentDoc, fromPad, tally.pvw, 'cut');
+            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+              try {
+                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+              } catch (err) {
+                console.warn('[controller] Strom selectPreview (pip restore after macro take) error:', err);
+              }
+            }
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
             const updated: ProductionDoc = {
               ...currentDoc,


### PR DESCRIPTION
**Top of a three-PR stack: #182 (harness) → #179 (displace a PGM PiP) → this.** The diff contains all three commits until those merge — only the third, `fix(ws): take a preview PiP to program from a macro`, belongs to this PR.

## Problem

A macro TAKE never promotes a PiP sitting in preview, and the failure is silent rather than merely stale.

`SELECT_PVW_PIP` sets `newTally = { pgm: tally.pgm, pvw: null }`, so `tally.pvw` is null whenever a PiP is in preview. The macro TAKE then does:

```js
const newTally = { pgm: tally.pvw, pvw: tally.pgm };   // → { pgm: null, pvw: <old pgm> }
broadcast(productionId, { type: 'TALLY', ...newTally });
await stromTransition(currentDoc, fromPad, tally.pvw, 'cut');
//                                         ^^^^^^^^^ null → early return on !toMixerInput
```

So every subscriber is told the program bus went empty, Strom is never called and keeps airing the previous source, and `pgmPipByProduction` is never set — the server does not know the PiP took either. The operator sees a macro that appears to do nothing while the tally says the show went black.

## Fix

Restructures the macro TAKE to mirror the interactive handler's three branches — PiP moving PVW→PGM, PiP moving PGM→PVW, and no PiP — instead of the single displacement path that only covered the second.

The pip maps are now swapped as a pair (`newPgmPip = curPvwPip`, `newPvwPip = curPgmPip`) rather than cleared, and `PIP_STATE` is emitted unconditionally, both matching the interactive TAKE.

The forward branch reuses `pvwBeforePipByProduction` as `to_input` and records it as the new `pgmBg`, so a later CUT or TRANSITION while the PiP is on program has a background to report and Strom keeps `pgm_input ≠ pvw_input`.

## Impact

The `selectPreview({ source: { pip: N } })` and `transition` pair in the forward branch is what reaches the mixer — previously no Strom call was made at all on this path. `trigger_transition` reads the authoritative PGM/PVW source from overlay state (`gst/pipeline/effects/take.rs`), which `selectPreview` is what sets.

As in #179, the `from_input`/`to_input` values are carried for consistency with the interactive handler rather than as a fix; Strom reads them only when overlay state is missing.

With no PiP on either bus, the new `else` branch is the previous behaviour unchanged.

## Conflicts with #156

Same five hunks as #179 — three in `src/ws/controller.ts`, two in `src/__tests__/ws-macro-pip.test.ts` — since this PR carries #179's commit until that merges. Mechanical, and I will rebase whichever lands second.

## Testing

Ships with the harness case it makes pass. That case asserts Strom is called *at all* on this path, which is precisely what the previous behaviour got wrong — it fails against #179 and passes here.

- `npx vitest run src/__tests__/ws-macro-pip.test.ts` — 4 passed.
- `npx tsc --noEmit` clean.
- `npx vitest run` — the suite's 27 pre-existing failures in `activation.test.ts` and `macros.test.ts` are unchanged and present on `main` too.
- **Not exercised against a live mixer.** Strom builds and runs locally, but neither of its sample flows carries a vision mixer block and its own suite has no PiP coverage, so Strom's response to `selectPreview({pip:N})` rests on reading `flows.rs` and `mixer_ops.rs` rather than on execution.

