### PR TITLE
fix(lib): wire up log redaction to prevent plaintext credential logging

### DIFF
--- a/src/__tests__/log-redact.test.ts
+++ b/src/__tests__/log-redact.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for log redaction (issue #69).
+ *
+ * Verifies that redactSensitive() strips known-sensitive fields and that
+ * safeFlowProjection() never emits block/element properties (which may carry
+ * SRT URIs, passphrases, tokens, or credentials) into logs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { redactSensitive, safeFlowProjection } from '../lib/log-redact.js';
+
+describe('redactSensitive', () => {
+  it('redacts top-level sensitive keys', () => {
+    const out = redactSensitive({
+      passphrase: 'sup3r-s3cret',
+      token: 'ghp_abc123',
+      secret: 'my-secret',
+      name: 'cam-1',
+    }) as Record<string, unknown>;
+
+    expect(out.passphrase).toBe('[REDACTED]');
+    expect(out.token).toBe('[REDACTED]');
+    expect(out.secret).toBe('[REDACTED]');
+    expect(out.name).toBe('cam-1');
+  });
+
+  it('redacts nested sensitive values and matches key substrings', () => {
+    const out = redactSensitive({
+      block: {
+        srt_uri: 'srt://host:1234?passphrase=leaked',
+        streamid: 'live/cam1',
+        authorization: 'Bearer xyz',
+        label: 'ok',
+      },
+    }) as { block: Record<string, unknown> };
+
+    expect(out.block.srt_uri).toBe('[REDACTED]');
+    expect(out.block.streamid).toBe('[REDACTED]');
+    expect(out.block.authorization).toBe('[REDACTED]');
+    expect(out.block.label).toBe('ok');
+  });
+
+  it('does not leak the sensitive string anywhere in serialized output', () => {
+    const secretValue = 'srt://h:9000?passphrase=TOPSECRET-PW';
+    const out = redactSensitive({ nested: [{ srt_uri: secretValue }] });
+    expect(JSON.stringify(out)).not.toContain('TOPSECRET-PW');
+  });
+
+  it('preserves non-object primitives', () => {
+    expect(redactSensitive('plain')).toBe('plain');
+    expect(redactSensitive(42)).toBe(42);
+    expect(redactSensitive(null)).toBe(null);
+  });
+});
+
+describe('safeFlowProjection', () => {
+  it('keeps only IDs/types and never emits block or element properties', () => {
+    const flow = {
+      blocks: [
+        {
+          id: 'blk-1',
+          block_definition_id: 'srt.input',
+          properties: { srt_uri: 'srt://h?passphrase=LEAKED-PW', streamid: 'live/1' },
+        },
+      ],
+      elements: [
+        { id: 'el-1', element_type: 'video', config: { token: 'LEAKED-TOKEN' } },
+      ],
+      links: [{ id: 'lnk-1' }],
+    };
+
+    const out = safeFlowProjection(flow) as Record<string, unknown>;
+    const serialized = JSON.stringify(out);
+
+    expect(serialized).not.toContain('LEAKED-PW');
+    expect(serialized).not.toContain('LEAKED-TOKEN');
+    expect(serialized).not.toContain('passphrase');
+    expect(out.blockCount).toBe(1);
+    expect(out.elementCount).toBe(1);
+    expect(out.linkCount).toBe(1);
+    expect((out.blocks as Record<string, unknown>[])[0]).toEqual({
+      id: 'blk-1',
+      block_definition_id: 'srt.input',
+    });
+    expect((out.elements as Record<string, unknown>[])[0]).toEqual({
+      id: 'el-1',
+      element_type: 'video',
+    });
+  });
+
+  it('handles missing arrays gracefully', () => {
+    const out = safeFlowProjection({}) as Record<string, unknown>;
+    expect(out.blockCount).toBe(0);
+    expect(out.elementCount).toBe(0);
+    expect(out.linkCount).toBe(0);
+    expect(out.blocks).toEqual([]);
+    expect(out.elements).toEqual([]);
+  });
+});

--- a/src/lib/flow-generator.ts
+++ b/src/lib/flow-generator.ts
@@ -4,6 +4,7 @@ import { getSourcesDb, getGraphicsDb } from '../db/index.js';
 import { StromClient } from './strom.js';
 import { DEFAULT_FLOW, type FlowTopology } from './default-flow.js';
 import { decryptAddressPassphrase } from './srt-passphrase-crypto.js';
+import { safeFlowProjection } from './log-redact.js';
 
 /**
  * Generates a Strom flow from a template + source assignments,
@@ -861,11 +862,7 @@ export async function activateStromFlow(
     await strom.flows.start(flowId);
   } catch (err) {
     // Log a sanitized flow projection — never log block properties (may contain SRT URIs, tokens, passphrases)
-    const safeFlow = {
-      blockCount: flow.blocks.length,
-      blocks: flow.blocks.map((b) => ({ id: b['id'], block_definition_id: b['block_definition_id'] })),
-      linkCount: flow.links.length,
-    };
+    const safeFlow = safeFlowProjection(flow as unknown as Record<string, unknown>);
     console.error('[flow-generator] Flow start failed. Flow topology (properties redacted):',
       JSON.stringify(safeFlow, null, 2));
     // Start failed — clean up the created flow so the endpoint isn't left registered

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,26 @@ export async function buildServer() {
   const fastify = Fastify({
     logger: {
       level: config.logLevel,
+      // Defence-in-depth: strip credentials from any log object regardless of
+      // call site, in case a raw flow/source/error escapes explicit redaction.
+      // Field names mirror the sensitive keys in src/lib/log-redact.ts.
+      redact: {
+        paths: [
+          'srt_uri',
+          'passphrase',
+          'streamid',
+          'token',
+          'secret',
+          '*.srt_uri',
+          '*.passphrase',
+          '*.streamid',
+          '*.token',
+          '*.secret',
+          'req.headers.authorization',
+          'headers.authorization',
+        ],
+        censor: '[REDACTED]',
+      },
     },
     disableRequestLogging: true,
     // Prevent memory exhaustion via oversized request bodies (1 MB limit)


### PR DESCRIPTION
## Summary
- `redactSensitive()` and `safeFlowProjection()` in `src/lib/log-redact.ts` were defined but never imported — dead code, leaving sensitive data (SRT passphrases, tokens, credentials) exposed in logs.
- Wires the existing helper into the one live log site that emits flow data, and adds Pino `redact` as defence-in-depth.

Closes #69

## Changes
- `src/lib/flow-generator.ts` — the flow-start failure handler hand-rolled an inline "safe" projection (dropping `elements` entirely). Replaced it with the existing `safeFlowProjection()` helper, which keeps only IDs/types for blocks AND elements and never emits block/element properties (SRT URIs, passphrases, tokens).
- `src/server.ts` — added a Pino `redact` block to the Fastify logger config as defence-in-depth. Paths mirror the sensitive keys in `log-redact.ts` (`srt_uri`, `passphrase`, `streamid`, `token`, `secret`, plus one-level wildcards and `authorization` headers), censored to `[REDACTED]`.
- `src/__tests__/log-redact.test.ts` — new vitest suite asserting known-sensitive strings (passphrases, tokens, SRT URIs) never appear in serialized output from either function.

Note: `src/routes/productions.ts` and `src/lib/strom.ts` log sites were reviewed — they only log scalar IDs (`productionId`, `stromFlowId`, `whepEndpoint`) or `err.message`, not raw flow/source objects, so no change was needed there. The Pino `redact` option covers them as defence-in-depth.

## Test Plan
- [x] Unit tests pass
- [x] Manual verification: confirmed `flow` at the log site is a `FlowTopology` (has `blocks`/`elements`/`links`), matching `safeFlowProjection`'s expected shape; verified new tests fail without redaction and pass with it.

## Checklist
- [x] Code-quality checks passed (`pnpm run typecheck`, `pnpm run build`, `npx vitest run` — 76 tests pass)
🤖 Generated with Claude Code