### PR TITLE
fix(sources): block private/internal hosts in srtUrl to prevent SRT SSRF

### DIFF
--- a/src/__tests__/url-validation.test.ts
+++ b/src/__tests__/url-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { graphicUrl, httpUrlOnly, srtUrl } from '../lib/url-validation.js';
+import { graphicUrl, httpUrlOnly, srtUrl, isPrivateHost } from '../lib/url-validation.js';
 
 describe('graphicUrl', () => {
   it('accepts https:// URLs', () => {
@@ -73,12 +73,83 @@ describe('httpUrlOnly', () => {
   });
 });
 
+describe('isPrivateHost', () => {
+  it('flags IPv4 loopback (127/8)', () => {
+    expect(isPrivateHost('127.0.0.1')).toBe(true);
+    expect(isPrivateHost('127.255.255.254')).toBe(true);
+  });
+
+  it('flags IPv4 private ranges (10/8, 172.16/12, 192.168/16)', () => {
+    expect(isPrivateHost('10.0.0.1')).toBe(true);
+    expect(isPrivateHost('172.16.0.1')).toBe(true);
+    expect(isPrivateHost('172.31.255.255')).toBe(true);
+    expect(isPrivateHost('192.168.1.1')).toBe(true);
+  });
+
+  it('flags IPv4 link-local (169.254/16) and 0.0.0.0/8', () => {
+    expect(isPrivateHost('169.254.169.254')).toBe(true);
+    expect(isPrivateHost('0.0.0.0')).toBe(true);
+  });
+
+  it('flags IPv6 loopback, link-local (fe80::/10), and ULA (fc00::/7)', () => {
+    expect(isPrivateHost('::1')).toBe(true);
+    expect(isPrivateHost('[::1]')).toBe(true);
+    expect(isPrivateHost('fe80::1')).toBe(true);
+    expect(isPrivateHost('fc00::1')).toBe(true);
+    expect(isPrivateHost('fd12:3456::1')).toBe(true);
+  });
+
+  it('flags IPv4-mapped IPv6 for private embedded addresses', () => {
+    expect(isPrivateHost('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateHost('::ffff:10.0.0.1')).toBe(true);
+  });
+
+  it('does not flag public IPv4/IPv6 addresses', () => {
+    expect(isPrivateHost('8.8.8.8')).toBe(false);
+    expect(isPrivateHost('1.1.1.1')).toBe(false);
+    expect(isPrivateHost('172.15.0.1')).toBe(false); // just below 172.16/12
+    expect(isPrivateHost('172.32.0.1')).toBe(false); // just above 172.16/12
+    expect(isPrivateHost('2606:4700:4700::1111')).toBe(false);
+    expect(isPrivateHost('::ffff:8.8.8.8')).toBe(false);
+  });
+
+  it('does not flag public DNS hostnames', () => {
+    expect(isPrivateHost('example.com')).toBe(false);
+    expect(isPrivateHost('srt.example.org')).toBe(false);
+  });
+
+  it('does not flag empty host (listener form)', () => {
+    expect(isPrivateHost('')).toBe(false);
+  });
+});
+
 describe('srtUrl', () => {
   it('accepts valid srt:// URLs', () => {
     expect(() => srtUrl('srt://example.com:9000')).not.toThrow();
   });
 
+  it('accepts the hostless listener form (srt://:PORT)', () => {
+    expect(() => srtUrl('srt://:6000')).not.toThrow();
+    expect(() => srtUrl('srt://:6000?mode=listener')).not.toThrow();
+  });
+
+  it('accepts a public host', () => {
+    expect(() => srtUrl('srt://198.51.100.5:9000?mode=caller')).not.toThrow();
+  });
+
   it('rejects non-srt URLs', () => {
     expect(() => srtUrl('http://example.com')).toThrow();
+  });
+
+  it('rejects private/loopback IPv4 hosts', () => {
+    expect(() => srtUrl('srt://127.0.0.1:9999?mode=caller')).toThrow(/private|loopback/i);
+    expect(() => srtUrl('srt://10.0.0.1:5005')).toThrow(/private|loopback/i);
+    expect(() => srtUrl('srt://192.168.1.10:5005')).toThrow(/private|loopback/i);
+    expect(() => srtUrl('srt://169.254.169.254:80')).toThrow(/private|loopback/i);
+  });
+
+  it('rejects IPv6 loopback and ULA hosts', () => {
+    expect(() => srtUrl('srt://[::1]:9000')).toThrow(/private|loopback/i);
+    expect(() => srtUrl('srt://[fc00::1]:9000')).toThrow(/private|loopback/i);
   });
 });

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -4,8 +4,73 @@
  * Rules:
  * - httpUrlOnly: allow only http/https schemes
  * - graphicUrl:  httpUrlOnly OR safe data: image URIs (no svg, no text/html)
- * - srtUrl:      srt:// scheme only
+ * - srtUrl:      srt:// scheme only; reject private/internal hosts (listener form allowed)
  */
+
+/**
+ * Returns true if the given host is an IP literal in a private, loopback,
+ * link-local, or internal range that must not be reachable via SSRF.
+ *
+ * Covered ranges:
+ * - IPv4: 10/8, 172.16/12, 192.168/16, 127/8 (loopback), 169.254/16 (link-local),
+ *   0.0.0.0
+ * - IPv6: ::1 (loopback), fe80::/10 (link-local), fc00::/7 (unique-local)
+ * - IPv4-mapped IPv6: ::ffff:a.b.c.d (evaluated as the embedded IPv4 address)
+ *
+ * Non-IP hostnames (public DNS names) are NOT flagged here — DNS resolution is out
+ * of scope for this synchronous validator; this blocks the direct-IP SSRF vector.
+ */
+export function isPrivateHost(hostname: string): boolean {
+  // Strip surrounding brackets from IPv6 literals and normalise case.
+  const host = hostname.trim().replace(/^\[|\]$/g, '').toLowerCase();
+  if (!host) return false;
+
+  // IPv4-mapped IPv6, e.g. ::ffff:127.0.0.1 — evaluate the embedded IPv4.
+  const mapped = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mapped) {
+    return isPrivateIPv4(mapped[1]!);
+  }
+
+  if (host.includes(':')) {
+    return isPrivateIPv6(host);
+  }
+
+  return isPrivateIPv4(host);
+}
+
+/**
+ * True if `host` is a dotted-quad IPv4 literal in a private/loopback/link-local range.
+ * Returns false for anything that is not a valid IPv4 literal (e.g. DNS names).
+ */
+function isPrivateIPv4(host: string): boolean {
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  const octets = m.slice(1, 5).map(Number);
+  if (octets.some((n) => n > 255)) return false;
+  const [a, b] = octets as [number, number, number, number];
+  if (a === 0) return true; // 0.0.0.0/8 ("this host")
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  return false;
+}
+
+/**
+ * True if `host` is an IPv6 literal in the loopback, link-local (fe80::/10),
+ * or unique-local (fc00::/7) ranges. `host` is expected lower-cased and unbracketed.
+ */
+function isPrivateIPv6(host: string): boolean {
+  if (host === '::1') return true; // loopback
+  if (host === '::') return true; // unspecified
+  const first = host.split(':')[0] ?? '';
+  // Unique-local fc00::/7 -> first hextet in fc00..fdff.
+  if (/^f[cd][0-9a-f]{0,2}$/.test(first)) return true;
+  // Link-local fe80::/10 -> first hextet in fe80..febf.
+  if (/^fe[89ab][0-9a-f]$/.test(first)) return true;
+  return false;
+}
 
 /**
  * Throws if the URL is not a safe http/https URL.
@@ -53,6 +118,10 @@ const SRT_URL_RE = /^srt:\/\/[^!; ]*$/i;
 
 /**
  * Throws if the value is not a valid SRT URL.
+ *
+ * The hostless listener form (`srt://:PORT`, binds all interfaces) is allowed.
+ * URLs whose host is a private/loopback/link-local/internal IP are rejected to
+ * prevent SSRF from the GStreamer pipeline to internal services.
  */
 export function srtUrl(url: string): void {
   if (!url.startsWith('srt://')) {
@@ -60,5 +129,23 @@ export function srtUrl(url: string): void {
   }
   if (!SRT_URL_RE.test(url)) {
     throw new Error('SRT URL contains disallowed characters');
+  }
+
+  // Extract the authority (host[:port]) from srt://<authority>[/path][?query].
+  // The listener form `srt://:6000` has an empty host and is allowed as-is; the
+  // WHATWG URL parser rejects the equivalent `http://:6000`, so parse manually.
+  const authority = url.slice('srt://'.length).split(/[/?#]/, 1)[0] ?? '';
+
+  let hostname = '';
+  const bracketed = authority.match(/^\[([^\]]*)\](?::\d+)?$/); // IPv6 literal, e.g. [::1]:9000
+  if (bracketed) {
+    hostname = bracketed[1]!;
+  } else {
+    // Host is everything up to the final ":port" (if any).
+    hostname = authority.replace(/:\d+$/, '');
+  }
+
+  if (hostname && isPrivateHost(hostname)) {
+    throw new Error('SRT URL must not target private, loopback, or link-local addresses');
   }
 }


### PR DESCRIPTION
## Summary
- `srtUrl()` only validated the `srt://` scheme and character set, so an attacker could point an SRT source/output at internal hosts (`srt://127.0.0.1`, `srt://10.0.0.1`, `srt://[::1]`), causing the GStreamer pipeline (via Strom) to make SSRF connections to internal services. This adds an IP-literal blocklist while keeping the hostless listener form (`srt://:PORT`) allowed.

Closes #78.

## Changes
- `src/lib/url-validation.ts`: add `isPrivateHost(hostname)` helper covering IPv4 private (10/8, 172.16/12, 192.168/16), loopback (127/8), link-local (169.254/16), 0.0.0.0/8, IPv6 loopback (`::1`), link-local (fe80::/10), unique-local (fc00::/7), and IPv4-mapped IPv6 (`::ffff:a.b.c.d`). Apply it inside `srtUrl()`; the hostless listener form parses to an empty host and is still accepted. `httpUrlOnly()`/`graphicUrl()` were left untouched to keep the change minimal and focused.
- `src/__tests__/url-validation.test.ts`: unit tests for `isPrivateHost` and for `srtUrl()` rejecting private hosts while accepting a public host and the listener form.

## Test Plan
- [x] Unit tests pass (isPrivateHost + srtUrl)
- [x] Manual: private host rejected, public host + listener form accepted

## Checklist
- [x] Code-quality checks passed
- [x] No self-review

🤖 Generated with Claude Code