### PR TITLE
fix(flow-generator): validate forwarded production values before sending to Strom

### DIFF
--- a/src/__tests__/production-values-validation.test.ts
+++ b/src/__tests__/production-values-validation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for PATCH /api/v1/productions/:id `values` validation (issue #88).
+ *
+ * Several production `values` are forwarded verbatim to Strom block properties by
+ * flow-generator.ts (pgm_resolution, pgm_framerate, multiview_*, clock → clock_type).
+ * These must be validated against format-specific allowlists so malformed values are
+ * rejected with a 400 (via the global ZodError handler) rather than injected into
+ * Strom flow properties.
+ *
+ * CouchDB and the WS controller are mocked — no real services required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../server.js';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+const mockFind = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: mockFind }),
+  getSourcesDb: () => ({ get: mockGet }),
+  getOutputsDb: () => ({ get: mockGet }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// Avoid WS controller startup side effects
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+function makeProductionDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'prod-test-1',
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Test Production',
+    status: 'inactive',
+    sources: [],
+    pipeline: { stromConfig: null, status: 'stopped' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function patchValues(values: Record<string, unknown>) {
+  const doc = makeProductionDoc();
+  mockGet.mockResolvedValue(doc);
+  mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+  const app = await buildServer();
+  return app.inject({
+    method: 'PATCH',
+    url: '/api/v1/productions/prod-test-1',
+    payload: { values },
+  });
+}
+
+describe('PATCH /api/v1/productions/:id — values validation (issue #88)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it('rejects a malformed pgm_resolution with 400', async () => {
+    const res = await patchValues({ pgm_resolution: '1280x720; drop-block' });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('Validation error');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed pgm_framerate with 400', async () => {
+    const res = await patchValues({ pgm_framerate: 'evil' });
+    expect(res.statusCode).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a clock value outside the fixed allowlist with 400', async () => {
+    const res = await patchValues({ clock: 'malicious_clock' });
+    expect(res.statusCode).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('accepts valid forwarded values (resolution, framerate, clock)', async () => {
+    const res = await patchValues({
+      pgm_resolution: '1920x1080',
+      pgm_framerate: '30000/1001',
+      multiview_resolution: '1280x720',
+      multiview_framerate: '25',
+      clock: 'ntp',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+
+  it('accepts an empty clock (treated as "use template default")', async () => {
+    const res = await patchValues({ clock: '' });
+    expect(res.statusCode).toBe(200);
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+
+  it('leaves unrelated keys (numbers, booleans, labels) untouched', async () => {
+    const res = await patchValues({ bitrate: 6000, ebu_main: true, some_label: 'Camera 1' });
+    expect(res.statusCode).toBe(200);
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+});

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -312,9 +312,58 @@ const ProductionInput = z.object({
   name: z.string().min(1).max(256),
 });
 
+// Format-specific allowlists for production `values` that are forwarded verbatim
+// to Strom block properties by flow-generator.ts. Validated here so malformed
+// values are rejected with a 400 (via the global ZodError handler) rather than
+// being injected into Strom flow properties (issue #88).
+//
+// - resolution keys (pgm_resolution, multiview_resolution) → e.g. "1280x720"
+// - framerate keys  (pgm_framerate, multiview_framerate)   → e.g. "30" or "30000/1001"
+//   (fractions must allow NTSC-style rates like 30000/1001, so up to 6 digits/side)
+// - clock → forwarded as the flow-level `clock_type` property; fixed set only.
+const RESOLUTION_RE = /^\d{3,5}x\d{3,5}$/;
+const FRAMERATE_RE = /^\d{1,6}\/\d{1,6}$|^\d{1,3}$/;
+const CLOCK_TYPES = new Set(['ntp', 'gst', 'system']);
+
+const RESOLUTION_VALUE_KEYS = ['pgm_resolution', 'multiview_resolution'] as const;
+const FRAMERATE_VALUE_KEYS = ['pgm_framerate', 'multiview_framerate'] as const;
+
+const ProductionValues = z
+  .record(z.union([z.string(), z.number(), z.boolean()]))
+  .superRefine((values, ctx) => {
+    for (const key of RESOLUTION_VALUE_KEYS) {
+      const v = values[key];
+      if (typeof v === 'string' && !RESOLUTION_RE.test(v)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `${key} must match <width>x<height> (e.g. "1280x720")`,
+        });
+      }
+    }
+    for (const key of FRAMERATE_VALUE_KEYS) {
+      const v = values[key];
+      if (typeof v === 'string' && !FRAMERATE_RE.test(v)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `${key} must be an integer or fraction (e.g. "30" or "30000/1001")`,
+        });
+      }
+    }
+    const clock = values['clock'];
+    if (typeof clock === 'string' && clock !== '' && !CLOCK_TYPES.has(clock)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['clock'],
+        message: `clock must be one of: ${[...CLOCK_TYPES].join(', ')}`,
+      });
+    }
+  });
+
 const ProductionPatch = z.object({
   name: z.string().min(1).max(256).optional(),
-  values: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+  values: ProductionValues.optional(),
   airTime: z.string().datetime().nullable().optional(),
 });
 


### PR DESCRIPTION
## Summary

Closes #88

Production `values` (`PATCH /api/v1/productions/:id`) were accepted as an unconstrained `z.record(z.union([z.string(), z.number(), z.boolean()]))`. Several of those values are forwarded verbatim to Strom block/flow properties by `flow-generator.ts`:

- `pgm_resolution`, `multiview_resolution` → mixer/videoformat `resolution`
- `pgm_framerate`, `multiview_framerate` → mixer `*_framerate`
- `clock` → forwarded as the flow-level `clock_type` property

None were validated, allowing arbitrary strings to be injected into Strom flow properties (property injection). This is broader than #60, which only covered raw `pgm_resolution`/`pgm_framerate` forwarding — this change also covers `clock` and the multiview variants.

## Changes

- `src/routes/productions.ts`: Add format-specific allowlists on the `ProductionPatch` `values` schema via `superRefine`:
  - resolution keys must match `^\d{3,5}x\d{3,5}$` (e.g. `1280x720`)
  - framerate keys must match `^\d{1,6}\/\d{1,6}$|^\d{1,3}$` (integer or NTSC-style fraction, e.g. `30` or `30000/1001`)
  - `clock` must be one of `ntp`, `gst`, `system` (empty string allowed = use template default)
  - Other keys/values (numbers, booleans, labels) pass through unchanged.
  - Invalid values are rejected with a 400 through the existing global `ZodError` handler — no new error path.
- `src/__tests__/production-values-validation.test.ts`: New vitest coverage for rejected malformed values (resolution, framerate, clock) and accepted valid values.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `npx vitest run` (76 passed)
- [x] New tests: malformed `pgm_resolution`/`pgm_framerate`/`clock` → 400; valid combo → 200; empty clock → 200; unrelated keys untouched

## Checklist

- [x] Branched from `main`
- [x] Validation surfaced via existing Zod/400 path
- [x] No secrets committed
- [x] Minimal, pattern-matching change (mirrors existing `mixerInputSchema` regex approach)

> Note for reviewers: the `clock` allowlist (`ntp`/`gst`/`system`) follows the values suggested in issue #88; there is no in-repo enum for `clock_type` (Strom is an external service), so please confirm the accepted set against Strom before merge.

🤖 Generated with Claude Code