### PR TITLE
chore: add CI workflow (typecheck, build, test) on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "tsx watch --env-file=.env src/main.ts",
     "build": "tsc",
     "start": "node --env-file-if-exists=.env dist/main.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.2",

--- a/src/__tests__/activation.test.ts
+++ b/src/__tests__/activation.test.ts
@@ -20,6 +20,7 @@ vi.mock('../db/index.js', () => ({
   getSourcesDb: () => ({ get: mockGet }),
   connectDb: vi.fn().mockResolvedValue(undefined),
   isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
 }));
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/macros.test.ts
+++ b/src/__tests__/macros.test.ts
@@ -23,6 +23,7 @@ vi.mock('../db/index.js', () => ({
   getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
   connectDb: vi.fn().mockResolvedValue(undefined),
   isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
 }));
 
 // Prevent the WebSocket controller from doing anything at startup

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    // Exclude the tsc build output — without this, running `build` before
+    // `test` (as CI does) makes vitest pick up compiled dist/__tests__/*.js
+    // alongside src/__tests__/*.ts and double-report every test.
+    exclude: ['**/node_modules/**', 'dist/**'],
     // Use forks pool so vi.mock works properly with ESM
     pool: 'forks',
     // Provide env vars required by config.ts


### PR DESCRIPTION
Part of addressing [Eyevinn/agent-team-open-live#4](https://github.com/Eyevinn/agent-team-open-live/issues/4) — this repo had exactly one GitHub Actions workflow (`sync-fork.yml`, a manual deploy trigger) and nothing ran on pull requests. `main` also has no branch protection (tracked separately — that's a settings change, not a code change, so it's not part of this PR).

## What this adds
`.github/workflows/ci.yml`: on every PR and push to `main`, runs `pnpm install --frozen-lockfile`, then `typecheck`, `build`, and `test` (new `test` script — none existed despite vitest being a devDependency with real tests in `src/__tests__/`).

## Two small fixes this exposed
1. **`vitest.config.ts` didn't exclude the `tsc` build output.** Running `build` before `test` (as CI does) made vitest also pick up compiled `dist/__tests__/*.js` alongside `src/__tests__/*.ts`, double-reporting every test. Added an explicit `exclude` for `dist/`.
2. **`activation.test.ts` and `macros.test.ts`'s `vi.mock('../db/index.js', ...)` factories were missing `isDbConnected`**, which `server.ts`'s `onRequest` hook (added in #99, alongside the WHIP/WHEP SSRF fix) calls on every `/api/v1` request. Every mocked HTTP test was failing with 500 — i.e. the entire test suite has been silently broken since #99 merged, with nothing to catch it. Added the missing mock export; this alone took the suite from 22/49 passing to 45/49.

## Known remaining gap
4 tests in `activation.test.ts` still fail — cross-test state leakage unrelated to the above (each fails only as part of the suite, passes in isolation). Filed as #188 with a working hypothesis rather than guessed at further here, so the first CI run isn't a surprise: it'll show 4 known, tracked failures until #188 is resolved.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run build` — passes
- [x] `pnpm test` — 45/49 passing (4 known failures tracked in #188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)