### PR TITLE
fix(server): require API key auth for Swagger UI and OpenAPI spec routes

### DIFF
--- a/src/__tests__/docs-auth.test.ts
+++ b/src/__tests__/docs-auth.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests that the Swagger UI and OpenAPI spec routes are protected by the same
+ * API-key auth guard as the rest of the API when API_KEY is configured.
+ *
+ * Regression test for the "Swagger UI / OpenAPI spec served without
+ * authentication" security issue (#81): the auth hook previously only fired for
+ * /api/v1 and /ws/ paths, leaving /documentation (+ /documentation/json,
+ * /documentation/yaml) exposed.
+ *
+ * CouchDB, the WS controller, and Strom are mocked — no real services required.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const TEST_API_KEY = 'test-secret-key';
+
+// Inject an apiKey into config so the auth hook is registered. The factory is
+// hoisted above imports, so the key is written inline here (it must match
+// TEST_API_KEY above).
+vi.mock('../config.js', () => ({
+  config: {
+    port: 3000,
+    couchdbUrl: 'http://localhost:5984',
+    stromUrl: 'http://localhost:7000',
+    stromToken: undefined,
+    stromAuthMode: 'osc',
+    logLevel: 'silent',
+    apiKey: 'test-secret-key',
+    corsOrigin: 'http://localhost:5173',
+    publicBaseUrl: undefined,
+  },
+}));
+
+// Mock CouchDB — the docs/spec routes don't touch the DB.
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  getSourcesDb: () => ({ get: vi.fn() }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbConnected: () => true,
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+// Mock the WebSocket controller (avoids startup side effects).
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+}));
+
+import { buildServer } from '../server.js';
+
+describe('Swagger UI / OpenAPI spec auth gating (API_KEY set)', () => {
+  let app: Awaited<ReturnType<typeof buildServer>>;
+
+  beforeEach(async () => {
+    app = await buildServer();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const specRoutes = ['/documentation/json', '/documentation/yaml'];
+
+  it.each(specRoutes)('rejects unauthenticated GET %s with 401', async (url) => {
+    const res = await app.inject({ method: 'GET', url });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects unauthenticated GET /documentation (UI) with 401', async () => {
+    const res = await app.inject({ method: 'GET', url: '/documentation' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it.each(specRoutes)('allows authenticated GET %s with valid bearer token', async (url) => {
+    const res = await app.inject({
+      method: 'GET',
+      url,
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects a wrong bearer token on /documentation/json with 401', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json',
+      headers: { authorization: 'Bearer wrong-key' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -115,10 +115,19 @@ export async function buildServer() {
     fastify.addHook('onRequest', async (req, reply) => {
       const path = req.url.split('?')[0]!;
       if (AUTH_EXEMPT_PATHS.has(path)) return;
-      // Guard both the REST API and the WebSocket controller. The /ws/ prefix
-      // must be listed explicitly: without it, /ws/productions/:id/controller
-      // bypasses auth entirely and accepts live production commands unauthenticated.
-      if (!req.url.startsWith('/api/v1') && !req.url.startsWith('/ws/')) return;
+      // Guard the REST API, the WebSocket controller, and the Swagger UI / OpenAPI
+      // spec. The /ws/ prefix must be listed explicitly: without it,
+      // /ws/productions/:id/controller bypasses auth entirely and accepts live
+      // production commands unauthenticated. The /documentation prefix covers the
+      // Swagger UI plus its machine-readable specs (/documentation/json,
+      // /documentation/yaml) — without it the full API blueprint is exposed.
+      if (
+        !req.url.startsWith('/api/v1') &&
+        !req.url.startsWith('/ws/') &&
+        !req.url.startsWith('/documentation')
+      ) {
+        return;
+      }
 
       const authHeader = req.headers['authorization'];
       const keyFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;


### PR DESCRIPTION
## Summary
- The API-key auth `onRequest` hook only fired for `/api/v1` and `/ws/` prefixes, so `/documentation` (Swagger UI) and its specs (`/documentation/json`, `/documentation/yaml`) were served unauthenticated even when `API_KEY` was set — exposing the full API blueprint (OWASP A01, CVSS 7.5). This extends the existing guard to also cover the `/documentation` prefix.

## Changes
- `src/server.ts`: added `!req.url.startsWith('/documentation')` to the auth-hook early-return so the Swagger UI and OpenAPI JSON/YAML spec routes require the same `Authorization: Bearer <API_KEY>` as the rest of the API. Reuses the existing guard/exemption logic — no new auth scheme. When `API_KEY` is unset, behaviour is unchanged (docs remain open, e.g. behind OSC's reverse-proxy auth wall).
- `src/__tests__/docs-auth.test.ts`: new focused vitest suite verifying unauthenticated requests to `/documentation`, `/documentation/json`, `/documentation/yaml` return 401, a wrong token returns 401, and a valid bearer token returns 200.

## Test Plan
- [x] Unit tests pass
- [x] Manual verification: unauthenticated request to Swagger UI / OpenAPI spec returns 401 when API_KEY set

## Checklist
- [x] Code-quality checks passed
- [x] No self-review

🤖 Generated with Claude Code