### PR TITLE
fix(outputs): persist PiP/graphics configuration across deactivation

### DIFF
--- a/src/__tests__/pip-persistence.test.ts
+++ b/src/__tests__/pip-persistence.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression tests for issue #177 — "Production graphics (PiP) configuration is
+ * lost on deactivation, and setup does not persist".
+ *
+ * Root cause: the PiP layout set via the WS SET_PIP handler was stored ONLY in
+ * the in-memory `pipConfigsByProduction` cache and never written to the
+ * ProductionDoc. On deactivate the cache is wiped (clearPipState); on the next
+ * connect it was re-seeded with EMPTY slots, so the operator's PiP placement was
+ * lost across every activate/deactivate cycle (and every server restart).
+ *
+ * Fix: persist pipConfigs on the ProductionDoc (via updateProductionDoc) and
+ * re-hydrate the cache from the doc on connect (hydratePipConfigsFromDoc).
+ *
+ * These tests exercise the persistence/hydration seam directly. CouchDB is
+ * mocked as a tiny in-memory store so updateProductionDoc round-trips like the
+ * real thing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ProductionDoc } from '../db/types.js';
+import type { PipConfig } from '../lib/strom.js';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB with a minimal in-memory store keyed by _id.
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, ProductionDoc>();
+
+const mockGet = vi.fn(async (id: string) => {
+  const doc = store.get(id);
+  if (!doc) {
+    const err = new Error('not_found') as Error & { statusCode: number };
+    err.statusCode = 404;
+    throw err;
+  }
+  return structuredClone(doc);
+});
+
+const mockInsert = vi.fn(async (doc: ProductionDoc) => {
+  store.set(doc._id, structuredClone(doc));
+  return { id: doc._id, rev: `${(store.size)}-rev`, ok: true };
+});
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// updateProductionDoc lives in the productions route module; import AFTER the db mock.
+import { updateProductionDoc } from '../routes/productions.js';
+import {
+  setPipConfigSlot,
+  getPipConfigs,
+  hydratePipConfigsFromDoc,
+  clearPipState,
+} from '../ws/controller.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProductionDoc(overrides: Partial<ProductionDoc> = {}): ProductionDoc {
+  return {
+    _id: 'prod-pip-1',
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Test Production',
+    status: 'active',
+    sources: [],
+    values: { num_pips: 2 },
+    pipeline: { stromConfig: null, status: 'running' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    stromFlowId: 'flow-1',
+    mixerBlockId: 'mixer-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const SAMPLE_PIP: PipConfig = {
+  bg: 0,
+  zones: [{ rect: { x: 0.6, y: 0.6, w: 0.35, h: 0.35 }, capacity: 1, sources: [1] }],
+  transforms: {},
+};
+
+/** Simulate the persistence side-effect of the SET_PIP handler. */
+async function simulateSetPip(productionId: string, pip: number, cfg: PipConfig) {
+  setPipConfigSlot(productionId, pip, cfg);
+  await updateProductionDoc(productionId, { pipConfigs: getPipConfigs(productionId) ?? [] });
+}
+
+describe('PiP configuration persistence (issue #177)', () => {
+  beforeEach(() => {
+    store.clear();
+    vi.clearAllMocks();
+    // Ensure no stale in-memory cache leaks between tests.
+    clearPipState('prod-pip-1');
+    store.set('prod-pip-1', makeProductionDoc());
+  });
+
+  it('persists the PiP layout to the ProductionDoc when SET_PIP runs', async () => {
+    await simulateSetPip('prod-pip-1', 0, SAMPLE_PIP);
+
+    const persisted = store.get('prod-pip-1');
+    expect(persisted?.pipConfigs).toBeDefined();
+    expect(persisted?.pipConfigs?.[0]).toEqual(SAMPLE_PIP);
+  });
+
+  it('deactivate (clearPipState) does NOT wipe the persisted pipConfigs on the doc', async () => {
+    await simulateSetPip('prod-pip-1', 0, SAMPLE_PIP);
+
+    // Deactivate: the in-memory cache is flushed, but the DB doc must be untouched.
+    clearPipState('prod-pip-1');
+    expect(getPipConfigs('prod-pip-1')).toBeUndefined();
+
+    const persisted = store.get('prod-pip-1');
+    expect(persisted?.pipConfigs?.[0]).toEqual(SAMPLE_PIP);
+  });
+
+  it('restores the PiP layout from the doc on reconnect after a deactivate cycle', async () => {
+    // 1. Operator configures a PiP while the production is active.
+    await simulateSetPip('prod-pip-1', 0, SAMPLE_PIP);
+
+    // 2. Deactivate wipes the live cache.
+    clearPipState('prod-pip-1');
+    expect(getPipConfigs('prod-pip-1')).toBeUndefined();
+
+    // 3. Reconnect: hydrate from the persisted doc (as the WS connect handler does).
+    const doc = await mockGet('prod-pip-1');
+    const restored = hydratePipConfigsFromDoc(doc);
+
+    // The operator's layout is back — not an empty slot.
+    expect(restored).not.toBeNull();
+    expect(getPipConfigs('prod-pip-1')?.[0]).toEqual(SAMPLE_PIP);
+    // restored is returned so the caller can re-push it to Strom.
+    expect(restored?.[0]).toEqual(SAMPLE_PIP);
+  });
+
+  it('seeds empty slots from num_pips when nothing was ever persisted', () => {
+    clearPipState('prod-pip-1');
+    const doc = makeProductionDoc({ pipConfigs: undefined, values: { num_pips: 3 } });
+    const restored = hydratePipConfigsFromDoc(doc);
+
+    // No persisted layout to restore → returns null but seeds empty slots.
+    expect(restored).toBeNull();
+    const seeded = getPipConfigs('prod-pip-1');
+    expect(seeded).toHaveLength(3);
+    expect(seeded?.every((c) => c.bg === null && c.zones.length === 0)).toBe(true);
+  });
+
+  it('does not clobber a live cache when the doc is re-read (hydration is cold-only)', async () => {
+    // Live edit present in the cache.
+    setPipConfigSlot('prod-pip-1', 0, SAMPLE_PIP);
+    // A stale doc (no pipConfigs) must not overwrite the live layout.
+    const staleDoc = makeProductionDoc({ pipConfigs: undefined });
+    const restored = hydratePipConfigsFromDoc(staleDoc);
+
+    expect(restored).toBeNull();
+    expect(getPipConfigs('prod-pip-1')?.[0]).toEqual(SAMPLE_PIP);
+  });
+});

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,3 +1,5 @@
+import type { PipConfig } from '../lib/strom.js';
+
 // --------------- Macro types ---------------
 
 export type MacroActionType = 'CUT' | 'TRANSITION' | 'TAKE' | 'GRAPHIC_ON' | 'GRAPHIC_OFF' | 'DSK_TOGGLE';
@@ -138,6 +140,13 @@ export interface ProductionDoc {
   whepOutputUrls?: Array<{ outputId: string; url: string }>;
   /** Graphic-to-DSK-pad assignments for this production */
   graphicAssignments?: ProductionGraphicAssignment[];
+  /**
+   * Persisted Picture-in-Picture layout (background + zones + per-source crops)
+   * per PiP slot. Set via the WS SET_PIP handler; survives deactivate/reactivate
+   * and server restarts so operators do not have to reconfigure PiP placement.
+   * Indexed by PiP slot number.
+   */
+  pipConfigs?: PipConfig[];
   /** ID of the running Strom flow (set on activate, cleared on deactivate) */
   stromFlowId?: string;
   /** WHEP multiview endpoint URL — set when flow reaches 'playing' state, cleared on deactivate */

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -356,6 +356,55 @@ export function clearPipState(productionId: string): void {
   })
 }
 
