### PR TITLE
Trigger sync-fork on PR merge, then restart olivedev instances

### DIFF
--- a/.github/workflows/sync-fork-on-merge.yml
+++ b/.github/workflows/sync-fork-on-merge.yml
@@ -1,0 +1,18 @@
+name: Trigger Sync Fork on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: sync-fork-prod
+  cancel-in-progress: false
+
+jobs:
+  sync-fork:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/sync-fork.yml
+    with:
+      environment: prod
+    secrets: inherit

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -12,12 +12,22 @@ on:
           - prod
           - dev
           - stage
+  workflow_call:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: string
+
+concurrency:
+  group: sync-fork-${{ inputs.environment }}
+  cancel-in-progress: false
 
 jobs:
   sync-fork:
     name: Sync fork (${{ inputs.environment }})
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Validate environment
         run: |
@@ -33,4 +43,13 @@ jobs:
         env:
           OSC_ACCESS_TOKEN: unused
           OSC_API_KEY: ${{ secrets.OSC_API_KEY }}
-        run: osc --env "${{ inputs.environment }}" admin sync-fork eyevinn-open-live
+        run: osc --env "${{ inputs.environment }}" admin sync-fork --wait eyevinn-open-live
+
+      - name: Restart olivedev service instances
+        if: inputs.environment == 'prod'
+        env:
+          OSC_ACCESS_TOKEN: unused
+          OSC_API_KEY: ${{ secrets.OSC_OLIVEDEV_PAT }}
+        run: |
+          osc --env prod restart eyevinn-open-live openlivedev
+          osc --env prod restart eyevinn-open-live-studio openlivedev


### PR DESCRIPTION
## What
- Adds \`.github/workflows/sync-fork-on-merge.yml\`: automatically runs the existing \`sync-fork\` workflow (environment \`prod\`) whenever a PR merges into \`main\`. Guarded by a \`concurrency\` group (\`sync-fork-prod\`) so only one sync-fork run is ever in flight.
- Modifies \`.github/workflows/sync-fork.yml\`:
  - Adds a \`workflow_call\` trigger (alongside the existing manual \`workflow_dispatch\`) so the new merge-triggered workflow can invoke it.
  - Adds a \`concurrency\` group keyed by environment (\`sync-fork-\${{ inputs.environment }}\`), enforced on the reusable workflow itself regardless of which trigger calls it.
  - Uses \`admin sync-fork --wait\` so the job blocks until the fork sync (and remake) has actually completed.
  - After a successful \`prod\` sync, restarts both the \`open-live\` and \`open-live-studio\` \`openlivedev\` service instances in the \`olivedev\` tenant (\`osc restart eyevinn-open-live openlivedev\` / \`osc restart eyevinn-open-live-studio openlivedev\`), so the two stay in lockstep after any merge to either repo.

## New secret required
The restart step needs a **tenant-scoped PAT for \`olivedev\`**, added as \`OSC_OLIVEDEV_PAT\` in this repo's secrets (kept separate from the existing admin-scoped \`OSC_API_KEY\`, which is still used for the \`admin sync-fork\` call). Until that secret is added, the restart step will fail — the sync-fork step itself is unaffected.

## Companion PR
Same change in [open-live-studio](https://github.com/Eyevinn/open-live-studio/pull/94) (also bumps the pinned \`@osaas/cli\` version there to \`4.33.1\`, since \`--wait\` on \`admin sync-fork\` was only added in \`4.33.0\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)