### PR TITLE
docs: state the one-click CouchDB flow and the two undocumented Strom gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ Visit **[openlive.apps.osaas.io](https://openlive.apps.osaas.io)** to spin up a 
 - 14-day free trial, free plan available
 - 15 EUR/month (self-hosted Strom) or 69 EUR/month (shared GPU in Frankfurt)
 
+The in-app **Create New Open Live** flow provisions CouchDB for you and generates its admin
+password automatically. You do not choose or handle that password yourself on this path.
+The `COUCHDB_URL` environment variable documented under [Environment variables](#environment-variables)
+below is only for a self-hosted deployment where you run CouchDB yourself; it does not apply
+to the managed OSC flow above.
+
+**Before you start, two things that are not obvious from the pricing line above:**
+
+- **Shared Strom (the 69 EUR/month option) requires the Professional plan or above.** If your
+  account is not eligible, the app shows this up front when you open the environment, not as a
+  failed submission after you try to create one.
+- **Your own ("BYO") Strom instance has no plan requirement, but its URL must be publicly
+  reachable.** A plain local-network or loopback address is rejected. A mesh VPN such as
+  [Tailscale](https://tailscale.com) or a self-hosted [Headscale](https://github.com/juanfont/headscale)
+  server is one way to give a locally hosted Strom instance a publicly routable address without
+  port-forwarding. On the free plan this path is metered by your token allowance rather than
+  gated by plan, so budget for that if you are testing rather than running on a paid plan.
+
 ## Features
 
 - **Vision mixing** — cuts, auto transitions, DSK layers, picture-in-picture, graphics overlays, and fade-to-black

--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ to the managed OSC flow above.
   account is not eligible, the app shows this up front when you open the environment, not as a
   failed submission after you try to create one.
 - **Your own ("BYO") Strom instance has no plan requirement, but its URL must be publicly
-  reachable.** A plain local-network or loopback address is rejected. A mesh VPN such as
-  [Tailscale](https://tailscale.com) or a self-hosted [Headscale](https://github.com/juanfont/headscale)
-  server is one way to give a locally hosted Strom instance a publicly routable address without
-  port-forwarding. On the free plan this path is metered by your token allowance rather than
-  gated by plan, so budget for that if you are testing rather than running on a paid plan.
+  reachable.** A plain local-network or loopback address is rejected, and so is any address
+  that is not reachable from OSC, including a plain Tailscale or other mesh-VPN address in the
+  `100.64.0.0/10` range even though it clears the initial check. To expose a locally hosted
+  Strom instance without port-forwarding, use a public ingress feature such as
+  [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) (opt-in, off by default; also
+  implemented by self-hosted [Headscale](https://github.com/juanfont/headscale)), which gives
+  the instance a genuinely public `ts.net` hostname. On the free plan this path is metered by
+  your one-time token allowance rather than gated by plan, so budget for that if you are
+  testing rather than running on a paid plan.
 
 ## Features
 


### PR DESCRIPTION
## What

The managed OSC flow ("Try it on OSC") already auto-provisions CouchDB and generates its own
admin password, but the README did not say so, and did not distinguish that flow from the
self-hosted `.env` setup further down. It also did not mention two gates that stop an operator
before they reach any further setup step:

- Shared Strom (the 69 EUR/month option) requires the Professional plan or above. The app shows
  this proactively when you open the environment, not as a failed submission on create.
- A self-hosted ("BYO") Strom instance has no plan requirement, but its URL must be publicly
  reachable; a plain LAN or loopback address is rejected. A mesh VPN (Tailscale, self-hosted
  Headscale) is one way to satisfy that without port-forwarding, and this path is token-metered
  on the free plan instead of plan-gated.

## Why

Source: an Open Live DX audit run 2026-08-27/28 (`osc-devrel-agent`), Headline Finding 1 and 2a/2b.
The finding traces to a live read of `Eyevinn/open-live-site`'s `POST /api/openlive/create` and to
the live app HTML/copy. Full audit:
https://github.com/Eyevinn (internal agent output, happy to share the source doc on request).

This is item 1 of a 4-item proposal (DR-88). Item 4 of that proposal (naming a specific external
switcher in the Studio wiki's Stream Type table) is deliberately not included here or anywhere:
a CEO decision logged 2026-08-27 bars naming a competing production switcher in interoperability
documentation, and that table is exactly that surface. The existing OBS/ffmpeg mention in that
table is unchanged; this PR does not touch the wiki.

## Not in this PR

- The community wiki's own Setup Guide page still describes the older four-manual-step CouchDB
  process, including a password-format warning that cannot occur on the flow this PR documents.
  That page needs the same correction, but GitHub wikis take no PR review and write access for
  this account is still pending a response from the maintainer (asked 2026-08-26). Flagging here
  so this PR is not read as having already fixed the wiki too.
- Any SRT/switcher-connection content. That is gated on confirming the SRT source address's
  caller/listener resolution behaviour with the team first (a separate, still-open item).

## Verification

Docs-only change, no code path affected. Rendered locally to confirm the added Markdown and the
`#environment-variables` anchor link resolve correctly.
