### PR TITLE
fix(deploy): document required API_KEY for network-accessible deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,32 @@ Copy `.env.example` to `.env` and fill in the values:
 | `CORS_ORIGIN` | Allowed CORS origin (URL of the studio frontend) | `http://localhost:5173` |
 | `STROM_URL` | Base URL of the Strom pipeline engine | `http://localhost:7000` |
 | `STROM_TOKEN` | OSC Personal Access Token for authenticating against an OSC-hosted Strom instance | _(empty — not needed for local Strom)_ |
+| `API_KEY` | Static API key protecting all `/api/v1` routes, the WebSocket controller, and the Swagger UI. **Required for any network-accessible deployment** (see below) | _(empty — routes unauthenticated)_ |
 | `LOG_LEVEL` | Fastify log level (`trace`, `debug`, `info`, `warn`, `error`) | `info` |
 
 > **Never commit `.env`** — it is gitignored. Use `.env.example` as the reference.
+
+### API authentication
+
+All `/api/v1` routes, the WebSocket controller (`/ws/`), and the Swagger UI
+(`/documentation`) are protected by a static API key when `API_KEY` is set. Clients
+must send it as a bearer token:
+
+```
+Authorization: Bearer <API_KEY>
+```
+
+WebSocket clients pass the key via the `?key=<API_KEY>` query parameter on the upgrade
+request, since the browser WebSocket API does not support custom headers.
+
+> **`API_KEY` must be set for any network-accessible deployment.** When `API_KEY` is
+> unset, every API route is unauthenticated — any client that can reach the service can
+> create, modify, delete, and activate productions. The server **refuses to start** when
+> `NODE_ENV=production` and `API_KEY` is unset, and logs a prominent warning otherwise.
+> Leave it unset **only** when running behind a trusted external auth layer (e.g. the OSC
+> reverse proxy). The reference `docker-compose.yml` requires `API_KEY` to be set in your
+> `.env` before the stack will start — generate a strong random value with
+> `openssl rand -base64 32`.
 
 ### Strom authentication
 


### PR DESCRIPTION
Closes #56

## Summary

Completes the remaining remediation item from #56. The docker-compose reference deployment and the production startup guard already require `API_KEY` (added in PR #148), but the README did not document `API_KEY` at all — so operators had no guidance that the API is unauthenticated unless the key is set. This PR documents the requirement so a copy-paste deployment is secured by default.

## Changes

- `README.md`: add `API_KEY` to the environment-variable table, marked **Required for any network-accessible deployment**.
- `README.md`: add an **API authentication** subsection explaining the bearer-token scheme, the WebSocket `?key=` mechanism, the production startup refusal when `API_KEY` is unset, and the docker-compose `API_KEY` requirement (with `openssl rand -base64 32`).

No source/code changes — the auth mechanism, docker-compose `${API_KEY:?...}` requirement, and `NODE_ENV=production` startup guard already exist (PR #148, `src/main.ts`, `src/server.ts`, `docker-compose.yml`, `.env.example`).

## Test Plan

Ran from the repo root:

- `pnpm install --frozen-lockfile` — OK
- `pnpm run typecheck` — OK (no errors)
- `pnpm run build` — OK (no errors)
- `npx vitest run` — 117 passed (10 files)

Docs-only change; TS checks run to confirm no breakage.

## Checklist

- [x] Branched from `main`
- [x] No changes under `.github/workflows/`
- [x] typecheck passes
- [x] build passes
- [x] tests pass
- [x] `Closes #56`