### PR TITLE
ci: allow manual re-trigger of CI via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Findings on #194

The `build-and-test` required check's `pull_request`/`push` triggers in `ci.yml` are configured correctly — new PRs get green runs as expected (see e.g. #191, #193, and the `fix/issue-79-*` PR).

The ~28 stuck PRs aren't hitting a broken trigger: their branches were cut **before** `ci.yml` existed (added in #189), so no `pull_request` event has fired for them since — GitHub doesn't retroactively run a newly added workflow against an already-open PR. Confirmed directly:

```
$ git show fix/issue-78-srt-private-host-blocklist:.github/workflows/ci.yml
fatal: path '.github/workflows/ci.yml' exists on disk, but not in 'fix/issue-78-srt-private-host-blocklist'
```

Each stuck PR needs one fresh commit (a rebase/merge from `main`, which brings `ci.yml` along) to get a `synchronize` event and populate the check. `workflow_dispatch` can't backfill these specific PRs either — dispatch requires the workflow file to already exist on the target ref (confirmed via the Actions API, which 422s with "Workflow does not have workflow_dispatch trigger" against one of the stale branches).

## What this PR does

Adds `workflow_dispatch` to `ci.yml` so that, for any branch that *does* have the workflow file, CI can be manually re-run (e.g. after a transient failure, or once a branch has been synced) without needing to push an empty commit.

Closes part of #194 (the `open-live` side). A separate PR addresses `open-live-studio`, where CI does trigger correctly but was failing even on `main` due to pre-existing lint debt — an actual bug, not a trigger issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)