### PR TITLE
fix(productions): stop leaking internal error details on activate/deactivate

### DIFF
--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -530,9 +530,8 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
         _rev: insertResponse.rev,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      fastify.log.error({ err }, 'Failed to initiate production activation');
-      return reply.status(500).send({ error: message, statusCode: 500 });
+      req.log.error({ err }, 'Activation failed');
+      return reply.status(500).send({ error: 'Activation failed — check server logs', statusCode: 500 });
     }
   });
 
@@ -584,9 +583,8 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
       notifyProductionDeactivated(doc._id);
       return reply.send({ id: updated._id, name: updated.name, status: updated.status, _rev: response.rev });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      fastify.log.error({ err }, 'Failed to deactivate production');
-      return reply.status(500).send({ error: message, statusCode: 500 });
+      req.log.error({ err }, 'Deactivation failed');
+      return reply.status(500).send({ error: 'Deactivation failed — check server logs', statusCode: 500 });
     }
   });
 


### PR DESCRIPTION
## Summary
Fixes a MEDIUM-severity information-disclosure issue (#79). The per-route `try/catch` blocks in `src/routes/productions.ts` for `POST /:id/activate` and `POST /:id/deactivate` forwarded raw `err.message` in their 500 responses, bypassing the global error handler hardened in #12. This could leak Strom API bodies, CouchDB doc IDs, internal hostnames, and the SAT endpoint to clients.

## Changes
- `activate` catch block: log full error server-side (`req.log.error({ err }, 'Activation failed')`) and return generic `'Activation failed — check server logs'`.
- `deactivate` catch block: log full error server-side (`req.log.error({ err }, 'Deactivation failed')`) and return generic `'Deactivation failed — check server logs'`.
- No other logic touched.

## Test Plan
- `pnpm run typecheck` — passes
- `pnpm run build` — passes
- `npx vitest run` — 49/49 pass

## Checklist
- [x] Typecheck passes
- [x] Build passes
- [x] Tests pass
- [x] Change scoped to the two affected catch blocks
- [x] No secrets committed

Closes #79