### PR TITLE
fix(server): require API key auth for Swagger UI and OpenAPI spec routes

### DIFF
--- a/src/__tests__/swagger-auth.test.ts
+++ b/src/__tests__/swagger-auth.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for API-key auth coverage of the Swagger UI / OpenAPI spec routes.
+ *
+ * Regression guard for #81: /documentation and its specs sit outside the
+ * /api/v1 prefix and must still require the API key when API_KEY is set.
+ *
+ * CouchDB, Strom client, and the WS controller are mocked — no real services
+ * required. API_KEY is set before importing the server so config.apiKey (read
+ * once at module load) picks it up.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+const TEST_API_KEY = 'test-secret-key';
+process.env['API_KEY'] = TEST_API_KEY;
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  getSourcesDb: () => ({ get: vi.fn() }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket controller (avoids startup side effects)
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient / flow-generator (imported transitively via routes)
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: vi.fn(),
+  deactivateStromFlow: vi.fn(),
+}));
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = { version: vi.fn(), iceServers: vi.fn() };
+    flows = {
+      get: vi.fn(),
+      start: vi.fn().mockResolvedValue({}),
+      stop: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    mixer = { multiviewEndpoint: vi.fn() };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeAll(async () => {
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Swagger UI / OpenAPI spec auth (#81)', () => {
+  const specPaths = ['/documentation/json', '/documentation/yaml'];
+
+  it('rejects the Swagger UI page without an API key when API_KEY is set', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'GET', url: '/documentation' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it.each(specPaths)('rejects %s without an API key when API_KEY is set', async (url) => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'GET', url });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects an OpenAPI spec request with a wrong API key', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json',
+      headers: { authorization: 'Bearer wrong-key' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('serves the OpenAPI spec with the correct API key', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/documentation/json',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty('openapi');
+  });
+
+  it('still exempts health probes from auth', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'GET', url: '/health' });
+    expect(res.statusCode).not.toBe(401);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -120,10 +120,22 @@ export async function buildServer() {
     fastify.addHook('onRequest', async (req, reply) => {
       const path = req.url.split('?')[0]!;
       if (AUTH_EXEMPT_PATHS.has(path)) return;
-      // Guard both the REST API and the WebSocket controller. The /ws/ prefix
-      // must be listed explicitly: without it, /ws/productions/:id/controller
-      // bypasses auth entirely and accepts live production commands unauthenticated.
-      if (!req.url.startsWith('/api/v1') && !req.url.startsWith('/ws/')) return;
+      // Guard the REST API, the WebSocket controller, and the Swagger UI /
+      // OpenAPI spec routes. The /ws/ prefix must be listed explicitly:
+      // without it, /ws/productions/:id/controller bypasses auth entirely and
+      // accepts live production commands unauthenticated. The /documentation
+      // prefix must also be listed: Swagger UI and its specs
+      // (/documentation, /documentation/json, /documentation/yaml) sit outside
+      // /api/v1 and would otherwise expose the full API blueprint — route
+      // signatures, schemas, and the bearer-auth config — unauthenticated even
+      // when API_KEY is set.
+      if (
+        !req.url.startsWith('/api/v1') &&
+        !req.url.startsWith('/ws/') &&
+        !req.url.startsWith('/documentation')
+      ) {
+        return;
+      }
 
       const authHeader = req.headers['authorization'];
       const keyFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;


### PR DESCRIPTION
## Summary
- Close a HIGH/P1 security gap: Swagger UI (`/documentation`) and its specs (`/documentation/json`, `/documentation/yaml`) were served unauthenticated even when `API_KEY` was configured, leaking the full API blueprint (route signatures, schemas, bearer-auth config).
- Extend the existing API-key `onRequest` auth guard to also cover the `/documentation` prefix, alongside the existing `/api/v1` and `/ws/` prefixes.

## Changes
- `src/server.ts`: the API-key auth hook previously only treated a request as protected when its URL started with `/api/v1` or `/ws/`. Added `/documentation` to that set so Swagger UI and the OpenAPI spec routes require the API key when `API_KEY` is set. Existing auth exemptions (`/health`, `/ready`, `/api/v1/status`, `/api/v1/reconnect`) are preserved, and behavior is unchanged when `API_KEY` is unset (the whole hook is only registered when `config.apiKey` is set).
- `src/__tests__/swagger-auth.test.ts`: new vitest suite (regression guard for #81) verifying `/documentation`, `/documentation/json`, and `/documentation/yaml` return 401 without/with a wrong key, return 200 with the correct key, and that `/health` remains exempt.

## Test Plan
- [x] Unit tests pass (`npx vitest run` — 76 passed / 6 files, incl. 6 new swagger-auth tests)
- [ ] Integration tests pass
- [x] Manual verification: `pnpm run typecheck` and `pnpm run build` both pass with zero errors

## Checklist
- [x] Code-quality checks passed
- [x] No hardcoded SRT ports
- [x] GStreamer pipelines have watchdogs (if applicable)
- [x] EFP sequence validation present (if applicable)
- [ ] docs/repo-patterns.md updated if non-obvious issue encountered

Closes #81

🤖 Generated with Claude Code