### PR TITLE
ci: fix concurrency-group deadlock in sync-fork-on-merge.yml

### DIFF
--- a/.github/workflows/sync-fork-on-merge.yml
+++ b/.github/workflows/sync-fork-on-merge.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: sync-fork-prod
+  group: sync-fork-on-merge-prod
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Reported: [this run](https://github.com/Eyevinn/open-live/actions/runs/33531543168) (triggered by merging #72) failed instantly with 0 steps.

## Root cause

GitHub's own diagnostic on the run:
> Canceling since a deadlock was detected for concurrency group: 'sync-fork-prod' between a top level workflow and 'sync-fork / Sync fork (prod)'

`sync-fork-on-merge.yml`'s top-level `concurrency.group` (`sync-fork-prod`) and the reusable `sync-fork.yml` workflow's job-level `concurrency.group` (`sync-fork-${{ inputs.environment }}`, which resolves to `sync-fork-prod` when called with `environment: prod`) are identical. GitHub treats the called job as waiting on a group that includes its own parent workflow and cancels it as a deadlock — every time, unconditionally. This has been failing on every single merge into `main` today (confirmed against several recent merge-triggered runs, all 0-2s / 0 steps).

## Fix

Rename this workflow's group to `sync-fork-on-merge-prod` so the two levels no longer collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)