### PR TITLE
fix(tests): stop cross-test state leakage in activation.test.ts

### DIFF
--- a/src/__tests__/activation.test.ts
+++ b/src/__tests__/activation.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildServer } from '../server.js';
+import { resetIceServersCache } from '../routes/ice-servers.js';
 
 // ---------------------------------------------------------------------------
 // Mock CouchDB
@@ -29,6 +30,11 @@ vi.mock('../db/index.js', () => ({
 
 vi.mock('../ws/controller.js', () => ({
   default: async () => {},
+  // The deactivate route imports these live-state cleanup helpers; without them
+  // the mock is missing exports and the handler throws (→ 500) instead of 200.
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -239,6 +245,10 @@ describe('GET /api/v1/ice-servers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFind.mockResolvedValue({ docs: [] });
+    // The ice-servers route keeps a module-level stale-on-error cache that
+    // survives across buildServer() instances. Clear it so a cached success
+    // from an earlier test can't be served in place of a mocked error (502).
+    resetIceServersCache();
   });
 
   it('returns 200 with iceServers array from Strom', async () => {

--- a/src/routes/ice-servers.ts
+++ b/src/routes/ice-servers.ts
@@ -20,6 +20,19 @@ import { config } from '../config.js';
 
 let cachedIceServers: IceServer[] | null = null
 
+/**
+ * Clear the module-level stale-on-error cache.
+ *
+ * The cache is module-scoped so it survives across `buildServer()` instances —
+ * that is correct in production (the last-good ICE config should outlive a
+ * server rebuild) but leaks state between tests, where each test builds a fresh
+ * server yet shares this module. Tests call this in `beforeEach` so a cached
+ * success from an earlier test can't mask a later error expectation.
+ */
+export function resetIceServersCache(): void {
+  cachedIceServers = null
+}
+
 const iceServersRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/v1/ice-servers', async (_req, reply) => {
     try {


### PR DESCRIPTION
## Summary
`npx vitest run src/__tests__/activation.test.ts` failed 4 of 49 tests only when run as a full suite. The failures traced to two independent test-isolation defects, both fixed here without weakening any assertions or disabling the stale-on-error cache feature.

Closes #188

## Changes
- **`src/routes/ice-servers.ts`** — export `resetIceServersCache()`. The stale-on-error cache (`cachedIceServers`) is module-scoped, so it correctly outlives a `buildServer()` rebuild in production but leaks between tests, which each build a fresh server yet share the module. An earlier test's successful ICE response was returned to a later test that mocked a rejection and expected a 502 (`expected 200 to be 502`). The reset hook lets tests clear it; the cache feature itself is untouched.
- **`src/__tests__/activation.test.ts`**
  - Call `resetIceServersCache()` in the ice-servers `beforeEach` so a cached success can't mask a later error expectation.
  - Complete the `../ws/controller.js` mock with `clearAudioState`, `clearPipState`, and `clearFxState`. The deactivate route imports these live-state cleanup helpers; the mock previously exported only `default`, so the handler threw on the missing export and returned 500 instead of 200.

## Test Plan
- [x] `npx vitest run src/__tests__/activation.test.ts` — 9/9 pass
- [x] `npx vitest run` (full suite) — 49/49 pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean

🤖 Generated with Claude Code