### PR TITLE
test(ws): cover PiP handling in macro CUT, TRANSITION, and TAKE

### DIFF
--- a/src/__tests__/ws-macro-pip.test.ts
+++ b/src/__tests__/ws-macro-pip.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for PiP handling in macro-executed CUT, TRANSITION, and TAKE actions.
+ *
+ * `handleMessage` is driven directly with CouchDB and StromClient mocked, so
+ * the assertions cover the Strom call sequence and the broadcast payloads
+ * without needing a mixer or a database.
+ *
+ * PiP state is established through real inbound messages (SELECT_PVW_PIP,
+ * TAKE) rather than by reaching into the module-level maps, so each case
+ * exercises the same state machine the server runs in production.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock the CouchDB layer
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn().mockResolvedValue({ ok: true });
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../routes/productions.js', () => ({
+  updateProductionDoc: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient — every mixer call the macro paths can reach
+// ---------------------------------------------------------------------------
+
+const selectPreview = vi.fn().mockResolvedValue({});
+const transition = vi.fn().mockResolvedValue({});
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    mixer = {
+      selectPreview,
+      transition,
+      toggleDsk: vi.fn().mockResolvedValue({ dsk: 1, enabled: true }),
+      setPip: vi.fn().mockResolvedValue({}),
+    };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Capture broadcasts, keep the real tally state machine
+// ---------------------------------------------------------------------------
+
+const broadcasts: Array<Record<string, unknown>> = [];
+
+vi.mock('../services/tally.service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/tally.service.js')>();
+  return {
+    ...actual,
+    broadcast: (_id: string, message: unknown) => {
+      broadcasts.push(message as Record<string, unknown>);
+    },
+  };
+});
+
+const { handleMessage, clearPipState } = await import('../ws/controller.js');
+const { setTally } = await import('../services/tally.service.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PROD = 'prod-pip-1';
+
+function makeDoc(actions: Array<Record<string, unknown>>) {
+  return {
+    _id: PROD,
+    _rev: '1-abc',
+    type: 'production',
+    name: 'PiP Test',
+    status: 'active',
+    stromFlowId: 'flow-1',
+    mixerBlockId: 'mixer-1',
+    sources: [
+      { sourceId: 'cam1', mixerInput: 'video_in_0' },
+      { sourceId: 'cam2', mixerInput: 'video_in_1' },
+      { sourceId: 'cam3', mixerInput: 'video_in_2' },
+    ],
+    pipeline: { stromConfig: null, status: 'running' },
+    graphics: [],
+    macros: [{ id: 'macro-1', slot: 0, label: 'M', color: '#ffffff', actions }],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const ws = { send: vi.fn() } as unknown as import('@fastify/websocket').WebSocket;
+
+/** Send one inbound message through the controller. */
+function send(msg: Record<string, unknown>) {
+  return handleMessage(PROD, ws, JSON.stringify(msg), {});
+}
+
+/** Every PIP_STATE broadcast seen so far, in order. */
+function pipStates() {
+  return broadcasts.filter((m) => m.type === 'PIP_STATE');
+}
+
+/** Every TALLY broadcast seen so far, in order. */
+function tallies() {
+  return broadcasts.filter((m) => m.type === 'TALLY');
+}
+
+beforeEach(() => {
+  clearPipState(PROD);
+  setTally(PROD, { pgm: 'video_in_0', pvw: 'video_in_1' });
+  broadcasts.length = 0;
+  selectPreview.mockClear();
+  transition.mockClear();
+  mockGet.mockReset();
+  mockInsert.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Macro CUT / TRANSITION over a PiP that is on program
+// ---------------------------------------------------------------------------
+
+describe('macro CUT with a PiP on program', () => {
+  it('moves the PiP to preview, tells clients, and restores it in Strom', async () => {
+    mockGet.mockResolvedValue(makeDoc([{ type: 'CUT', sourceId: 'cam3' }]));
+
+    // Put PiP 0 on program: select it into preview, then take.
+    await send({ type: 'SELECT_PVW_PIP', pip: 0 });
+    await send({ type: 'TAKE' });
+
+    broadcasts.length = 0;
+    selectPreview.mockClear();
+    transition.mockClear();
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    // The PiP leaves program for preview, and every subscriber is told.
+    expect(pipStates()).toHaveLength(1);
+    expect(pipStates()[0]).toMatchObject({ pgmPip: null, pvwPip: 0 });
+
+    // The PiP is put back on Strom's preview bus.
+    expect(selectPreview).toHaveBeenCalledWith('flow-1', 'mixer-1', { source: { pip: 0 } });
+
+    // from_input is the tracked background (video_in_1), not a collapsed to_input.
+    expect(transition).toHaveBeenCalledWith(
+      'flow-1',
+      'mixer-1',
+      expect.objectContaining({ from_input: 1, to_input: 2 }),
+    );
+  });
+});
+
+describe('macro TRANSITION with a PiP on program', () => {
+  it('moves the PiP to preview and restores it in Strom', async () => {
+    mockGet.mockResolvedValue(
+      makeDoc([{ type: 'TRANSITION', sourceId: 'cam3', transitionType: 'mix', durationMs: 500 }]),
+    );
+
+    await send({ type: 'SELECT_PVW_PIP', pip: 0 });
+    await send({ type: 'TAKE' });
+
+    broadcasts.length = 0;
+    selectPreview.mockClear();
+    transition.mockClear();
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    expect(pipStates()).toHaveLength(1);
+    expect(pipStates()[0]).toMatchObject({ pgmPip: null, pvwPip: 0 });
+    expect(selectPreview).toHaveBeenCalledWith('flow-1', 'mixer-1', { source: { pip: 0 } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Macro TAKE promoting a PiP that is sitting in preview
+// ---------------------------------------------------------------------------
+
+describe('macro TAKE with a PiP in preview', () => {
+  it('takes the PiP to program instead of reporting an empty bus', async () => {
+    mockGet.mockResolvedValue(makeDoc([{ type: 'TAKE' }]));
+
+    // PiP 1 into preview only — nothing on program yet.
+    await send({ type: 'SELECT_PVW_PIP', pip: 1 });
+
+    broadcasts.length = 0;
+    selectPreview.mockClear();
+    transition.mockClear();
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    // The regression: previously stromTransition early-returned on the null
+    // target and Strom was never called at all.
+    expect(transition).toHaveBeenCalledTimes(1);
+    expect(selectPreview).toHaveBeenCalledWith('flow-1', 'mixer-1', { source: { pip: 1 } });
+
+    // The server records the PiP as being on program.
+    expect(pipStates()).toHaveLength(1);
+    expect(pipStates()[0]).toMatchObject({ pgmPip: 1, pvwPip: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No PiP involved — the pre-existing path must be untouched
+// ---------------------------------------------------------------------------
+
+describe('macro CUT with no PiP anywhere', () => {
+  it('behaves exactly as before: no PIP_STATE, no pip selectPreview', async () => {
+    mockGet.mockResolvedValue(makeDoc([{ type: 'CUT', sourceId: 'cam3' }]));
+
+    await send({ type: 'MACRO_EXEC', macroId: 'macro-1' });
+
+    expect(pipStates()).toHaveLength(0);
+
+    // Only stromTransition's own preview select, addressed by input not pip.
+    for (const call of selectPreview.mock.calls) {
+      expect(call[2]).toEqual({ source: { input: 2 } });
+    }
+
+    expect(transition).toHaveBeenCalledWith(
+      'flow-1',
+      'mixer-1',
+      expect.objectContaining({ from_input: 0, to_input: 2 }),
+    );
+    expect(tallies()[0]).toMatchObject({ pgm: 'video_in_2', pvw: 'video_in_0' });
+  });
+});

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -456,7 +456,8 @@ async function applyAudioFollow(
 // Message handler
 // ---------------------------------------------------------------------------
 
-async function handleMessage(
+/** Exported for tests: drives one inbound message against a production. */
+export async function handleMessage(
   productionId: string,
   ws: WebSocket,
   raw: string,

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -811,30 +811,101 @@ async function handleMessage(
             const mixerInput = resolveInput(action.sourceId);
             if (!mixerInput) break;
             const tally = getTally(productionId);
+            const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
+            // tally.pgm is null while a PiP is on PGM, so pass the tracked
+            // background input. Strom takes from its own overlay state and
+            // reads from_input only when that state is missing.
+            const fromPad = (curPgmPip !== null && tally.pgm === null)
+              ? (pgmBgByProduction.get(productionId) ?? null)
+              : tally.pgm;
             const newTally = { pgm: mixerInput, pvw: tally.pgm };
             setTally(productionId, newTally);
+            const curPvwPip = pvwPipByProduction.get(productionId) ?? null;
+            if (curPgmPip !== null) {
+              // PiP was on PGM → moves to PVW
+              pgmPipByProduction.set(productionId, null);
+              pvwPipByProduction.set(productionId, curPgmPip);
+              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
+              pgmBgByProduction.delete(productionId);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            } else if (curPvwPip !== null) {
+              // PiP was in PVW — cutting a real source to PGM replaces PVW, so clear it
+              pvwPipByProduction.set(productionId, null);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: null, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            }
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
-            await stromTransition(currentDoc, tally.pgm, mixerInput, 'cut');
+            await stromTransition(currentDoc, fromPad, mixerInput, 'cut');
+            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+              try {
+                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+              } catch (err) {
+                console.warn('[controller] Strom selectPreview (pip restore after macro cut) error:', err);
+              }
+            }
           } else if (action.type === 'TRANSITION' && action.sourceId) {
             const mixerInput = resolveInput(action.sourceId);
             if (!mixerInput) break;
             const tally = getTally(productionId);
+            const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
+            // tally.pgm is null while a PiP is on PGM, so pass the tracked
+            // background input. Strom takes from its own overlay state and
+            // reads from_input only when that state is missing.
+            const fromPad = (curPgmPip !== null && tally.pgm === null)
+              ? (pgmBgByProduction.get(productionId) ?? null)
+              : tally.pgm;
             const newTally = { pgm: mixerInput, pvw: tally.pgm };
             setTally(productionId, newTally);
+            if (curPgmPip !== null) {
+              // PiP was on PGM → moves to PVW
+              pgmPipByProduction.set(productionId, null);
+              pvwPipByProduction.set(productionId, curPgmPip);
+              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
+              pgmBgByProduction.delete(productionId);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            }
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally, transitionType: action.transitionType, durationMs: action.durationMs });
-            await stromTransition(currentDoc, tally.pgm, mixerInput, toStromTransition(action.transitionType ?? 'cut'), action.durationMs);
+            await stromTransition(currentDoc, fromPad, mixerInput, toStromTransition(action.transitionType ?? 'cut'), action.durationMs);
+            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+              try {
+                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+              } catch (err) {
+                console.warn('[controller] Strom selectPreview (pip restore after macro transition) error:', err);
+              }
+            }
           } else if (action.type === 'TAKE') {
             const tally = getTally(productionId);
+            const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
+            // tally.pgm is null while a PiP is on PGM, so pass the tracked
+            // background input. Strom takes from its own overlay state and
+            // reads from_input only when that state is missing.
+            const fromPad = (curPgmPip !== null && tally.pgm === null)
+              ? (pgmBgByProduction.get(productionId) ?? null)
+              : tally.pgm;
             const newTally = { pgm: tally.pvw, pvw: tally.pgm };
             setTally(productionId, newTally);
+            if (curPgmPip !== null) {
+              // PiP was on PGM → moves to PVW
+              pgmPipByProduction.set(productionId, null);
+              pvwPipByProduction.set(productionId, curPgmPip);
+              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
+              pgmBgByProduction.delete(productionId);
+              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            }
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
-            await stromTransition(currentDoc, tally.pgm, tally.pvw, 'cut');
+            await stromTransition(currentDoc, fromPad, tally.pvw, 'cut');
+            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+              try {
+                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+              } catch (err) {
+                console.warn('[controller] Strom selectPreview (pip restore after macro take) error:', err);
+              }
+            }
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
             const updated: ProductionDoc = {
               ...currentDoc,

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -878,33 +878,59 @@ async function handleMessage(
             }
           } else if (action.type === 'TAKE') {
             const tally = getTally(productionId);
+            const curPvwPip = pvwPipByProduction.get(productionId) ?? null;
             const curPgmPip = pgmPipByProduction.get(productionId) ?? null;
-            // tally.pgm is null while a PiP is on PGM, so pass the tracked
-            // background input. Strom takes from its own overlay state and
-            // reads from_input only when that state is missing.
-            const fromPad = (curPgmPip !== null && tally.pgm === null)
-              ? (pgmBgByProduction.get(productionId) ?? null)
-              : tally.pgm;
             const newTally = { pgm: tally.pvw, pvw: tally.pgm };
+            const newPgmPip = curPvwPip;
+            const newPvwPip = curPgmPip;
             setTally(productionId, newTally);
-            if (curPgmPip !== null) {
-              // PiP was on PGM → moves to PVW
-              pgmPipByProduction.set(productionId, null);
-              pvwPipByProduction.set(productionId, curPgmPip);
-              pvwBeforePipByProduction.set(productionId, pgmBgByProduction.get(productionId) ?? null);
-              pgmBgByProduction.delete(productionId);
-              broadcast(productionId, { type: 'PIP_STATE', pgmPip: null, pvwPip: curPgmPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
-            }
+            pgmPipByProduction.set(productionId, newPgmPip);
+            pvwPipByProduction.set(productionId, newPvwPip);
             const updated: ProductionDoc = { ...currentDoc, tally: newTally, updatedAt: new Date().toISOString() };
             await getDb().insert(updated);
             broadcast(productionId, { type: 'TALLY', ...newTally });
-            await stromTransition(currentDoc, fromPad, tally.pvw, 'cut');
-            if (curPgmPip !== null && currentDoc.stromFlowId && currentDoc.mixerBlockId) {
-              try {
-                await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
-              } catch (err) {
-                console.warn('[controller] Strom selectPreview (pip restore after macro take) error:', err);
+            broadcast(productionId, { type: 'PIP_STATE', pgmPip: newPgmPip, pvwPip: newPvwPip, pips: pipConfigsByProduction.get(productionId) ?? [] });
+            if (curPvwPip !== null) {
+              // PiP is on PVW → moving to PGM
+              if (currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+                try {
+                  const fromInputIndex = tally.pgm ? (padToIndex(tally.pgm) ?? 0) : 0;
+                  const pvwBeforePip = pvwBeforePipByProduction.get(productionId) ?? null;
+                  const toInputIndex = pvwBeforePip !== null ? (padToIndex(pvwBeforePip) ?? fromInputIndex) : fromInputIndex;
+                  await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPvwPip } });
+                  await strom.mixer.transition(currentDoc.stromFlowId, currentDoc.mixerBlockId, {
+                    from_input: fromInputIndex,
+                    to_input: toInputIndex,
+                    transition_type: 'cut',
+                  });
+                  pgmBgByProduction.set(productionId, pvwBeforePip);
+                  pvwBeforePipByProduction.delete(productionId);
+                } catch (err) {
+                  console.warn('[controller] Strom PiP transition error (macro take):', err);
+                }
               }
+            } else if (curPgmPip !== null) {
+              // PiP is on PGM → taking to a real input; PiP moves to PVW
+              const pgmBg = pgmBgByProduction.get(productionId) ?? null;
+              pvwBeforePipByProduction.set(productionId, pgmBg);
+              pgmBgByProduction.delete(productionId);
+              if (currentDoc.stromFlowId && currentDoc.mixerBlockId) {
+                try {
+                  const fromInputIndex = pgmBg ? (padToIndex(pgmBg) ?? 0) : 0;
+                  const toInputIndex = tally.pvw ? (padToIndex(tally.pvw) ?? fromInputIndex) : fromInputIndex;
+                  await strom.mixer.transition(currentDoc.stromFlowId, currentDoc.mixerBlockId, {
+                    from_input: fromInputIndex,
+                    to_input: toInputIndex,
+                    transition_type: 'cut',
+                  });
+                  await strom.mixer.selectPreview(currentDoc.stromFlowId, currentDoc.mixerBlockId, { source: { pip: curPgmPip } });
+                } catch (err) {
+                  console.warn('[controller] Strom reverse-PiP transition error (macro take):', err);
+                }
+              }
+            } else {
+              pgmBgByProduction.delete(productionId);
+              await stromTransition(currentDoc, tally.pgm, tally.pvw, 'cut');
             }
           } else if (action.type === 'GRAPHIC_ON' && action.overlayId) {
             const updated: ProductionDoc = {


### PR DESCRIPTION
**Builds on #179 and #180.** The diff contains all three commits until those merge — only the third, `test(ws): cover PiP handling in macro CUT, TRANSITION, and TAKE`, belongs to this PR.

## Why

The macro PiP paths had no coverage, and neither does the WS controller as a whole — `activation.test.ts` and `macros.test.ts` both mock `../ws/controller.js` out entirely. #179 and #180 rested on reading the interactive handlers and mirroring them, which is exactly the kind of change that deserves execution behind it.

## What it does

Drives `handleMessage` with CouchDB and `StromClient` mocked, asserting the Strom call sequence and the broadcast payloads. PiP state is established through real inbound messages (`SELECT_PVW_PIP`, `TAKE`) rather than by reaching into the module-level maps, so each case exercises the same state machine the server runs in production.

Four cases:

| Case | Asserts |
| --- | --- |
| macro CUT over a PGM PiP | PiP moves to preview, `PIP_STATE` emitted, `selectPreview({pip:0})` called, `from_input` is the tracked background |
| macro TRANSITION over a PGM PiP | same displacement and restore |
| macro TAKE with a PiP in preview | Strom is called at all, PiP reaches program |
| macro CUT with no PiP | no `PIP_STATE`, no pip-addressed `selectPreview`, tally unchanged |

## It discriminates

A test that passes against broken code is worth nothing, so each case was run against the unfixed trees:

```
against main (neither fix)    3 fail, control passes
with #179 only                1 fails — the preview-PiP take
with both fixes               4 pass
```

The no-PiP control passes on all three, which is what makes it a control rather than a vacuous assertion. The single failure against #179 is precisely the bug #180 fixes.

## Production change

One export:

```ts
/** Exported for tests: drives one inbound message against a production. */
export async function handleMessage(
```

`handleMessage` was module-private and the plugin only exposes a websocket route, so there was no seam. The alternative — a fastify + websocket fixture — would drive the connect handler too and test far more than these paths. If you would rather have that, I am happy to switch; this felt like the smaller commitment to make on your behalf. Nothing else in `controller.ts` moves.

## Testing

- `npx tsc --noEmit` clean.
- `npx vitest run` — the new file passes 4/4. The suite's 27 pre-existing failures in `activation.test.ts` and `macros.test.ts` are unchanged (all 500s from the HTTP layer, present on `main` too).

**Still not covered:** anything requiring a real mixer. Strom builds and runs locally, but neither of its sample flows carries a vision mixer block and its own suite has no PiP coverage either, so `selectPreview({pip:N})` setting `pvw_pip` such that the next transition takes the PiP to program remains supported by reading `flows.rs` and `mixer_ops.rs` rather than by execution.
