### PR TITLE
fix(validation): add regex validation for dskInput in graphic assignments

### DIFF
--- a/src/__tests__/dsk-input-validation.test.ts
+++ b/src/__tests__/dsk-input-validation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for POST/DELETE /api/v1/productions/:id/graphics `dskInput` validation (issue #61).
+ *
+ * `dskInput` is forwarded verbatim into a Strom flow link `to` field by
+ * flow-generator.ts (`${mixerBlockId}:${assignment.dskInput}`). An unvalidated value
+ * containing a `:` or other unexpected characters corrupts the flow topology sent to
+ * Strom. It must be validated against the `dsk_in_N` pad naming convention (mirroring
+ * `mixerInput`'s `video_in_N` allowlist) so malformed values are rejected with a 400
+ * (via the global ZodError handler) rather than injected into the Strom pipeline.
+ *
+ * CouchDB and the WS controller are mocked — no real services required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../server.js';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+const mockFind = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: mockFind }),
+  getSourcesDb: () => ({ get: mockGet }),
+  getOutputsDb: () => ({ get: mockGet }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// Avoid WS controller startup side effects
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+function makeProductionDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'prod-test-1',
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Test Production',
+    status: 'inactive',
+    sources: [],
+    graphicAssignments: [],
+    pipeline: { stromConfig: null, status: 'stopped' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function postGraphic(payload: Record<string, unknown>) {
+  const doc = makeProductionDoc();
+  mockGet.mockResolvedValue(doc);
+  mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+  const app = await buildServer();
+  return app.inject({
+    method: 'POST',
+    url: '/api/v1/productions/prod-test-1/graphics',
+    payload,
+  });
+}
+
+async function deleteGraphic(dskInput: string) {
+  const doc = makeProductionDoc({
+    graphicAssignments: [{ graphicId: 'gfx-x', dskInput: 'dsk_in_0' }],
+  });
+  mockGet.mockResolvedValue(doc);
+  mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+  const app = await buildServer();
+  return app.inject({
+    method: 'DELETE',
+    url: `/api/v1/productions/prod-test-1/graphics/${encodeURIComponent(dskInput)}`,
+  });
+}
+
+describe('POST /api/v1/productions/:id/graphics — dskInput validation (issue #61)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it('accepts a well-formed dskInput (dsk_in_0)', async () => {
+    const res = await postGraphic({ graphicId: 'gfx-x', dskInput: 'dsk_in_0' });
+    expect(res.statusCode).toBe(201);
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+
+  it('accepts a multi-digit dskInput (dsk_in_12)', async () => {
+    const res = await postGraphic({ graphicId: 'gfx-x', dskInput: 'dsk_in_12' });
+    expect(res.statusCode).toBe(201);
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a dskInput with an injected pad separator (dsk_in_0:injected_pad)', async () => {
+    const res = await postGraphic({ graphicId: 'gfx-x', dskInput: 'dsk_in_0:injected_pad' });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('Validation error');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a dskInput with unexpected characters', async () => {
+    const res = await postGraphic({ graphicId: 'gfx-x', dskInput: 'dsk_in_0; drop-block' });
+    expect(res.statusCode).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a dskInput that does not match the dsk_in_N convention', async () => {
+    const res = await postGraphic({ graphicId: 'gfx-x', dskInput: 'arbitrary_string' });
+    expect(res.statusCode).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long dskInput (max 20 chars)', async () => {
+    const res = await postGraphic({ graphicId: 'gfx-x', dskInput: `dsk_in_${'9'.repeat(30)}` });
+    expect(res.statusCode).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/v1/productions/:id/graphics/:dskInput — dskInput validation (issue #61)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+  });
+
+  it('removes an assignment for a well-formed dskInput', async () => {
+    const res = await deleteGraphic('dsk_in_0');
+    expect(res.statusCode).toBe(204);
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a malformed dskInput path param with 400', async () => {
+    const res = await deleteGraphic('dsk_in_0:injected_pad');
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('Invalid dskInput format');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -370,6 +370,13 @@ const ProductionPatch = z.object({
 // mixerInput must match the Strom pad naming convention (e.g. "video_in_0", "video_in_15")
 const mixerInputSchema = z.string().regex(/^video_in_\d{1,2}$/, 'mixerInput must match video_in_N format').max(20);
 
+// dskInput must match the Strom DSK pad naming convention (e.g. "dsk_in_0"). It is
+// forwarded verbatim into a Strom flow link `to` field by flow-generator.ts
+// (`${mixerBlockId}:${assignment.dskInput}`), so an unvalidated value containing a
+// `:` or other unexpected characters corrupts the flow topology (issue #61). Mirror
+// the mixerInput allowlist so only well-formed pad names reach the Strom pipeline.
+const dskInputSchema = z.string().regex(/^dsk_in_\d+$/, 'dskInput must match dsk_in_N format').max(20);
+
 const SourceAssignmentInput = z.object({
   sourceId: z.string().min(1).max(128),
   mixerInput: mixerInputSchema,
@@ -377,7 +384,7 @@ const SourceAssignmentInput = z.object({
 
 const GraphicAssignmentInput = z.object({
   graphicId: z.string().min(1),
-  dskInput: z.string().min(1),
+  dskInput: dskInputSchema,
 });
 
 const OutputAssignmentInput = z.object({
@@ -717,6 +724,10 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.delete<{ Params: { id: string; dskInput: string } }>(
     '/api/v1/productions/:id/graphics/:dskInput',
     async (req, reply) => {
+      const dskInputParsed = dskInputSchema.safeParse(req.params.dskInput);
+      if (!dskInputParsed.success) {
+        return reply.status(400).send({ error: 'Invalid dskInput format', statusCode: 400 });
+      }
       try {
         const doc = await getDb().get(req.params.id);
         const exists = (doc.graphicAssignments ?? []).some((g) => g.dskInput === req.params.dskInput);


### PR DESCRIPTION
Closes #61

## Summary

`GraphicAssignmentInput` validated `dskInput` as `z.string().min(1)` — any non-empty string. That value is forwarded verbatim into a Strom flow link `to` field by `flow-generator.ts` (`{ from: fmtId+':video_out', to: mixerBlockId+':'+assignment.dskInput }`). A `dskInput` containing a `:` or other unexpected characters corrupts the flow topology sent to Strom, and the internal `/dsk_in_(\d+)$/` extraction silently skips non-matching values (`dskIndex = NaN`), masking the error (OWASP A03 — Injection, CVSS 4.9 Medium).

This mirrors the existing tight validation used for the sibling `mixerInput` field (`/^video_in_\d{1,2}$/`).

## Changes

- `src/routes/productions.ts`: added `dskInputSchema = z.string().regex(/^dsk_in_\d+$/).max(20)` and used it in `GraphicAssignmentInput` so malformed values are rejected with a 400 via the global ZodError handler instead of reaching the Strom pipeline.
- `src/routes/productions.ts`: the `DELETE /api/v1/productions/:id/graphics/:dskInput` route now `safeParse`s the path param against the same schema (returning `400 Invalid dskInput format`), matching the existing `DELETE .../sources/:mixerInput` pattern.
- `src/__tests__/dsk-input-validation.test.ts`: new vitest suite covering accepted well-formed values and rejected malicious/malformed input for both POST and DELETE.

## Allowed format

`dskInput` must match `^dsk_in_\d+$` (e.g. `dsk_in_0`, `dsk_in_12`), max 20 chars.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `npx vitest run` — 11 files / 125 tests passing, including the new suite

## Checklist

- [x] Branched from `main`
- [x] No changes to `.github/workflows/`
- [x] Minimal change consistent with the existing Zod validation pattern (mirrors `mixerInput`)
- [x] New tests cover valid-accepted and malicious-rejected cases