### PR TITLE
fix(deploy): bind CouchDB port to localhost in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       COUCHDB_USER: ${COUCHDB_USER:-admin}
       COUCHDB_PASSWORD: ${COUCHDB_PASSWORD:?Set COUCHDB_PASSWORD in .env (see .env.example)}
     ports:
-      - "5984:5984"
+      - "127.0.0.1:5984:5984"
     volumes:
       - couchdb_data:/opt/couchdb/data
 


### PR DESCRIPTION
Closes #62

## Summary

Fixes a HIGH security misconfiguration (CVSS 8.2, OWASP A05) where `docker-compose.yml` published CouchDB's `5984` port to `0.0.0.0`, exposing the CouchDB admin API and Fauxton UI (`/_utils`) to the host machine's network. On a cloud host with a misconfigured firewall this is effectively internet-exposed.

## Changes

- `docker-compose.yml`: change the CouchDB port mapping from `"5984:5984"` to `"127.0.0.1:5984:5984"` so the published port binds to loopback only.

The `open-live` container still reaches CouchDB via the Docker internal network (`COUCHDB_URL=http://...@couchdb:5984`), so no application change is required.

## Test Plan

- [x] `pnpm install --frozen-lockfile` — success
- [x] `pnpm run typecheck` — exit 0
- [x] `pnpm run build` — exit 0
- [x] `npx vitest run` — 117 tests passed across 10 files
- [ ] Manual: `docker compose up` then confirm `5984` is no longer reachable from another host on the LAN, while `curl http://127.0.0.1:5984` from the host still works.

## Checklist

- [x] Branched from `main`
- [x] No changes to `.github/workflows/`
- [x] Minimal, scoped change (single line in docker-compose)
- [x] No secrets committed