### PR TITLE
fix(ws): propagate non-conflict errors from persistMixerMutation

### DIFF
--- a/src/__tests__/ws-persist-error-propagation.test.ts
+++ b/src/__tests__/ws-persist-error-propagation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for issue #203 — "persistMixerMutation swallows non-conflict
+ * errors that used to propagate, after #175".
+ *
+ * #175 routed mixer writes through persistMixerMutation, whose catch block
+ * consulted isConflictError only to decide whether to retry. After the retry
+ * loop fell through, EVERY error — 409 conflicts AND non-conflict errors (500s,
+ * socket resets, not_found from db.get) — was logged at warn and swallowed.
+ * Before #175 non-conflict errors propagated to the socket handler's catch-all.
+ *
+ * Fix: re-check the error class after the loop. Exhausted 409s stay swallowed
+ * (the accepted decision); non-conflict errors are re-thrown so they propagate
+ * out of handleMessage exactly as before #175.
+ *
+ * These tests drive a real inbound CUT through handleMessage (the harness from
+ * ws-macro-pip.test.ts) and assert on whether the returned promise rejects.
+ * CouchDB is mocked via vi.mock('../db/index.js').
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+// ---------------------------------------------------------------------------
+// Mock the CouchDB layer. mockGet always succeeds; mockInsert is the seam we
+// drive to reject with either a 409 conflict or a non-conflict error.
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn().mockResolvedValue({ ok: true });
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../routes/productions.js', () => ({
+  updateProductionDoc: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Keep the real tally state machine but drop broadcasts on the floor.
+vi.mock('../services/tally.service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/tally.service.js')>();
+  return {
+    ...actual,
+    broadcast: () => {},
+  };
+});
+
+// ---------------------------------------------------------------------------
+// A throwaway Strom the real StromClient can talk to, so the CUT reaches
+// persistMixerMutation without the transition call itself failing.
+// ---------------------------------------------------------------------------
+
+const stromServer: Server = createServer((_req, res) => {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({ success: true }));
+});
+
+await new Promise<void>((resolve) => {
+  stromServer.listen(0, '127.0.0.1', () => resolve());
+});
+process.env['STROM_URL'] = `http://127.0.0.1:${(stromServer.address() as AddressInfo).port}`;
+
+afterAll(() => {
+  stromServer.close();
+});
+
+const { handleMessage, clearPipState } = await import('../ws/controller.js');
+const { setTally } = await import('../services/tally.service.js');
+
+const PROD = 'prod-203';
+
+function makeProductionDoc() {
+  return {
+    _id: PROD,
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Err Prop Test',
+    status: 'active',
+    stromFlowId: 'flow-1',
+    mixerBlockId: 'mixer-1',
+    sources: [
+      { sourceId: 'cam1', mixerInput: 'video_in_0' },
+      { sourceId: 'cam2', mixerInput: 'video_in_1' },
+    ],
+    pipeline: { stromConfig: null, status: 'running' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: 'video_in_0', pvw: 'video_in_1' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const ws = { send: vi.fn() } as unknown as import('@fastify/websocket').WebSocket;
+
+function conflictError(): Error & { statusCode: number } {
+  const err = new Error('Document update conflict') as Error & { statusCode: number };
+  err.statusCode = 409;
+  return err;
+}
+
+function serverError(): Error & { statusCode: number } {
+  const err = new Error('Internal Server Error') as Error & { statusCode: number };
+  err.statusCode = 500;
+  return err;
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  clearPipState(PROD);
+  setTally(PROD, { pgm: 'video_in_0', pvw: 'video_in_1' });
+  mockGet.mockReset();
+  mockGet.mockResolvedValue(makeProductionDoc());
+  mockInsert.mockReset();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe('persistMixerMutation error propagation (issue #203)', () => {
+  it('propagates a non-conflict error (500) out of handleMessage', async () => {
+    mockInsert.mockRejectedValue(serverError());
+
+    await expect(
+      handleMessage(PROD, ws, JSON.stringify({ type: 'CUT', mixerInput: 'video_in_1' }), {}),
+    ).rejects.toThrow('Internal Server Error');
+
+    // Retries are conflict-only, so a non-conflict error fails on the first attempt.
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    // A non-conflict error must not be swallowed at warn.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows an exhausted 409 conflict (the accepted decision) without throwing', async () => {
+    mockInsert.mockRejectedValue(conflictError());
+
+    await expect(
+      handleMessage(PROD, ws, JSON.stringify({ type: 'CUT', mixerInput: 'video_in_1' }), {}),
+    ).resolves.toBeUndefined();
+
+    // MAX_DB_WRITE_RETRIES === 3: the write is attempted the full budget.
+    expect(mockInsert).toHaveBeenCalledTimes(3);
+    // The exhausted conflict is deliberately logged at warn and swallowed.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to persist mixer mutation'),
+      expect.objectContaining({ productionId: PROD, action: 'CUT' }),
+      expect.anything(),
+    );
+  });
+});

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -40,8 +40,10 @@ function isConflictError(err: unknown): boolean {
  * fresh `_rev` before each retry, so the change actually lands. `mutate`
  * receives the freshly read doc and returns the updated doc to insert;
  * `updatedAt` is stamped automatically. If every attempt still conflicts the
- * failure is logged at warn (with productionId + action) instead of silently
- * dropped — it is no longer thrown, to keep the mixer broadcast path unchanged.
+ * failure is logged at warn (with productionId + action) and swallowed — a
+ * deliberate decision to keep the mixer broadcast path unchanged. Non-conflict
+ * errors (500s, transport failures, a not_found from the db.get) are NOT
+ * swallowed; they propagate to the socket handler's catch-all as before #175.
  */
 async function persistMixerMutation(
   productionId: string,
@@ -59,14 +61,21 @@ async function persistMixerMutation(
       await db.insert(updated);
       return;
     } catch (err) {
-      // On a revision conflict, loop to re-read the latest _rev and re-apply.
-      if (isConflictError(err) && attempt < MAX_DB_WRITE_RETRIES - 1) continue;
-      console.warn(
-        `[controller] Failed to persist mixer mutation after ${attempt + 1} attempt(s)`,
-        { productionId, action },
-        err,
-      );
-      return;
+      if (isConflictError(err)) {
+        // On a revision conflict, loop to re-read the latest _rev and re-apply.
+        if (attempt < MAX_DB_WRITE_RETRIES - 1) continue;
+        // Exhausted conflict retries: deliberately logged and swallowed to
+        // keep the mixer broadcast path unchanged (accepted decision).
+        console.warn(
+          `[controller] Failed to persist mixer mutation after ${attempt + 1} conflict attempt(s)`,
+          { productionId, action },
+          err,
+        );
+        return;
+      }
+      // Non-conflict errors (500s, socket resets, not_found from db.get, …)
+      // propagate to the socket handler's catch-all, as before #175.
+      throw err;
     }
   }
 }


### PR DESCRIPTION
## Summary

Since #175 routed mixer writes through `persistMixerMutation`, its catch block
consulted `isConflictError` only to decide whether to **retry**. Once the retry
loop fell through, EVERY error was logged at `warn` and swallowed via `return` —
including non-conflict errors (500s, socket resets, a `not_found` from the
`db.get` on the read) that used to propagate to the socket handler's catch-all
(`console.error('[controller] unhandled message error:', err)`) before #175.

Only the exhausted-409 swallow was an accepted decision. Swallowing non-conflict
errors was an unintended regression: the cut is broadcast to clients while the
document does not reflect it, and the operator-facing signal dropped from
`error` to `warn`.

## Changes

- `src/ws/controller.ts`: re-check the error class after the retry loop. Exhausted
  409 conflicts stay logged-at-`warn`-and-swallowed (unchanged, deliberate);
  non-conflict errors are re-thrown so they propagate exactly as before #175.
  Retry-on-conflict behaviour is untouched. Doc comment updated to state the
  non-conflict path explicitly.
- `src/__tests__/ws-persist-error-propagation.test.ts`: new focused test that
  drives a real `CUT` through `handleMessage` (reusing the `ws-macro-pip.test.ts`
  harness) and asserts a non-conflict `500` now rejects out of `handleMessage`
  (attempted once, not logged at `warn`), while an exhausted `409` still resolves
  (attempted `MAX_DB_WRITE_RETRIES` times, logged at `warn`).

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `npx vitest run` — 11 files, 119 tests pass (incl. 2 new)

## Checklist

- [x] Branched from `main`, not committing to `main`
- [x] Non-conflict error propagation restored; exhausted-409 swallow preserved
- [x] Retry-on-conflict behaviour unchanged
- [x] No secrets committed

Closes #203