### PR TITLE
fix(ci): pin @osaas/cli version in sync-fork workflow

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -36,7 +36,7 @@ jobs:
           esac
 
       - name: Install OSC CLI
-        run: npm install -g @osaas/cli
+        run: npm install -g @osaas/cli@4.31.3
 
       - name: Trigger sync fork
         env:


### PR DESCRIPTION
## Summary

Pins the OSC CLI install in `sync-fork.yml` to `@osaas/cli@4.31.3`, matching what `open-live-studio` already uses in its equivalent workflow.

`npm install -g @osaas/cli` (no version, no lockfile, no integrity hash) means any malicious or compromised release of the CLI executes immediately in the deployment pipeline with full CI permissions, including `OSC_API_KEY`. Addresses the supply-chain risk described in #166 (OWASP A06, CVSS 3.1 7.3).

## Note

The `daily-backlog-pr` automation already prepared exactly this change but is blocked from pushing to `.github/workflows/` by design (its token intentionally lacks the `workflow` scope \u2014 see the triage comments on #166). This PR is that same one-line fix, submitted by a human-run contributor token that does have the scope.

Fixes #166