+/**
+ * Read-only view of the in-memory PiP layout cache for a production.
+ * Exported for tests.
+ */
+export function getPipConfigs(productionId: string): PipConfig[] | undefined {
+  return pipConfigsByProduction.get(productionId)
+}
+
+/**
+ * Store one PiP slot's layout in the in-memory cache and return the updated
+ * array. Does not persist to the DB — callers own persistence.
+ */
+export function setPipConfigSlot(productionId: string, pip: number, cfg: PipConfig): PipConfig[] {
+  const pips = (pipConfigsByProduction.get(productionId) ?? []).slice()
+  pips[pip] = cfg
+  pipConfigsByProduction.set(productionId, pips)
+  return pips
+}
+
+/**
+ * Hydrate the in-memory PiP cache for a production from its persisted
+ * ProductionDoc.pipConfigs (issue #177). Only runs when the cache is cold, so
+ * live edits are never clobbered. Falls back to empty slots seeded from
+ * num_pips when nothing was persisted.
+ *
+ * Returns the restored persisted layout when it was populated from the doc
+ * (so the caller can re-push it to Strom), otherwise null.
+ */
+export function hydratePipConfigsFromDoc(doc: ProductionDoc): PipConfig[] | null {
+  if (pipConfigsByProduction.has(doc._id)) return null
+  const rawNumPips = doc.values?.num_pips
+  const numPips = typeof rawNumPips === 'number' ? Math.max(0, Math.round(rawNumPips))
+    : typeof rawNumPips === 'string' ? Math.max(0, parseInt(rawNumPips, 10) || 0)
+    : 0
+  const persisted = doc.pipConfigs
+  if (persisted && persisted.length > 0) {
+    // Pad/truncate to the currently configured slot count so the cache matches
+    // num_pips even if it changed since the layout was saved.
+    const restored = Array.from({ length: Math.max(numPips, persisted.length) }, (_, i) =>
+      persisted[i] ?? { bg: null, zones: [], transforms: {} })
+    pipConfigsByProduction.set(doc._id, restored)
+    return restored
+  }
+  if (numPips > 0) {
+    pipConfigsByProduction.set(doc._id, Array.from({ length: numPips }, () => ({ bg: null, zones: [], transforms: {} })))
+  }
+  return null
+}
+
 /** Wipe all per-production FX state. Called when the pipeline changes or production deactivates. */
 export function clearFxState(productionId: string): void {
   inputEffectsByProduction.delete(productionId)
@@ -701,9 +750,7 @@ async function handleMessage(
         const strom = await makeStromClient();
         const transforms: PipTransforms = msg.transforms ?? {};
 
-        const pips = (pipConfigsByProduction.get(productionId) ?? []).slice();
-        pips[msg.pip] = { bg: msg.bg, zones: msg.zones, transforms };
-        pipConfigsByProduction.set(productionId, pips);
+        const pips = setPipConfigSlot(productionId, msg.pip, { bg: msg.bg, zones: msg.zones, transforms });
         broadcast(productionId, { type: 'PIP_STATE', pgmPip: pgmPipByProduction.get(productionId) ?? null, pvwPip: pvwPipByProduction.get(productionId) ?? null, pips });
 
         const resp = await strom.mixer.updatePipConfig(doc.stromFlowId, doc.mixerBlockId, msg.pip, {
@@ -713,12 +760,18 @@ async function handleMessage(
         });
         // Sync back Strom-clamped transforms (may differ due to clamping)
         if (resp?.transforms && Object.keys(resp.transforms).length > 0) {
-          const syncedPips = (pipConfigsByProduction.get(productionId) ?? []).slice();
-          if (syncedPips[msg.pip]) {
-            syncedPips[msg.pip] = { ...syncedPips[msg.pip]!, transforms: resp.transforms };
-            pipConfigsByProduction.set(productionId, syncedPips);
+          const current = pipConfigsByProduction.get(productionId)?.[msg.pip];
+          if (current) {
+            setPipConfigSlot(productionId, msg.pip, { ...current, transforms: resp.transforms });
           }
         }
+
+        // Persist the PiP layout to the ProductionDoc so it survives
+        // deactivate/reactivate and server restarts (issue #177). The in-memory
+        // cache is authoritative for the write; updateProductionDoc is 409-safe.
+        await updateProductionDoc(productionId, {
+          pipConfigs: pipConfigsByProduction.get(productionId) ?? [],
+        }).catch((err) => console.warn('[controller] persist pipConfigs error:', err));
       } catch (err) {
         console.warn('[controller] Strom SET_PIP error:', err);
         ws.send(JSON.stringify({ type: 'ERROR', error: stromErrorMessage(err) }));
@@ -1437,23 +1490,41 @@ const controllerWs: FastifyPluginAsync = async (fastify) => {
       }
 
       // Sync PiP state from in-memory server cache (populated by SET_PIP / SELECT_PVW_PIP).
-      // If the cache is cold, seed empty slots from num_pips so the PipPanel shows the
-      // correct number of slots without requiring a SET_PIP first.
-      if (!pipConfigsByProduction.has(id)) {
-        const rawNumPips = connectDoc?.values?.num_pips;
-        const numPips = typeof rawNumPips === 'number' ? Math.max(0, Math.round(rawNumPips))
-          : typeof rawNumPips === 'string' ? Math.max(0, parseInt(rawNumPips, 10) || 0)
-          : 0;
-        if (numPips > 0) {
-          pipConfigsByProduction.set(id, Array.from({ length: numPips }, () => ({ bg: null, zones: [], transforms: {} })));
-        }
-      }
+      // If the cache is cold (fresh connect after deactivate or server restart),
+      // hydrate it from the persisted pipConfigs on the ProductionDoc (issue #177)
+      // so the operator's PiP layout is restored. If nothing was persisted, seed
+      // empty slots from num_pips so the PipPanel shows the correct number of slots
+      // without requiring a SET_PIP first.
+      const restoredPipConfigs = connectDoc ? hydratePipConfigsFromDoc(connectDoc) : null;
       socket.send(JSON.stringify({
         type: 'PIP_STATE',
         pgmPip: pgmPipByProduction.get(id) ?? null,
         pvwPip: pvwPipByProduction.get(id) ?? null,
         pips:   pipConfigsByProduction.get(id) ?? [],
       }));
+
+      // On the first connect after (re)activation, Strom's PiP slots start empty
+      // (flow-generator only sets num_pips). Re-push any restored persisted layout
+      // to Strom so what the operator saved is actually rendered (issue #177).
+      if (restoredPipConfigs && connectDoc?.stromFlowId && connectDoc.mixerBlockId) {
+        try {
+          const strom = await makeStromClient();
+          const flowId = connectDoc.stromFlowId;
+          const mixerBlockId = connectDoc.mixerBlockId;
+          for (let i = 0; i < restoredPipConfigs.length; i++) {
+            const cfg = restoredPipConfigs[i];
+            // Skip empty slots — nothing to restore.
+            if (!cfg || (cfg.bg === null && cfg.zones.length === 0)) continue;
+            await strom.mixer.updatePipConfig(flowId, mixerBlockId, i, {
+              bg: cfg.bg,
+              zones: cfg.zones,
+              transforms: cfg.transforms,
+            }).catch((err) => console.warn('[controller] restore pipConfig error:', err));
+          }
+        } catch (err) {
+          console.warn('[controller] restore pipConfigs to Strom error:', err);
+        }
+      }
 
       const cachedDskLayers = dskLayersByProduction.get(id);
       if (cachedDskLayers) {


### PR DESCRIPTION
## Summary

Picture-in-Picture (PiP) layout configured by the operator was lost whenever a production was deactivated, and never survived a server restart. This meant multi-session / multi-day productions had to have their PiP placement reconfigured from scratch on every reactivation.

Closes #177

## Root cause

The PiP layout (`bg` / `zones` / `transforms` per slot) set via the WS `SET_PIP` handler was stored **only** in the in-memory `pipConfigsByProduction` cache in `src/ws/controller.ts` and was **never written to the `ProductionDoc`**. On deactivate, `clearPipState()` deletes the cache entry; on the next WS connect the cache was re-seeded with **empty** slots derived from `num_pips`. So the operator's layout was dropped on every activate/deactivate cycle and on every server restart.

This is distinct from #168 (mixer-cut 409-swallow): the PiP config was never persisted at all, so no revision-conflict handling was involved.

## Changes

- Add `pipConfigs?: PipConfig[]` to `ProductionDoc` (`src/db/types.ts`).
- `SET_PIP` now persists the updated layout to the doc via the existing 409-safe `updateProductionDoc` helper.
- On WS connect, when the in-memory cache is cold, hydrate it from the persisted `pipConfigs` (falling back to empty `num_pips` slots only when nothing was saved).
- On the first connect after (re)activation, re-push any restored layout to Strom (which starts with empty PiP slots) so the saved config is actually rendered.
- Extract `setPipConfigSlot` / `getPipConfigs` / `hydratePipConfigsFromDoc` helpers to make the persistence/hydration seam testable; behaviour is otherwise unchanged.

## Test Plan

- [x] Regression test added (`src/__tests__/pip-persistence.test.ts`): proves the PiP layout is persisted on `SET_PIP`, is NOT wiped from the doc on deactivate, and is restored on reconnect after a deactivate cycle; plus empty-slot seeding and cold-only hydration guards.
- [x] `pnpm run typecheck` — zero errors
- [x] `pnpm run build` — compiles
- [x] `npx vitest run` — all 75 tests pass (70 existing + 5 new)

## Checklist

- [x] Branched from `main`
- [x] Focused change; no unrelated refactoring
- [x] No new DB/API fields invented beyond `ProductionDoc.pipConfigs`
- [x] No secrets committed
- [x] No `.github/workflows/` changes

🤖 Generated with Claude Code