### PR TITLE
Add pollable source providers and an open-weave source provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Copy `.env.example` to `.env` and fill in the values:
 | `STROM_TOKEN` | OSC Personal Access Token for authenticating against an OSC-hosted Strom instance | _(empty — not needed for local Strom)_ |
 | `API_KEY` | Static API key protecting all `/api/v1` routes, the WebSocket controller, and the Swagger UI. **Required for any network-accessible deployment** (see below) | _(empty — routes unauthenticated)_ |
 | `LOG_LEVEL` | Fastify log level (`trace`, `debug`, `info`, `warn`, `error`) | `info` |
+| `SOURCE_PROVIDERS` | Comma-separated ids of [source providers](#source-providers) to poll. Unknown ids fail startup. | _(empty — disabled)_ |
+| `SOURCE_PROVIDER_POLL_MS` | Interval between source provider polls, in milliseconds | `5000` |
 
 > **Never commit `.env`** — it is gitignored. Use `.env.example` as the reference.
 
@@ -148,6 +150,12 @@ broadcasts — is documented separately in [`docs/controller-websocket.md`](docs
 Sources represent individual video/audio feeds. Each source has a `streamType` (`srt` or `whip`) and an `address` (SRT URI or WHIP endpoint URL).
 
 SRT passphrases are embedded in the source `address` and encrypted at rest before being stored in CouchDB. For rotating a passphrase or responding to a suspected compromise, see the operator runbook in [`docs/srt-passphrase-rotation.md`](docs/srt-passphrase-rotation.md).
+
+### Source providers
+
+A source provider is a small module under `src/providers/` that lists source candidates produced by another system. The server polls every provider named in `SOURCE_PROVIDERS` and materialises the candidates as ordinary sources, so assignment, activation and the studio UI need no knowledge of where a source came from.
+
+Provider-owned sources carry a `provider` object (`{ id, externalId, syncedAt }`) and `readOnly: true` in API responses. `PATCH` and `DELETE` on them return `409`. A source that the provider stops listing is marked `inactive` rather than deleted, so a production that still references it keeps its assignment.
 
 ### Template model
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Copy `.env.example` to `.env` and fill in the values:
 | `LOG_LEVEL` | Fastify log level (`trace`, `debug`, `info`, `warn`, `error`) | `info` |
 | `SOURCE_PROVIDERS` | Comma-separated ids of [source providers](#source-providers) to poll. Unknown ids fail startup. | _(empty — disabled)_ |
 | `SOURCE_PROVIDER_POLL_MS` | Interval between source provider polls, in milliseconds | `5000` |
+| `WEAVE_NORTHBOUND_URL` | Base URL of the open-weave northbound API (e.g. `http://localhost:29080`). Required when `weave` is in `SOURCE_PROVIDERS`. | _(unset)_ |
+| `WEAVE_NORTHBOUND_TOKEN` | Bearer token for the open-weave northbound API. Required when `weave` is in `SOURCE_PROVIDERS`. | _(unset)_ |
 
 > **Never commit `.env`** — it is gitignored. Use `.env.example` as the reference.
 
@@ -156,6 +158,21 @@ SRT passphrases are embedded in the source `address` and encrypted at rest befor
 A source provider is a small module under `src/providers/` that lists source candidates produced by another system. The server polls every provider named in `SOURCE_PROVIDERS` and materialises the candidates as ordinary sources, so assignment, activation and the studio UI need no knowledge of where a source came from.
 
 Provider-owned sources carry a `provider` object (`{ id, externalId, syncedAt }`) and `readOnly: true` in API responses. `PATCH` and `DELETE` on them return `409`. A source that the provider stops listing is marked `inactive` rather than deleted, so a production that still references it keeps its assignment.
+
+Available providers:
+
+| Id | System | Configuration |
+|---|---|---|
+| `weave` | [open-weave](https://github.com/Eyevinn/open-weave) | `WEAVE_NORTHBOUND_URL`, `WEAVE_NORTHBOUND_TOKEN` |
+
+The `weave` provider lists every enabled stream on the northbound API and offers each placed, node-hosted output as an SRT source with `?mode=caller` appended, which is the address open-live's `builtin.mpegtssrt_input` block dials. Outputs that weave dials out to (remote destinations) and streams that are not yet placed are skipped. The matching destination's declared SRT latency is carried onto the source, so the input block and the vision mixer's `min_upstream_latency` agree with what weave configured; a value outside the 20–8000 ms the REST schema allows is ignored in favour of the default.
+
+```bash
+SOURCE_PROVIDERS=weave \
+WEAVE_NORTHBOUND_URL=http://localhost:29080 \
+WEAVE_NORTHBOUND_TOKEN=<token> \
+pnpm dev
+```
 
 ### Template model
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Copy `.env.example` to `.env` and fill in the values:
 | `SOURCE_PROVIDERS` | Comma-separated ids of [source providers](#source-providers) to poll. Unknown ids fail startup. | _(empty — disabled)_ |
 | `SOURCE_PROVIDER_POLL_MS` | Interval between source provider polls, in milliseconds | `5000` |
 | `SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS` | Set to `true` to accept provider-listed SRT addresses on private, loopback or link-local hosts. See [source providers](#source-providers). | `false` |
+| `SOURCE_PROVIDER_ALLOWED_HOSTS` | Comma-separated hostnames, IPs and CIDR blocks a provider may name (e.g. `10.42.0.0/16`). When set, any other host is skipped and `SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS` is not consulted. See [source providers](#source-providers). | _(empty — not enforced)_ |
 | `WEAVE_NORTHBOUND_URL` | Base URL of the open-weave northbound API (e.g. `http://localhost:29080`). Required when `weave` is in `SOURCE_PROVIDERS`. | _(unset)_ |
 | `WEAVE_NORTHBOUND_TOKEN` | Bearer token for the open-weave northbound API. Required when `weave` is in `SOURCE_PROVIDERS`. | _(unset)_ |
 
@@ -162,6 +163,14 @@ Provider-owned sources carry a `provider` object (`{ id, externalId, syncedAt }`
 
 `srtUrl()` rejects private, loopback and link-local hosts so a source address in a request body cannot make the pipeline dial internal services. A provider that places media on a container or cluster network lists RFC1918 addresses for every source — open-weave puts its SRT outputs on a node subnet — so the rule would reject all of them. `SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS=true` waives it for provider-listed addresses only, which do not come from a request. The REST routes keep the rule unconditionally.
 
+`SOURCE_PROVIDER_ALLOWED_HOSTS` is the tighter control and is what a deployment should prefer. It names the hostnames, IPs and CIDR blocks a provider is allowed to place sources on:
+
+```bash
+SOURCE_PROVIDER_ALLOWED_HOSTS=10.42.0.0/16,weave-1.internal
+```
+
+When it is set, a candidate whose host is not on the list is skipped and `SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS` is not consulted — the list already says which private hosts are acceptable. It also bounds candidates the private-host rule never looked at: a provider that starts returning `srt://attacker.example.com:9000` passes the SSRF rule, because that rule only rejects private IP literals, but fails the allow-list. Since the list comes from the operator rather than from the provider's own response, it is the part of provider validation a misbehaving provider cannot influence. A malformed entry fails at startup rather than silently matching nothing.
+
 Available providers:
 
 | Id | System | Configuration |
@@ -172,7 +181,7 @@ The `weave` provider lists every enabled stream on the northbound API and offers
 
 ```bash
 SOURCE_PROVIDERS=weave \
-SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS=true \
+SOURCE_PROVIDER_ALLOWED_HOSTS=10.42.0.0/16 \
 WEAVE_NORTHBOUND_URL=http://localhost:29080 \
 WEAVE_NORTHBOUND_TOKEN=<token> \
 pnpm dev

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Copy `.env.example` to `.env` and fill in the values:
 | `LOG_LEVEL` | Fastify log level (`trace`, `debug`, `info`, `warn`, `error`) | `info` |
 | `SOURCE_PROVIDERS` | Comma-separated ids of [source providers](#source-providers) to poll. Unknown ids fail startup. | _(empty — disabled)_ |
 | `SOURCE_PROVIDER_POLL_MS` | Interval between source provider polls, in milliseconds | `5000` |
+| `SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS` | Set to `true` to accept provider-listed SRT addresses on private, loopback or link-local hosts. See [source providers](#source-providers). | `false` |
 | `WEAVE_NORTHBOUND_URL` | Base URL of the open-weave northbound API (e.g. `http://localhost:29080`). Required when `weave` is in `SOURCE_PROVIDERS`. | _(unset)_ |
 | `WEAVE_NORTHBOUND_TOKEN` | Bearer token for the open-weave northbound API. Required when `weave` is in `SOURCE_PROVIDERS`. | _(unset)_ |
 
@@ -159,6 +160,8 @@ A source provider is a small module under `src/providers/` that lists source can
 
 Provider-owned sources carry a `provider` object (`{ id, externalId, syncedAt }`) and `readOnly: true` in API responses. `PATCH` and `DELETE` on them return `409`. A source that the provider stops listing is marked `inactive` rather than deleted, so a production that still references it keeps its assignment.
 
+`srtUrl()` rejects private, loopback and link-local hosts so a source address in a request body cannot make the pipeline dial internal services. A provider that places media on a container or cluster network lists RFC1918 addresses for every source — open-weave puts its SRT outputs on a node subnet — so the rule would reject all of them. `SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS=true` waives it for provider-listed addresses only, which do not come from a request. The REST routes keep the rule unconditionally.
+
 Available providers:
 
 | Id | System | Configuration |
@@ -169,6 +172,7 @@ The `weave` provider lists every enabled stream on the northbound API and offers
 
 ```bash
 SOURCE_PROVIDERS=weave \
+SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS=true \
 WEAVE_NORTHBOUND_URL=http://localhost:29080 \
 WEAVE_NORTHBOUND_TOKEN=<token> \
 pnpm dev

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -79,12 +79,33 @@ components:
           minimum: 20
           maximum: 8000
           description: SRT latency in milliseconds
+        provider:
+          $ref: '#/components/schemas/SourceProviderRef'
+        readOnly:
+          type: boolean
+          description: Present and true when a source provider owns this source; PATCH and DELETE return 409.
         createdAt:
           type: string
           format: date-time
         updatedAt:
           type: string
           format: date-time
+
+    SourceProviderRef:
+      type: object
+      required: [id, externalId, syncedAt]
+      description: Identifies the source provider that created and maintains this source.
+      properties:
+        id:
+          type: string
+          description: Provider id, e.g. `weave`
+        externalId:
+          type: string
+          description: The provider's own identifier for the source
+        syncedAt:
+          type: string
+          format: date-time
+          description: When the provider last wrote this document
 
     SourceInput:
       type: object
@@ -686,6 +707,12 @@ paths:
                 $ref: '#/components/schemas/Source'
         '404':
           description: Not found
+        '409':
+          description: Source is managed by a source provider and cannot be edited
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     delete:
       summary: Delete source
       operationId: deleteSource
@@ -695,6 +722,12 @@ paths:
           description: Deleted
         '404':
           description: Not found
+        '409':
+          description: Source is in use by an active production, or is managed by a source provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   # ── Graphics ─────────────────────────────────────────────────────────────────
 

--- a/src/__tests__/providers-registry.test.ts
+++ b/src/__tests__/providers-registry.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the source provider registry: reconciling provider candidates into
+ * provider-owned SourceDocs. CouchDB is mocked; no services required.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FastifyBaseLogger } from 'fastify';
+import { providerSourceId, syncProvider, startSourceProviderSync } from '../providers/registry.js';
+import type { ProviderSource, SourceProvider } from '../providers/types.js';
+import { resetKeyCache } from '../lib/srt-passphrase-crypto.js';
+
+const mockFind = vi.fn();
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+const mockIsDbConnected = vi.fn().mockReturnValue(true);
+
+vi.mock('../db/index.js', () => ({
+  getSourcesDb: () => ({ find: mockFind, get: mockGet, insert: mockInsert }),
+  isDbConnected: () => mockIsDbConnected(),
+}));
+
+const log = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+function fakeProvider(list: () => Promise<ProviderSource[]>, id = 'fake'): SourceProvider {
+  return { id, list };
+}
+
+const basic: ProviderSource = {
+  externalId: 'basic/0',
+  name: 'basic',
+  streamType: 'srt',
+  address: 'srt://172.27.0.10:20003?mode=caller',
+  status: 'active',
+};
+
+function storedDoc(candidate: ProviderSource, overrides: Record<string, unknown> = {}) {
+  return {
+    _id: providerSourceId('fake', candidate.externalId),
+    _rev: '1-abc',
+    type: 'source',
+    name: candidate.name,
+    address: candidate.address,
+    streamType: candidate.streamType,
+    status: candidate.status ?? 'active',
+    latency: candidate.latency,
+    provider: { id: 'fake', externalId: candidate.externalId, syncedAt: '2026-09-01T00:00:00.000Z' },
+    createdAt: '2026-09-01T00:00:00.000Z',
+    updatedAt: '2026-09-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDbConnected.mockReturnValue(true);
+  mockFind.mockResolvedValue({ docs: [] });
+  mockInsert.mockResolvedValue({ ok: true, id: 'x', rev: '2-def' });
+});
+
+describe('providerSourceId', () => {
+  it('slugs the external id and prefixes it with the provider', () => {
+    expect(providerSourceId('weave', 'basic/0')).toBe('src-ext-weave-basic-0');
+    expect(providerSourceId('weave', 'Studio Cam #2')).toBe('src-ext-weave-studio-cam-2');
+  });
+
+  it('stays within the 128-character source id cap', () => {
+    const id = providerSourceId('weave', 'x'.repeat(300));
+    expect(id.length).toBeLessThanOrEqual(128);
+    expect(id.startsWith('src-ext-weave-')).toBe(true);
+  });
+});
+
+describe('syncProvider', () => {
+  it('creates a provider-owned doc for each new candidate', async () => {
+    const second: ProviderSource = { ...basic, externalId: 'fanout/1', name: 'fanout (node-2)', address: 'srt://172.27.0.10:20004?mode=caller' };
+    const result = await syncProvider(fakeProvider(async () => [basic, second]), log);
+
+    expect(result).toMatchObject({ created: 2, updated: 0, deactivated: 0, skipped: [] });
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+    const first = mockInsert.mock.calls[0][0];
+    expect(first).toMatchObject({
+      _id: 'src-ext-fake-basic-0',
+      type: 'source',
+      name: 'basic',
+      address: basic.address,
+      streamType: 'srt',
+      status: 'active',
+      provider: { id: 'fake', externalId: 'basic/0' },
+    });
+    expect(first._rev).toBeUndefined();
+    expect(typeof first.provider.syncedAt).toBe('string');
+    expect(first.createdAt).toBe(first.updatedAt);
+    expect(mockInsert.mock.calls[1][0]._id).toBe('src-ext-fake-fanout-1');
+    expect(mockFind).toHaveBeenCalledWith({ selector: { type: 'source', 'provider.id': 'fake' } });
+  });
+
+  it('defaults status to active when the candidate leaves it unset', async () => {
+    const { status: _status, ...noStatus } = basic;
+    await syncProvider(fakeProvider(async () => [noStatus]), log);
+    expect(mockInsert.mock.calls[0][0].status).toBe('active');
+  });
+
+  it('writes nothing when the stored doc already matches', async () => {
+    mockFind.mockResolvedValue({ docs: [storedDoc(basic)] });
+    const result = await syncProvider(fakeProvider(async () => [basic]), log);
+
+    expect(result).toMatchObject({ created: 0, updated: 0, deactivated: 0 });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('updates the existing doc in place when the address changes', async () => {
+    const stored = storedDoc(basic);
+    mockFind.mockResolvedValue({ docs: [stored] });
+    const moved = { ...basic, address: 'srt://172.27.0.11:20005?mode=caller' };
+    const result = await syncProvider(fakeProvider(async () => [moved]), log);
+
+    expect(result).toMatchObject({ created: 0, updated: 1, deactivated: 0 });
+    const written = mockInsert.mock.calls[0][0];
+    expect(written._id).toBe(stored._id);
+    expect(written._rev).toBe(stored._rev);
+    expect(written.address).toBe(moved.address);
+    expect(written.createdAt).toBe(stored.createdAt);
+    expect(written.updatedAt).not.toBe(stored.updatedAt);
+    expect(written.provider.syncedAt).not.toBe(stored.provider.syncedAt);
+  });
+
+  it('marks a provider-owned doc inactive when its candidate vanishes, but keeps it', async () => {
+    const stored = storedDoc(basic);
+    mockFind.mockResolvedValue({ docs: [stored] });
+    const result = await syncProvider(fakeProvider(async () => []), log);
+
+    expect(result).toMatchObject({ created: 0, updated: 0, deactivated: 1 });
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const written = mockInsert.mock.calls[0][0];
+    expect(written).toMatchObject({ _id: stored._id, _rev: stored._rev, status: 'inactive', name: 'basic' });
+  });
+
+  it('does not rewrite a doc that is already inactive', async () => {
+    mockFind.mockResolvedValue({ docs: [storedDoc(basic, { status: 'inactive' })] });
+    await syncProvider(fakeProvider(async () => []), log);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('reactivates a doc when its candidate is listed again', async () => {
+    mockFind.mockResolvedValue({ docs: [storedDoc(basic, { status: 'inactive' })] });
+    const result = await syncProvider(fakeProvider(async () => [basic]), log);
+    expect(result.updated).toBe(1);
+    expect(mockInsert.mock.calls[0][0].status).toBe('active');
+  });
+
+  it('leaves docs untouched and rethrows when the provider fails', async () => {
+    mockFind.mockResolvedValue({ docs: [storedDoc(basic)] });
+    await expect(
+      syncProvider(fakeProvider(async () => { throw new Error('northbound unreachable'); }), log),
+    ).rejects.toThrow('northbound unreachable');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('retries once on a 409 revision conflict using the re-read doc', async () => {
+    const stored = storedDoc(basic);
+    mockFind.mockResolvedValue({ docs: [stored] });
+    const conflict = Object.assign(new Error('Document update conflict'), { statusCode: 409 });
+    mockInsert.mockRejectedValueOnce(conflict);
+    mockGet.mockResolvedValue({ ...stored, _rev: '5-newer' });
+    const moved = { ...basic, name: 'basic renamed' };
+
+    const result = await syncProvider(fakeProvider(async () => [moved]), log);
+
+    expect(result.updated).toBe(1);
+    expect(mockGet).toHaveBeenCalledWith(stored._id);
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+    expect(mockInsert.mock.calls[1][0]).toMatchObject({ _rev: '5-newer', name: 'basic renamed' });
+  });
+
+  it('skips candidates with an invalid SRT address or a duplicate externalId', async () => {
+    const bad = { ...basic, externalId: 'bad/0', address: 'http://not-srt.example' };
+    const result = await syncProvider(fakeProvider(async () => [basic, bad, basic]), log);
+
+    expect(result.created).toBe(1);
+    expect(result.skipped).toEqual([
+      { externalId: 'bad/0', reason: 'Invalid SRT URL format — expected srt://host:port or srt://:port with safe query params' },
+      { externalId: 'basic/0', reason: 'duplicate externalId' },
+    ]);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  describe('with SRT_PASSPHRASE_KEY set', () => {
+    beforeEach(() => {
+      vi.stubEnv('SRT_PASSPHRASE_KEY', Buffer.alloc(32, 7).toString('base64'));
+      resetKeyCache();
+    });
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      resetKeyCache();
+    });
+
+    it('stores the passphrase encrypted and compares against the decrypted form', async () => {
+      const secret = { ...basic, address: 'srt://172.27.0.10:20003?passphrase=hunter22&mode=caller' };
+      await syncProvider(fakeProvider(async () => [secret]), log);
+
+      const stored = mockInsert.mock.calls[0][0];
+      expect(stored.address).toMatch(/passphrase=encv1:/);
+      expect(stored.address).not.toContain('hunter22');
+
+      mockInsert.mockClear();
+      mockFind.mockResolvedValue({ docs: [{ ...stored, _rev: '1-abc' }] });
+      const result = await syncProvider(fakeProvider(async () => [secret]), log);
+      expect(result).toMatchObject({ created: 0, updated: 0, deactivated: 0 });
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('startSourceProviderSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function runTick() {
+    await vi.advanceTimersByTimeAsync(1000);
+  }
+
+  it('logs a failing provider once, then once more on recovery', async () => {
+    let fail = true;
+    const provider = fakeProvider(async () => {
+      if (fail) throw new Error('boom');
+      return [basic];
+    });
+    const stop = startSourceProviderSync([provider], log, 1000);
+
+    await runTick();
+    await runTick();
+    await runTick();
+    expect(log.error).toHaveBeenCalledTimes(1);
+    expect(mockInsert).not.toHaveBeenCalled();
+
+    fail = false;
+    await runTick();
+    expect(vi.mocked(log.info).mock.calls.some(([, msg]) => msg === '[providers] Sync recovered')).toBe(true);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+
+    stop();
+    const insertsAfterStop = mockInsert.mock.calls.length;
+    await runTick();
+    await runTick();
+    expect(mockInsert).toHaveBeenCalledTimes(insertsAfterStop);
+  });
+
+  it('skips the pass while the database is not connected', async () => {
+    mockIsDbConnected.mockReturnValue(false);
+    const list = vi.fn(async () => [basic]);
+    const stop = startSourceProviderSync([fakeProvider(list)], log, 1000);
+    await runTick();
+    expect(list).not.toHaveBeenCalled();
+    stop();
+  });
+});

--- a/src/__tests__/providers-registry.test.ts
+++ b/src/__tests__/providers-registry.test.ts
@@ -266,6 +266,62 @@ describe('syncProvider', () => {
     });
   });
 
+  describe('SOURCE_PROVIDER_ALLOWED_HOSTS', () => {
+    const onSubnet = { ...basic, address: 'srt://10.42.7.9:20003?mode=caller' };
+    const offSubnet = { ...basic, address: 'srt://10.99.7.9:20003?mode=caller' };
+    const publicHost = { ...basic, address: 'srt://attacker.example.com:9000?mode=caller' };
+
+    async function syncWith(
+      allowed: string,
+      candidate: ProviderSource,
+      allowPrivate = '',
+    ): Promise<import('../providers/registry.js').SyncResult> {
+      vi.resetModules();
+      vi.stubEnv('SOURCE_PROVIDER_ALLOWED_HOSTS', allowed);
+      vi.stubEnv('SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS', allowPrivate);
+      const { syncProvider: sync } = await import('../providers/registry.js');
+      return sync(fakeProvider(async () => [candidate]), log);
+    }
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
+    it('accepts an address inside the listed subnet without the private-host waiver', async () => {
+      const result = await syncWith('10.42.0.0/16', onSubnet);
+
+      expect(result.skipped).toEqual([]);
+      expect(result.created).toBe(1);
+    });
+
+    it('skips an address outside the listed subnet', async () => {
+      const result = await syncWith('10.42.0.0/16', offSubnet);
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toEqual([
+        { externalId: 'basic/0', reason: 'SRT URL host "10.99.7.9" is not in the configured host allow-list' },
+      ]);
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it('skips a public host a provider starts returning, which no private-host rule would catch', async () => {
+      expect((await syncWith('', publicHost)).created).toBe(1);
+      expect((await syncWith('10.42.0.0/16', publicHost)).created).toBe(0);
+    });
+
+    it('bounds the private-host waiver instead of stacking with it', async () => {
+      expect((await syncWith('', offSubnet, 'true')).created).toBe(1);
+      expect((await syncWith('10.42.0.0/16', offSubnet, 'true')).created).toBe(0);
+    });
+
+    it('fails at startup on a malformed entry rather than matching nothing', async () => {
+      vi.resetModules();
+      vi.stubEnv('SOURCE_PROVIDER_ALLOWED_HOSTS', '10.42.0.0/64');
+      await expect(import('../providers/registry.js')).rejects.toThrow(/prefix length/);
+    });
+  });
+
   describe('with SRT_PASSPHRASE_KEY set', () => {
     beforeEach(() => {
       vi.stubEnv('SRT_PASSPHRASE_KEY', Buffer.alloc(32, 7).toString('base64'));

--- a/src/__tests__/providers-registry.test.ts
+++ b/src/__tests__/providers-registry.test.ts
@@ -189,17 +189,38 @@ describe('syncProvider', () => {
     expect(mockInsert).toHaveBeenCalledTimes(1);
   });
 
+  it('skips a whip candidate whose address is not a safe http(s) URL', async () => {
+    const whip = { ...basic, externalId: 'whip/0', streamType: 'whip' as const, address: 'srt://203.0.113.10:20003' };
+    const result = await syncProvider(fakeProvider(async () => [whip]), log);
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toEqual([
+      { externalId: 'whip/0', reason: 'Disallowed URL scheme "srt:" — only http/https allowed' },
+    ]);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('accepts a whip candidate on a public https endpoint', async () => {
+    const whip = { ...basic, externalId: 'whip/0', streamType: 'whip' as const, address: 'https://ingest.example.com/whip/1' };
+    const result = await syncProvider(fakeProvider(async () => [whip]), log);
+
+    expect(result.skipped).toEqual([]);
+    expect(result.created).toBe(1);
+    expect(mockInsert.mock.calls[0][0]).toMatchObject({ streamType: 'whip' });
+  });
+
   describe('private provider addresses', () => {
     // A provider that places media on a container or cluster network lists
     // RFC1918 addresses for every source, which srtUrl() rejects by default.
     const priv = { ...basic, address: 'srt://172.27.0.10:20003?mode=caller' };
+    const privWhip = { ...basic, streamType: 'whip' as const, address: 'http://172.27.0.10:8080/whip/1' };
 
-    async function syncWith(flag: string | undefined): Promise<import('../providers/registry.js').SyncResult> {
+    async function syncWith(flag: string | undefined, candidate: ProviderSource = priv): Promise<import('../providers/registry.js').SyncResult> {
       vi.resetModules();
       if (flag === undefined) vi.stubEnv('SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS', '');
       else vi.stubEnv('SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS', flag);
       const { syncProvider: sync } = await import('../providers/registry.js');
-      return sync(fakeProvider(async () => [priv]), log);
+      return sync(fakeProvider(async () => [candidate]), log);
     }
 
     afterEach(() => {
@@ -223,6 +244,20 @@ describe('syncProvider', () => {
       expect(result.skipped).toEqual([]);
       expect(result.created).toBe(1);
       expect(mockInsert.mock.calls[0][0].address).toBe('srt://172.27.0.10:20003?mode=caller');
+    });
+
+    it('applies the same flag to whip candidates', async () => {
+      expect((await syncWith(undefined, privWhip)).skipped).toEqual([
+        { externalId: 'basic/0', reason: 'URL hostname "172.27.0.10" is in a private/reserved IP range — SSRF blocked' },
+      ]);
+      expect((await syncWith('true', privWhip)).created).toBe(1);
+    });
+
+    it('keeps blocking the cloud metadata hostname even with the flag on', async () => {
+      const metadata = { ...basic, streamType: 'whip' as const, address: 'http://metadata.google.internal/whip/1' };
+      expect((await syncWith('true', metadata)).skipped).toEqual([
+        { externalId: 'basic/0', reason: 'URL hostname "metadata.google.internal" is not allowed — SSRF blocked' },
+      ]);
     });
 
     it('treats any other value as off', async () => {

--- a/src/__tests__/providers-registry.test.ts
+++ b/src/__tests__/providers-registry.test.ts
@@ -34,7 +34,7 @@ const basic: ProviderSource = {
   externalId: 'basic/0',
   name: 'basic',
   streamType: 'srt',
-  address: 'srt://172.27.0.10:20003?mode=caller',
+  address: 'srt://203.0.113.10:20003?mode=caller',
   status: 'active',
 };
 
@@ -77,7 +77,7 @@ describe('providerSourceId', () => {
 
 describe('syncProvider', () => {
   it('creates a provider-owned doc for each new candidate', async () => {
-    const second: ProviderSource = { ...basic, externalId: 'fanout/1', name: 'fanout (node-2)', address: 'srt://172.27.0.10:20004?mode=caller' };
+    const second: ProviderSource = { ...basic, externalId: 'fanout/1', name: 'fanout (node-2)', address: 'srt://203.0.113.10:20004?mode=caller' };
     const result = await syncProvider(fakeProvider(async () => [basic, second]), log);
 
     expect(result).toMatchObject({ created: 2, updated: 0, deactivated: 0, skipped: [] });
@@ -116,7 +116,7 @@ describe('syncProvider', () => {
   it('updates the existing doc in place when the address changes', async () => {
     const stored = storedDoc(basic);
     mockFind.mockResolvedValue({ docs: [stored] });
-    const moved = { ...basic, address: 'srt://172.27.0.11:20005?mode=caller' };
+    const moved = { ...basic, address: 'srt://203.0.113.11:20005?mode=caller' };
     const result = await syncProvider(fakeProvider(async () => [moved]), log);
 
     expect(result).toMatchObject({ created: 0, updated: 1, deactivated: 0 });
@@ -189,6 +189,48 @@ describe('syncProvider', () => {
     expect(mockInsert).toHaveBeenCalledTimes(1);
   });
 
+  describe('private provider addresses', () => {
+    // A provider that places media on a container or cluster network lists
+    // RFC1918 addresses for every source, which srtUrl() rejects by default.
+    const priv = { ...basic, address: 'srt://172.27.0.10:20003?mode=caller' };
+
+    async function syncWith(flag: string | undefined): Promise<import('../providers/registry.js').SyncResult> {
+      vi.resetModules();
+      if (flag === undefined) vi.stubEnv('SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS', '');
+      else vi.stubEnv('SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS', flag);
+      const { syncProvider: sync } = await import('../providers/registry.js');
+      return sync(fakeProvider(async () => [priv]), log);
+    }
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
+    it('skips them by default, leaving upstream\'s SSRF rule in force', async () => {
+      const result = await syncWith(undefined);
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toEqual([
+        { externalId: 'basic/0', reason: 'SRT URL must not target private, loopback, or link-local addresses' },
+      ]);
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it('accepts them when SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS is true', async () => {
+      const result = await syncWith('true');
+
+      expect(result.skipped).toEqual([]);
+      expect(result.created).toBe(1);
+      expect(mockInsert.mock.calls[0][0].address).toBe('srt://172.27.0.10:20003?mode=caller');
+    });
+
+    it('treats any other value as off', async () => {
+      expect((await syncWith('1')).created).toBe(0);
+      expect((await syncWith('yes')).created).toBe(0);
+    });
+  });
+
   describe('with SRT_PASSPHRASE_KEY set', () => {
     beforeEach(() => {
       vi.stubEnv('SRT_PASSPHRASE_KEY', Buffer.alloc(32, 7).toString('base64'));
@@ -200,7 +242,7 @@ describe('syncProvider', () => {
     });
 
     it('stores the passphrase encrypted and compares against the decrypted form', async () => {
-      const secret = { ...basic, address: 'srt://172.27.0.10:20003?passphrase=hunter22&mode=caller' };
+      const secret = { ...basic, address: 'srt://203.0.113.10:20003?passphrase=hunter22&mode=caller' };
       await syncProvider(fakeProvider(async () => [secret]), log);
 
       const stored = mockInsert.mock.calls[0][0];

--- a/src/__tests__/providers-weave.test.ts
+++ b/src/__tests__/providers-weave.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the open-weave source provider. `fetch` is injected; no services required.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createWeaveProvider, weaveProviderFromEnv } from '../providers/weave.js';
+import { createSourceProviders } from '../providers/index.js';
+
+type Route = { status: number; body?: unknown };
+
+function fakeFetch(routes: Record<string, Route>) {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  const impl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init });
+    const route = routes[url.replace('http://weave.test', '')];
+    if (!route) return new Response('not routed', { status: 500 });
+    return new Response(route.body === undefined ? '' : JSON.stringify(route.body), {
+      status: route.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+  return { impl: impl as unknown as typeof fetch, calls };
+}
+
+function provider(routes: Record<string, Route>) {
+  const { impl, calls } = fakeFetch(routes);
+  return { provider: createWeaveProvider({ baseUrl: 'http://weave.test/', token: 'secret-token', fetch: impl }), calls };
+}
+
+const stream = (name: string, enabled?: boolean) => ({
+  name,
+  ...(enabled === undefined ? {} : { enabled }),
+  source: { srt: { node: 'node-1' } },
+  destinations: [{ srt: { node: 'node-2' } }],
+});
+
+const endpoint = (node: string, port: number) => ({ node, host: '172.27.0.10', port, url: `srt://172.27.0.10:${port}` });
+
+describe('weave provider', () => {
+  it('maps each node-hosted output of a placed stream to a caller-mode SRT source', async () => {
+    const { provider: p, calls } = provider({
+      '/v1/streams': { status: 200, body: [stream('basic'), stream('fanout')] },
+      '/v1/streams/basic/endpoints': { status: 200, body: { ingress: endpoint('node-1', 20001), outputs: [endpoint('node-2', 20003)] } },
+      '/v1/streams/fanout/endpoints': {
+        status: 200,
+        body: { ingress: endpoint('node-1', 20011), outputs: [endpoint('node-2', 20013), endpoint('', 9000), endpoint('node-3', 20014)] },
+      },
+    });
+
+    const sources = await p.list();
+
+    expect(sources).toEqual([
+      { externalId: 'basic/0', name: 'basic', streamType: 'srt', address: 'srt://172.27.0.10:20003?mode=caller', status: 'active' },
+      { externalId: 'fanout/0', name: 'fanout (node-2)', streamType: 'srt', address: 'srt://172.27.0.10:20013?mode=caller', status: 'active' },
+      { externalId: 'fanout/2', name: 'fanout (node-3)', streamType: 'srt', address: 'srt://172.27.0.10:20014?mode=caller', status: 'active' },
+    ]);
+    for (const call of calls) {
+      expect((call.init?.headers as Record<string, string>).authorization).toBe('Bearer secret-token');
+    }
+    expect(calls.map((c) => c.url)).toEqual([
+      'http://weave.test/v1/streams',
+      'http://weave.test/v1/streams/basic/endpoints',
+      'http://weave.test/v1/streams/fanout/endpoints',
+    ]);
+  });
+
+  it('skips disabled streams without asking for their endpoints', async () => {
+    const { provider: p, calls } = provider({
+      '/v1/streams': { status: 200, body: [stream('off', false), stream('on', true)] },
+      '/v1/streams/on/endpoints': { status: 200, body: { ingress: endpoint('node-1', 1), outputs: [endpoint('node-2', 2)] } },
+    });
+
+    const sources = await p.list();
+
+    expect(sources.map((s) => s.externalId)).toEqual(['on/0']);
+    expect(calls.some((c) => c.url.includes('/off/'))).toBe(false);
+  });
+
+  it('skips streams that are unplaced (503) or unknown (404)', async () => {
+    const { provider: p } = provider({
+      '/v1/streams': { status: 200, body: [stream('pending'), stream('gone'), stream('ok')] },
+      '/v1/streams/pending/endpoints': { status: 503, body: { error: 'not placed' } },
+      '/v1/streams/gone/endpoints': { status: 404 },
+      '/v1/streams/ok/endpoints': { status: 200, body: { ingress: endpoint('node-1', 1), outputs: [endpoint('node-2', 2)] } },
+    });
+
+    expect((await p.list()).map((s) => s.externalId)).toEqual(['ok/0']);
+  });
+
+  it('skips device ends, which weave reports as null endpoints', async () => {
+    const { provider: p } = provider({
+      '/v1/streams': { status: 200, body: [stream('browser-cam'), stream('browser-return')] },
+      '/v1/streams/browser-cam/endpoints': { status: 200, body: { ingress: null, outputs: [endpoint('node-1', 20352)] } },
+      '/v1/streams/browser-return/endpoints': { status: 200, body: { ingress: endpoint('node-1', 20617), outputs: [null] } },
+    });
+
+    expect(await p.list()).toEqual([
+      { externalId: 'browser-cam/0', name: 'browser-cam', streamType: 'srt', address: 'srt://172.27.0.10:20352?mode=caller', status: 'active' },
+    ]);
+  });
+
+  it('treats 401 as a configuration error without leaking the token', async () => {
+    const { provider: p } = provider({ '/v1/streams': { status: 401, body: { error: 'unauthorized' } } });
+    await expect(p.list()).rejects.toThrow(/401/);
+    await expect(p.list()).rejects.not.toThrow(/secret-token/);
+  });
+
+  it('fails the whole listing on an unexpected status so stale sources are kept', async () => {
+    const { provider: p } = provider({
+      '/v1/streams': { status: 200, body: [stream('ok')] },
+      '/v1/streams/ok/endpoints': { status: 500, body: { error: 'boom' } },
+    });
+    await expect(p.list()).rejects.toThrow(/500/);
+  });
+
+  it("carries a destination's declared SRT latency onto the matching source", async () => {
+    const { provider: p } = provider({
+      '/v1/streams': {
+        status: 200,
+        body: [{
+          name: 'guest-1',
+          source: { device: { node: 'guest-1' } },
+          destinations: [{ srt: { node: 'node-2', latency: 200 } }],
+        }],
+      },
+      '/v1/streams/guest-1/endpoints': { status: 200, body: { ingress: null, outputs: [endpoint('node-2', 20665)] } },
+    });
+
+    expect(await p.list()).toEqual([
+      { externalId: 'guest-1/0', name: 'guest-1', streamType: 'srt', address: 'srt://172.27.0.10:20665?mode=caller', status: 'active', latency: 200 },
+    ]);
+  });
+
+  it('pairs each latency with its own output, skipping the device end that holds a slot', async () => {
+    const { provider: p } = provider({
+      '/v1/streams': {
+        status: 200,
+        body: [{
+          name: 'mixed',
+          source: { srt: { node: 'node-1' } },
+          destinations: [
+            { srt: { node: 'node-2', latency: 300 } },
+            { device: { node: 'screen-1' } },
+            { srt: { node: 'node-3', latency: 900 } },
+          ],
+        }],
+      },
+      '/v1/streams/mixed/endpoints': {
+        status: 200,
+        body: { ingress: endpoint('node-1', 1), outputs: [endpoint('node-2', 2), null, endpoint('node-3', 3)] },
+      },
+    });
+
+    expect((await p.list()).map((s) => [s.externalId, s.latency])).toEqual([
+      ['mixed/0', 300],
+      ['mixed/2', 900],
+    ]);
+  });
+
+  it('falls back to open-live\'s default when a declared latency is out of range or absent', async () => {
+    const { provider: p } = provider({
+      '/v1/streams': {
+        status: 200,
+        body: [{
+          name: 'odd',
+          source: { srt: { node: 'node-1' } },
+          destinations: [
+            { srt: { node: 'node-2', latency: 19 } },
+            { srt: { node: 'node-2', latency: 8001 } },
+            { srt: { node: 'node-2', latency: 12.5 } },
+            { srt: { node: 'node-2' } },
+          ],
+        }],
+      },
+      '/v1/streams/odd/endpoints': {
+        status: 200,
+        body: {
+          ingress: endpoint('node-1', 1),
+          outputs: [endpoint('node-2', 2), endpoint('node-2', 3), endpoint('node-2', 4), endpoint('node-2', 5)],
+        },
+      },
+    });
+
+    expect((await p.list()).map((s) => s.latency)).toEqual([undefined, undefined, undefined, undefined]);
+  });
+
+  it('URL-encodes stream names', async () => {
+    const { provider: p, calls } = provider({
+      '/v1/streams': { status: 200, body: [stream('a b/c')] },
+      '/v1/streams/a%20b%2Fc/endpoints': { status: 200, body: { ingress: endpoint('node-1', 1), outputs: [endpoint('node-2', 2)] } },
+    });
+    expect((await p.list()).map((s) => s.externalId)).toEqual(['a b/c/0']);
+    expect(calls[1].url).toBe('http://weave.test/v1/streams/a%20b%2Fc/endpoints');
+  });
+});
+
+describe('provider factory', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('requires both weave variables when weave is enabled', () => {
+    vi.stubEnv('WEAVE_NORTHBOUND_URL', 'http://localhost:29080');
+    vi.stubEnv('WEAVE_NORTHBOUND_TOKEN', '');
+    expect(() => weaveProviderFromEnv()).toThrow('Missing required environment variable: WEAVE_NORTHBOUND_TOKEN');
+  });
+
+  it('resolves the weave id and rejects unknown ids', () => {
+    vi.stubEnv('WEAVE_NORTHBOUND_URL', 'http://localhost:29080');
+    vi.stubEnv('WEAVE_NORTHBOUND_TOKEN', 'tok');
+    expect(createSourceProviders(['weave']).map((p) => p.id)).toEqual(['weave']);
+    expect(createSourceProviders([])).toEqual([]);
+    expect(() => createSourceProviders(['nope'])).toThrow("Unknown source provider 'nope' in SOURCE_PROVIDERS (known: weave)");
+  });
+});

--- a/src/__tests__/providers-weave.test.ts
+++ b/src/__tests__/providers-weave.test.ts
@@ -206,6 +206,20 @@ describe('provider factory', () => {
     expect(() => weaveProviderFromEnv()).toThrow('Missing required environment variable: WEAVE_NORTHBOUND_TOKEN');
   });
 
+  it('rejects a northbound base URL that is not http or https', () => {
+    vi.stubEnv('WEAVE_NORTHBOUND_TOKEN', 'tok');
+    vi.stubEnv('WEAVE_NORTHBOUND_URL', 'file:///etc/passwd');
+    expect(() => weaveProviderFromEnv()).toThrow(/must use http or https/);
+    vi.stubEnv('WEAVE_NORTHBOUND_URL', 'not-a-url');
+    expect(() => weaveProviderFromEnv()).toThrow(/not a valid URL/);
+  });
+
+  it('accepts a node-local northbound base URL', () => {
+    vi.stubEnv('WEAVE_NORTHBOUND_TOKEN', 'tok');
+    vi.stubEnv('WEAVE_NORTHBOUND_URL', 'http://localhost:29080');
+    expect(() => weaveProviderFromEnv()).not.toThrow();
+  });
+
   it('resolves the weave id and rejects unknown ids', () => {
     vi.stubEnv('WEAVE_NORTHBOUND_URL', 'http://localhost:29080');
     vi.stubEnv('WEAVE_NORTHBOUND_TOKEN', 'tok');

--- a/src/__tests__/sources.test.ts
+++ b/src/__tests__/sources.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the sources routes' handling of provider-owned (read-only) sources.
+ *
+ * CouchDB is mocked via vi.mock('../db/index.js') — no real database required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../server.js';
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+const mockFind = vi.fn();
+const mockDestroy = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: mockFind }),
+  getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: mockFind, destroy: mockDestroy }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+const providerDoc = {
+  _id: 'src-ext-weave-basic-0',
+  _rev: '3-abc',
+  type: 'source',
+  name: 'basic',
+  address: 'srt://172.27.0.10:20003?mode=caller',
+  streamType: 'srt',
+  status: 'active',
+  provider: { id: 'weave', externalId: 'basic/0', syncedAt: '2026-09-01T00:00:00.000Z' },
+  createdAt: '2026-09-01T00:00:00.000Z',
+  updatedAt: '2026-09-01T00:00:00.000Z',
+};
+
+const manualDoc = {
+  _id: 'src-11111111-1111-1111-1111-111111111111',
+  _rev: '1-abc',
+  type: 'source',
+  name: 'Camera 1',
+  address: 'srt://203.0.113.5:9000?mode=caller',
+  streamType: 'srt',
+  status: 'inactive',
+  createdAt: '2026-09-01T00:00:00.000Z',
+  updatedAt: '2026-09-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFind.mockResolvedValue({ docs: [] });
+});
+
+describe('GET /api/v1/sources', () => {
+  it('marks provider-owned sources readOnly and exposes the provider reference', async () => {
+    mockFind.mockResolvedValue({ docs: [providerDoc, manualDoc] });
+    const app = await buildServer();
+    const res = await app.inject({ method: 'GET', url: '/api/v1/sources' });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(2);
+    expect(body[0]).toMatchObject({
+      id: providerDoc._id,
+      readOnly: true,
+      provider: providerDoc.provider,
+      address: providerDoc.address,
+    });
+    expect(body[1].id).toBe(manualDoc._id);
+    expect(body[1]).not.toHaveProperty('readOnly');
+    expect(body[1]).not.toHaveProperty('provider');
+  });
+});
+
+describe('PATCH /api/v1/sources/:id', () => {
+  it('returns 409 for a provider-owned source and writes nothing', async () => {
+    mockGet.mockResolvedValue(providerDoc);
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/v1/sources/${providerDoc._id}`,
+      payload: { name: 'renamed' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Source is managed by provider weave' });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('still updates a manually created source', async () => {
+    mockGet.mockResolvedValue(manualDoc);
+    mockInsert.mockResolvedValue({ ok: true, id: manualDoc._id, rev: '2-def' });
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/api/v1/sources/${manualDoc._id}`,
+      payload: { name: 'Camera 1b' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).name).toBe('Camera 1b');
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DELETE /api/v1/sources/:id', () => {
+  it('returns 409 for a provider-owned source and does not destroy it', async () => {
+    mockGet.mockResolvedValue(providerDoc);
+    const app = await buildServer();
+    const res = await app.inject({ method: 'DELETE', url: `/api/v1/sources/${providerDoc._id}` });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Source is managed by provider weave' });
+    expect(mockDestroy).not.toHaveBeenCalled();
+  });
+
+  it('still deletes a manually created source', async () => {
+    mockGet.mockResolvedValue(manualDoc);
+    mockDestroy.mockResolvedValue({ ok: true });
+    const app = await buildServer();
+    const res = await app.inject({ method: 'DELETE', url: `/api/v1/sources/${manualDoc._id}` });
+
+    expect(res.statusCode).toBe(204);
+    expect(mockDestroy).toHaveBeenCalledWith(manualDoc._id, manualDoc._rev);
+  });
+});

--- a/src/__tests__/url-validation.test.ts
+++ b/src/__tests__/url-validation.test.ts
@@ -6,6 +6,7 @@ import {
   isPrivateHost,
   effectivePort,
   assertSameStromOrigin,
+  parseHostPatterns,
 } from '../lib/url-validation.js';
 
 describe('graphicUrl', () => {
@@ -309,5 +310,70 @@ describe('assertSameStromOrigin (WHEP/WHIP proxy SSRF guard — issue #55)', () 
     expect(() =>
       assertSameStromOrigin('https://strom.example.com/whep', 'https://strom.example.com:8443'),
     ).toThrow(/port does not match/);
+  });
+});
+
+describe('allowedHosts', () => {
+  const nodeSubnet = parseHostPatterns(['10.42.0.0/16']);
+
+  it('accepts a private host inside the CIDR without the blanket private-host waiver', () => {
+    expect(() => srtUrl('srt://10.42.7.9:20003?mode=caller', { allowedHosts: nodeSubnet })).not.toThrow();
+    expect(() => httpUrlOnly('http://10.42.7.9:8080/whip/1', { allowedHosts: nodeSubnet })).not.toThrow();
+  });
+
+  it('rejects a private host outside the CIDR', () => {
+    expect(() => srtUrl('srt://10.43.7.9:20003', { allowedHosts: nodeSubnet })).toThrow(/not in the configured host allow-list/);
+  });
+
+  it('rejects a public host, which the private-host rule alone would accept', () => {
+    expect(() => srtUrl('srt://attacker.example.com:9000')).not.toThrow();
+    expect(() => srtUrl('srt://attacker.example.com:9000', { allowedHosts: nodeSubnet })).toThrow(/not in the configured host allow-list/);
+  });
+
+  it('overrides allowPrivateHosts rather than widening it', () => {
+    const options = { allowPrivateHosts: true, allowedHosts: nodeSubnet };
+    expect(() => srtUrl('srt://172.27.0.10:20003', options)).toThrow(/not in the configured host allow-list/);
+  });
+
+  it('matches a bracketed IPv4-mapped literal against an IPv4 CIDR', () => {
+    expect(() => httpUrlOnly('http://[::ffff:10.42.7.9]:8080/whip', { allowedHosts: nodeSubnet })).not.toThrow();
+    expect(() => httpUrlOnly('http://[::ffff:10.43.7.9]:8080/whip', { allowedHosts: nodeSubnet })).toThrow(/not in the configured host allow-list/);
+  });
+
+  it('matches exact hostnames and IPv6 CIDRs', () => {
+    const patterns = parseHostPatterns(['weave-1.internal', 'fd00::/8']);
+    expect(() => srtUrl('srt://weave-1.internal:20003', { allowedHosts: patterns })).not.toThrow();
+    expect(() => srtUrl('srt://weave-2.internal:20003', { allowedHosts: patterns })).toThrow(/not in the configured host allow-list/);
+    expect(() => srtUrl('srt://[fd12::1]:20003', { allowedHosts: patterns })).not.toThrow();
+    expect(() => srtUrl('srt://[fe80::1]:20003', { allowedHosts: patterns })).toThrow(/not in the configured host allow-list/);
+  });
+
+  it('rejects the hostless listener form, which has no host to match', () => {
+    expect(() => srtUrl('srt://:6000?mode=listener')).not.toThrow();
+    expect(() => srtUrl('srt://:6000?mode=listener', { allowedHosts: nodeSubnet })).toThrow(/not in the configured host allow-list/);
+  });
+
+  it('keeps blocking BLOCKED_HOSTNAMES even when the allow-list names them', () => {
+    const patterns = parseHostPatterns(['metadata.google.internal']);
+    expect(() => httpUrlOnly('http://metadata.google.internal/', { allowedHosts: patterns })).toThrow(/SSRF blocked/);
+  });
+
+  it('has no effect when empty, leaving the default rules in force', () => {
+    expect(() => srtUrl('srt://172.27.0.10:20003', { allowedHosts: [] })).toThrow(/private, loopback, or link-local/);
+  });
+});
+
+describe('parseHostPatterns', () => {
+  it('throws on a non-IP CIDR address so an operator typo fails at startup', () => {
+    expect(() => parseHostPatterns(['example.com/16'])).toThrow(/is not an IP address/);
+  });
+
+  it('throws on an out-of-range prefix length', () => {
+    expect(() => parseHostPatterns(['10.42.0.0/33'])).toThrow(/between 0 and 32/);
+    expect(() => parseHostPatterns(['fd00::/129'])).toThrow(/between 0 and 128/);
+  });
+
+  it('throws on a non-numeric prefix length', () => {
+    expect(() => parseHostPatterns(['10.42.0.0/sixteen'])).toThrow(/prefix length/);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { parseHostPatterns } from './lib/url-validation.js';
+
 export function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`Missing required environment variable: ${name}`);
@@ -87,4 +89,17 @@ export const config = {
    * address does arrive in a request body.
    */
   sourceProviderAllowPrivateHosts: process.env['SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS'] === 'true',
+  /**
+   * Hosts a provider may name, as a comma-separated list of hostnames, IPs and
+   * CIDR blocks (e.g. "10.42.0.0/16,weave-1.internal"). When set, a candidate
+   * address outside the list is skipped whether its host is private or public,
+   * and SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS is not consulted.
+   *
+   * The list is the one input to provider validation that the provider does not
+   * supply, so it is what bounds a provider that starts returning addresses it
+   * should not. Prefer it over the blanket private-host waiver.
+   */
+  sourceProviderAllowedHosts: parseHostPatterns(
+    (process.env['SOURCE_PROVIDER_ALLOWED_HOSTS'] ?? '').split(',').map((h) => h.trim()).filter(Boolean),
+  ),
 } as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,16 @@ function requireEnv(name: string): string {
   return value;
 }
 
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid environment variable ${name}: expected a positive integer, got '${raw}'`);
+  }
+  return value;
+}
+
 function buildCouchdbUrl(): string {
   const raw = requireEnv('COUCHDB_URL');
   const url = new URL(raw);
@@ -58,4 +68,11 @@ export const config = {
     .split(',')
     .map((h) => h.trim().toLowerCase())
     .filter(Boolean),
+  /**
+   * Source providers to poll, as a comma-separated list of ids (e.g. "weave").
+   * Empty (the default) disables provider sync entirely.
+   */
+  sourceProviders: (process.env['SOURCE_PROVIDERS'] ?? '').split(',').map((s) => s.trim()).filter(Boolean),
+  /** Interval between source provider polls, in milliseconds. */
+  sourceProviderPollMs: positiveIntEnv('SOURCE_PROVIDER_POLL_MS', 5000),
 } as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,4 +75,16 @@ export const config = {
   sourceProviders: (process.env['SOURCE_PROVIDERS'] ?? '').split(',').map((s) => s.trim()).filter(Boolean),
   /** Interval between source provider polls, in milliseconds. */
   sourceProviderPollMs: positiveIntEnv('SOURCE_PROVIDER_POLL_MS', 5000),
+  /**
+   * Accept provider-listed SRT addresses on private, loopback or link-local
+   * hosts. Off by default, which keeps srtUrl()'s SSRF rule intact everywhere.
+   *
+   * A provider address is not attacker-supplied: it comes from the system named
+   * in SOURCE_PROVIDERS, over the URL the operator configured. Providers that
+   * place media on container or cluster networks — open-weave puts SRT outputs
+   * on a node subnet — produce RFC1918 addresses for every source, so the rule
+   * would reject all of them. This does not relax the REST routes, where an
+   * address does arrive in a request body.
+   */
+  sourceProviderAllowPrivateHosts: process.env['SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS'] === 'true',
 } as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-function requireEnv(name: string): string {
+export function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`Missing required environment variable: ${name}`);
   return value;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -39,8 +39,16 @@ export interface SourceDoc {
   liveCamera?: boolean;
   /** SRT receiver buffer latency in ms. Only applies to srt/efp stream types. Default 125. */
   latency?: number;
+  /** Set when a source provider owns this document; such sources are read-only via the API. */
+  provider?: SourceProviderRef;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface SourceProviderRef {
+  id: string;
+  externalId: string;
+  syncedAt: string;
 }
 
 // --------------- Graphic types ---------------

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -6,9 +6,9 @@
  * - graphicUrl:  httpUrlOnly OR safe data: image URIs (no svg, no text/html)
  * - srtUrl:      srt:// scheme only; reject private/internal hosts (listener form allowed)
  *
- * `srtUrl` takes the private-host rule as an option rather than reading config,
- * so the module stays free of environment lookups and each caller states its own
- * trust assumption at the call site.
+ * `httpUrlOnly` and `srtUrl` take the private-host rule as an option rather than
+ * reading config, so the module stays free of environment lookups and each caller
+ * states its own trust assumption at the call site.
  */
 
 /**
@@ -106,13 +106,20 @@ const BLOCKED_HOSTNAMES = new Set([
   'metadata.google.internal', // GCP metadata endpoint
 ]);
 
+export interface UrlValidationOptions {
+  /** Skip the private/loopback/link-local rejection. Only for addresses that did
+   *  not come from a request body — see SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS.
+   *  BLOCKED_HOSTNAMES stays in force regardless. */
+  allowPrivateHosts?: boolean;
+}
+
 /**
  * Throws if the URL is not a safe http/https URL.
  * Rejects private/loopback/link-local/internal IP literals (via `isPrivateHost`,
  * which also catches IPv4-mapped IPv6 such as ::ffff:169.254.169.254 — the AWS
  * IMDS bypass an IPv4-only regex would miss) and well-known SSRF hostnames.
  */
-export function httpUrlOnly(url: string): void {
+export function httpUrlOnly(url: string, options: UrlValidationOptions = {}): void {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -127,7 +134,7 @@ export function httpUrlOnly(url: string): void {
   }
   // Strip surrounding brackets from IPv6 literals (e.g. [::1] → ::1)
   const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
-  if (isPrivateHost(hostname)) {
+  if (!options.allowPrivateHosts && isPrivateHost(hostname)) {
     throw new Error(`URL hostname "${hostname}" is in a private/reserved IP range — SSRF blocked`);
   }
   if (BLOCKED_HOSTNAMES.has(hostname.toLowerCase())) {
@@ -212,13 +219,7 @@ const SRT_URL_RE = /^srt:\/\/(([A-Za-z0-9.\-]|\[[0-9a-fA-F:]+\])*:\d{1,5})(\?[A-
  * URLs whose host is a private/loopback/link-local/internal IP are rejected to
  * prevent SSRF from the GStreamer pipeline to internal services.
  */
-export interface SrtUrlOptions {
-  /** Skip the private/loopback/link-local rejection. Only for addresses that did
-   *  not come from a request body — see SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS. */
-  allowPrivateHosts?: boolean;
-}
-
-export function srtUrl(url: string, options: SrtUrlOptions = {}): void {
+export function srtUrl(url: string, options: UrlValidationOptions = {}): void {
   if (url.length > 512) {
     throw new Error('SRT URL too long');
   }

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -19,12 +19,7 @@
  * - IPv4: 10/8, 172.16/12, 192.168/16, 127/8 (loopback), 169.254/16 (link-local),
  *   0.0.0.0
  * - IPv6: ::1 (loopback), fe80::/10 (link-local), fc00::/7 (unique-local)
- * - IPv4-mapped IPv6: ::ffff:a.b.c.d (evaluated as the embedded IPv4 address) —
- *   in BOTH forms the WHATWG URL parser can produce: dotted-decimal
- *   (::ffff:127.0.0.1) and the two-hextet hex form it normalizes bracketed
- *   literals to (`new URL('http://[::ffff:169.254.169.254]/').hostname` is
- *   `[::ffff:a9fe:a9fe]`, not the dotted form) — checking only the former
- *   lets a bracketed IPv4-mapped literal sail straight through.
+ * - IPv4-mapped IPv6: evaluated as the embedded IPv4 address (see `canonicalHost`)
  *
  * Non-IP hostnames (public DNS names) are NOT flagged here — DNS resolution is out
  * of scope for this synchronous validator; this blocks the direct-IP SSRF vector.
@@ -36,31 +31,36 @@
  * `src/__tests__/url-validation.test.ts`.
  */
 export function isPrivateHost(hostname: string): boolean {
-  // Strip surrounding brackets from IPv6 literals and normalise case.
-  const host = hostname.trim().replace(/^\[|\]$/g, '').toLowerCase();
+  const host = canonicalHost(hostname);
   if (!host) return false;
+  if (host.includes(':')) return isPrivateIPv6(host);
+  return isPrivateIPv4(host);
+}
 
-  // IPv4-mapped IPv6, dotted-decimal form, e.g. ::ffff:127.0.0.1.
+/**
+ * Unbracketed, lower-cased host, with an IPv4-mapped IPv6 literal reduced to the
+ * IPv4 address it embeds.
+ *
+ * Mapped literals must be reduced in BOTH forms the WHATWG URL parser can
+ * produce: dotted-decimal (::ffff:127.0.0.1) and the two-hextet hex form it
+ * normalizes bracketed literals to (`new URL('http://[::ffff:169.254.169.254]/')
+ * .hostname` is `[::ffff:a9fe:a9fe]`, not the dotted form). Handling only the
+ * former lets a bracketed IPv4-mapped literal sail straight through.
+ */
+export function canonicalHost(hostname: string): string {
+  const host = hostname.trim().replace(/^\[|\]$/g, '').toLowerCase();
+
   const mappedDotted = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (mappedDotted) {
-    return isPrivateIPv4(mappedDotted[1]!);
-  }
+  if (mappedDotted) return mappedDotted[1]!;
 
-  // IPv4-mapped IPv6, hex-hextet form, e.g. ::ffff:a9fe:a9fe (== 169.254.169.254).
-  // This is the form the URL parser actually produces for a bracketed literal.
   const mappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (mappedHex) {
     const hi = parseInt(mappedHex[1]!, 16);
     const lo = parseInt(mappedHex[2]!, 16);
-    const dotted = [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join('.');
-    return isPrivateIPv4(dotted);
+    return [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join('.');
   }
 
-  if (host.includes(':')) {
-    return isPrivateIPv6(host);
-  }
-
-  return isPrivateIPv4(host);
+  return host;
 }
 
 /**
@@ -106,11 +106,79 @@ const BLOCKED_HOSTNAMES = new Set([
   'metadata.google.internal', // GCP metadata endpoint
 ]);
 
+/** An entry of an operator-configured host allow-list: one exact host, or one
+ *  CIDR block held as its network prefix. */
+export type HostPattern =
+  | { host: string }
+  | { prefix: bigint; bits: number; width: 32 | 128 };
+
+function ipToBigInt(host: string): { value: bigint; width: 32 | 128 } | null {
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const octets = v4.slice(1, 5).map(Number);
+    if (octets.some((n) => n > 255)) return null;
+    return { value: octets.reduce((acc, n) => (acc << 8n) | BigInt(n), 0n), width: 32 };
+  }
+  if (!host.includes(':') || !/^[0-9a-f:]+$/.test(host)) return null;
+
+  const halves = host.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const fill = 8 - head.length - tail.length;
+  if (halves.length === 1 ? fill !== 0 : fill < 0) return null;
+  const hextets = [...head, ...Array<string>(halves.length === 2 ? fill : 0).fill('0'), ...tail];
+
+  let value = 0n;
+  for (const hextet of hextets) {
+    if (!/^[0-9a-f]{1,4}$/.test(hextet)) return null;
+    value = (value << 16n) | BigInt(parseInt(hextet, 16));
+  }
+  return { value, width: 128 };
+}
+
+/**
+ * Parses allow-list entries — an exact hostname or IP (`weave-1.internal`,
+ * `10.42.0.5`) or a CIDR block (`10.42.0.0/16`, `fd00::/8`). Throws on a
+ * malformed entry so a typo in the operator's config fails at startup rather
+ * than silently matching nothing.
+ */
+export function parseHostPatterns(entries: string[]): HostPattern[] {
+  return entries.map((entry) => {
+    const value = entry.trim().toLowerCase();
+    const slash = value.lastIndexOf('/');
+    if (slash === -1) return { host: canonicalHost(value) };
+
+    const ip = ipToBigInt(canonicalHost(value.slice(0, slash)));
+    if (!ip) throw new Error(`Invalid host pattern "${entry}": "${value.slice(0, slash)}" is not an IP address`);
+    const bits = Number(value.slice(slash + 1));
+    if (!Number.isInteger(bits) || bits < 0 || bits > ip.width) {
+      throw new Error(`Invalid host pattern "${entry}": prefix length must be an integer between 0 and ${ip.width}`);
+    }
+    return { prefix: ip.value >> BigInt(ip.width - bits), bits, width: ip.width };
+  });
+}
+
+function hostMatchesPatterns(hostname: string, patterns: HostPattern[]): boolean {
+  const host = canonicalHost(hostname);
+  const ip = ipToBigInt(host);
+  return patterns.some((pattern) => {
+    if ('host' in pattern) return pattern.host === host;
+    if (!ip || ip.width !== pattern.width) return false;
+    return (ip.value >> BigInt(pattern.width - pattern.bits)) === pattern.prefix;
+  });
+}
+
 export interface UrlValidationOptions {
   /** Skip the private/loopback/link-local rejection. Only for addresses that did
    *  not come from a request body — see SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS.
    *  BLOCKED_HOSTNAMES stays in force regardless. */
   allowPrivateHosts?: boolean;
+  /** When non-empty, the host must match one of these entries and nothing else
+   *  is accepted — public hosts included, so this both replaces the private-host
+   *  rule and narrows what a provider may name. BLOCKED_HOSTNAMES stays in force
+   *  regardless. See SOURCE_PROVIDER_ALLOWED_HOSTS. */
+  allowedHosts?: HostPattern[];
 }
 
 /**
@@ -134,7 +202,11 @@ export function httpUrlOnly(url: string, options: UrlValidationOptions = {}): vo
   }
   // Strip surrounding brackets from IPv6 literals (e.g. [::1] → ::1)
   const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
-  if (!options.allowPrivateHosts && isPrivateHost(hostname)) {
+  if (options.allowedHosts?.length) {
+    if (!hostMatchesPatterns(hostname, options.allowedHosts)) {
+      throw new Error(`URL hostname "${hostname}" is not in the configured host allow-list`);
+    }
+  } else if (!options.allowPrivateHosts && isPrivateHost(hostname)) {
     throw new Error(`URL hostname "${hostname}" is in a private/reserved IP range — SSRF blocked`);
   }
   if (BLOCKED_HOSTNAMES.has(hostname.toLowerCase())) {
@@ -245,7 +317,12 @@ export function srtUrl(url: string, options: UrlValidationOptions = {}): void {
     hostname = authority.replace(/:\d+$/, '');
   }
 
-  if (!options.allowPrivateHosts && hostname && isPrivateHost(hostname)) {
+  if (options.allowedHosts?.length) {
+    // The hostless listener form has nothing to match, so an allow-list rejects it.
+    if (!hostname || !hostMatchesPatterns(hostname, options.allowedHosts)) {
+      throw new Error(`SRT URL host "${hostname}" is not in the configured host allow-list`);
+    }
+  } else if (!options.allowPrivateHosts && hostname && isPrivateHost(hostname)) {
     throw new Error('SRT URL must not target private, loopback, or link-local addresses');
   }
 }

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -5,6 +5,10 @@
  * - httpUrlOnly: allow only http/https schemes with no private-IP targets
  * - graphicUrl:  httpUrlOnly OR safe data: image URIs (no svg, no text/html)
  * - srtUrl:      srt:// scheme only; reject private/internal hosts (listener form allowed)
+ *
+ * `srtUrl` takes the private-host rule as an option rather than reading config,
+ * so the module stays free of environment lookups and each caller states its own
+ * trust assumption at the call site.
  */
 
 /**
@@ -208,7 +212,13 @@ const SRT_URL_RE = /^srt:\/\/(([A-Za-z0-9.\-]|\[[0-9a-fA-F:]+\])*:\d{1,5})(\?[A-
  * URLs whose host is a private/loopback/link-local/internal IP are rejected to
  * prevent SSRF from the GStreamer pipeline to internal services.
  */
-export function srtUrl(url: string): void {
+export interface SrtUrlOptions {
+  /** Skip the private/loopback/link-local rejection. Only for addresses that did
+   *  not come from a request body — see SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS. */
+  allowPrivateHosts?: boolean;
+}
+
+export function srtUrl(url: string, options: SrtUrlOptions = {}): void {
   if (url.length > 512) {
     throw new Error('SRT URL too long');
   }
@@ -234,7 +244,7 @@ export function srtUrl(url: string): void {
     hostname = authority.replace(/:\d+$/, '');
   }
 
-  if (hostname && isPrivateHost(hostname)) {
+  if (!options.allowPrivateHosts && hostname && isPrivateHost(hostname)) {
     throw new Error('SRT URL must not target private, loopback, or link-local addresses');
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import { cleanLegacyFixtures } from './db/seed.js';
 import { buildServer } from './server.js';
 import { StromClient } from './lib/strom.js';
 import { getStromToken } from './lib/strom-token.js';
+import { createSourceProviders } from './providers/index.js';
+import { startSourceProviderSync } from './providers/registry.js';
 import type { ProductionDoc } from './db/types.js';
 import type { FastifyBaseLogger } from 'fastify';
 
@@ -125,6 +127,8 @@ async function main() {
     }
   }
 
+  // Resolve providers before the server and DB come up so an unknown id fails startup.
+  const sourceProviders = createSourceProviders(config.sourceProviders);
   const app = await buildServer();
 
   try {
@@ -137,6 +141,10 @@ async function main() {
   }
 
   startIdleWatchdog(app.log);
+  if (sourceProviders.length > 0) {
+    const stopSourceProviderSync = startSourceProviderSync(sourceProviders, app.log, config.sourceProviderPollMs);
+    app.addHook('onClose', async () => stopSourceProviderSync());
+  }
   await app.listen({ port: config.port, host: '0.0.0.0' });
 }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,9 @@
 import type { SourceProvider } from './types.js';
+import { weaveProviderFromEnv } from './weave.js';
 
-const PROVIDER_FACTORIES: Record<string, () => SourceProvider> = {};
+const PROVIDER_FACTORIES: Record<string, () => SourceProvider> = {
+  weave: weaveProviderFromEnv,
+};
 
 /** Resolve SOURCE_PROVIDERS ids to provider instances. Throws on an unknown id so a typo fails startup. */
 export function createSourceProviders(ids: string[]): SourceProvider[] {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,15 @@
+import type { SourceProvider } from './types.js';
+
+const PROVIDER_FACTORIES: Record<string, () => SourceProvider> = {};
+
+/** Resolve SOURCE_PROVIDERS ids to provider instances. Throws on an unknown id so a typo fails startup. */
+export function createSourceProviders(ids: string[]): SourceProvider[] {
+  return ids.map((id) => {
+    const factory = PROVIDER_FACTORIES[id];
+    if (!factory) {
+      const known = Object.keys(PROVIDER_FACTORIES).join(', ') || 'none';
+      throw new Error(`Unknown source provider '${id}' in SOURCE_PROVIDERS (known: ${known})`);
+    }
+    return factory();
+  });
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -12,6 +12,7 @@
  */
 
 import type { FastifyBaseLogger } from 'fastify';
+import { config } from '../config.js';
 import { getSourcesDb, isDbConnected } from '../db/index.js';
 import type { SourceDoc } from '../db/types.js';
 import { srtUrl } from '../lib/url-validation.js';
@@ -46,7 +47,7 @@ function validateCandidate(candidate: ProviderSource): string | null {
   if (!candidate.name) return 'missing name';
   if (candidate.streamType === 'srt' || candidate.streamType === 'efp') {
     try {
-      srtUrl(candidate.address);
+      srtUrl(candidate.address, { allowPrivateHosts: config.sourceProviderAllowPrivateHosts });
     } catch (err) {
       return err instanceof Error ? err.message : 'invalid SRT address';
     }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -15,7 +15,7 @@ import type { FastifyBaseLogger } from 'fastify';
 import { config } from '../config.js';
 import { getSourcesDb, isDbConnected } from '../db/index.js';
 import type { SourceDoc } from '../db/types.js';
-import { srtUrl } from '../lib/url-validation.js';
+import { httpUrlOnly, srtUrl } from '../lib/url-validation.js';
 import { encryptAddressPassphrase, decryptAddressPassphrase } from '../lib/srt-passphrase-crypto.js';
 import type { ProviderSource, SourceProvider } from './types.js';
 
@@ -42,15 +42,32 @@ export function providerSourceId(providerId: string, externalId: string): string
   return `src-ext-${providerId}-${slug}`.slice(0, MAX_SOURCE_ID_LENGTH);
 }
 
+/**
+ * The `never` default makes an added ProviderSource.streamType a compile error
+ * here, so a new stream type cannot reach the DB unvalidated.
+ */
+function assertCandidateAddress(candidate: ProviderSource): void {
+  const allowPrivateHosts = config.sourceProviderAllowPrivateHosts;
+  switch (candidate.streamType) {
+    case 'srt':
+    case 'efp':
+      return srtUrl(candidate.address, { allowPrivateHosts });
+    case 'whip':
+      return httpUrlOnly(candidate.address, { allowPrivateHosts });
+    default: {
+      const unsupported: never = candidate.streamType;
+      throw new Error(`unsupported stream type "${String(unsupported)}"`);
+    }
+  }
+}
+
 function validateCandidate(candidate: ProviderSource): string | null {
   if (!candidate.externalId) return 'missing externalId';
   if (!candidate.name) return 'missing name';
-  if (candidate.streamType === 'srt' || candidate.streamType === 'efp') {
-    try {
-      srtUrl(candidate.address, { allowPrivateHosts: config.sourceProviderAllowPrivateHosts });
-    } catch (err) {
-      return err instanceof Error ? err.message : 'invalid SRT address';
-    }
+  try {
+    assertCandidateAddress(candidate);
+  } catch (err) {
+    return err instanceof Error ? err.message : 'invalid address';
   }
   return null;
 }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -47,13 +47,16 @@ export function providerSourceId(providerId: string, externalId: string): string
  * here, so a new stream type cannot reach the DB unvalidated.
  */
 function assertCandidateAddress(candidate: ProviderSource): void {
-  const allowPrivateHosts = config.sourceProviderAllowPrivateHosts;
+  const options = {
+    allowPrivateHosts: config.sourceProviderAllowPrivateHosts,
+    allowedHosts: config.sourceProviderAllowedHosts,
+  };
   switch (candidate.streamType) {
     case 'srt':
     case 'efp':
-      return srtUrl(candidate.address, { allowPrivateHosts });
+      return srtUrl(candidate.address, options);
     case 'whip':
-      return httpUrlOnly(candidate.address, { allowPrivateHosts });
+      return httpUrlOnly(candidate.address, options);
     default: {
       const unsupported: never = candidate.streamType;
       throw new Error(`unsupported stream type "${String(unsupported)}"`);

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,0 +1,207 @@
+/**
+ * Polls each configured source provider and reconciles its candidates into
+ * CouchDB as provider-owned SourceDocs (see SourceDoc.provider).
+ *
+ * Reconciliation per tick:
+ *   - missing candidate → create
+ *   - changed name/address/streamType/latency/status → update
+ *   - unchanged → no write, so CouchDB is not touched every tick
+ *   - provider-owned doc no longer listed → status 'inactive', doc kept
+ *     (deleting would silently break production assignments)
+ *   - provider or DB failure → docs left as they are until the next tick
+ */
+
+import type { FastifyBaseLogger } from 'fastify';
+import { getSourcesDb, isDbConnected } from '../db/index.js';
+import type { SourceDoc } from '../db/types.js';
+import { srtUrl } from '../lib/url-validation.js';
+import { encryptAddressPassphrase, decryptAddressPassphrase } from '../lib/srt-passphrase-crypto.js';
+import type { ProviderSource, SourceProvider } from './types.js';
+
+/** Matches the cap SourceAssignmentInput.sourceId enforces in routes/productions.ts. */
+const MAX_SOURCE_ID_LENGTH = 128;
+
+export interface SkippedCandidate {
+  externalId: string;
+  reason: string;
+}
+
+export interface SyncResult {
+  created: number;
+  updated: number;
+  deactivated: number;
+  skipped: SkippedCandidate[];
+}
+
+export function providerSourceId(providerId: string, externalId: string): string {
+  const slug = externalId
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `src-ext-${providerId}-${slug}`.slice(0, MAX_SOURCE_ID_LENGTH);
+}
+
+function validateCandidate(candidate: ProviderSource): string | null {
+  if (!candidate.externalId) return 'missing externalId';
+  if (!candidate.name) return 'missing name';
+  if (candidate.streamType === 'srt' || candidate.streamType === 'efp') {
+    try {
+      srtUrl(candidate.address);
+    } catch (err) {
+      return err instanceof Error ? err.message : 'invalid SRT address';
+    }
+  }
+  return null;
+}
+
+function isUpToDate(doc: SourceDoc, candidate: ProviderSource): boolean {
+  return doc.name === candidate.name
+    && doc.streamType === candidate.streamType
+    && decryptAddressPassphrase(doc.address) === candidate.address
+    && doc.latency === candidate.latency
+    && doc.status === (candidate.status ?? 'active');
+}
+
+function applyCandidate(
+  provider: SourceProvider,
+  candidate: ProviderSource,
+  current: SourceDoc | undefined,
+  now: string,
+): SourceDoc {
+  const base: Pick<SourceDoc, '_id' | '_rev' | 'type' | 'createdAt' | 'liveCamera'> = current ?? {
+    _id: providerSourceId(provider.id, candidate.externalId),
+    type: 'source',
+    createdAt: now,
+  };
+  return {
+    ...base,
+    name: candidate.name,
+    address: encryptAddressPassphrase(candidate.address),
+    streamType: candidate.streamType,
+    status: candidate.status ?? 'active',
+    latency: candidate.latency,
+    provider: { id: provider.id, externalId: candidate.externalId, syncedAt: now },
+    updatedAt: now,
+  };
+}
+
+function isConflict(err: unknown): boolean {
+  return err instanceof Error && 'statusCode' in err && (err as { statusCode?: number }).statusCode === 409;
+}
+
+/** Insert `apply(current)`; on a 409 _rev conflict re-read the doc and apply once more. */
+async function upsert(
+  id: string,
+  current: SourceDoc | undefined,
+  apply: (current: SourceDoc | undefined) => SourceDoc,
+): Promise<void> {
+  const db = getSourcesDb();
+  try {
+    await db.insert(apply(current));
+  } catch (err) {
+    if (!isConflict(err)) throw err;
+    const latest = await db.get(id);
+    await db.insert(apply(latest));
+  }
+}
+
+/** One reconciliation pass for a single provider. Throws if the provider or CouchDB fails. */
+export async function syncProvider(provider: SourceProvider, log: FastifyBaseLogger): Promise<SyncResult> {
+  const candidates = await provider.list();
+  const result: SyncResult = { created: 0, updated: 0, deactivated: 0, skipped: [] };
+
+  const existing = await getSourcesDb().find({ selector: { type: 'source', 'provider.id': provider.id } });
+  const byExternalId = new Map<string, SourceDoc>();
+  for (const doc of existing.docs) {
+    if (doc.provider) byExternalId.set(doc.provider.externalId, doc);
+  }
+
+  const now = new Date().toISOString();
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const reason = validateCandidate(candidate) ?? (seen.has(candidate.externalId) ? 'duplicate externalId' : null);
+    if (reason) {
+      result.skipped.push({ externalId: candidate.externalId, reason });
+      continue;
+    }
+    seen.add(candidate.externalId);
+
+    const current = byExternalId.get(candidate.externalId);
+    if (current && isUpToDate(current, candidate)) continue;
+
+    const id = current?._id ?? providerSourceId(provider.id, candidate.externalId);
+    await upsert(id, current, (doc) => applyCandidate(provider, candidate, doc, now));
+    if (current) result.updated++; else result.created++;
+    log.debug({ provider: provider.id, sourceId: id, externalId: candidate.externalId }, current ? '[providers] Updated source' : '[providers] Created source');
+  }
+
+  for (const [externalId, doc] of byExternalId) {
+    if (seen.has(externalId) || doc.status === 'inactive') continue;
+    await upsert(doc._id, doc, (latest) => ({
+      ...(latest ?? doc),
+      status: 'inactive',
+      provider: { id: provider.id, externalId, syncedAt: now },
+      updatedAt: now,
+    }));
+    result.deactivated++;
+    log.debug({ provider: provider.id, sourceId: doc._id, externalId }, '[providers] Source no longer listed — marked inactive');
+  }
+
+  return result;
+}
+
+/**
+ * Poll the providers forever, one pass at a time. Failures are logged once per
+ * state change so a provider outage does not flood the log at the poll rate.
+ * Returns a stop function.
+ */
+export function startSourceProviderSync(
+  providers: SourceProvider[],
+  log: FastifyBaseLogger,
+  pollMs: number,
+): () => void {
+  const failing = new Set<string>();
+  const lastSkipped = new Map<string, string>();
+  let timer: NodeJS.Timeout | null = null;
+  let stopped = false;
+
+  const tick = async () => {
+    if (isDbConnected()) {
+      for (const provider of providers) {
+        try {
+          const result = await syncProvider(provider, log);
+          if (failing.delete(provider.id)) {
+            log.info({ provider: provider.id }, '[providers] Sync recovered');
+          }
+          if (result.created || result.updated || result.deactivated) {
+            const { skipped: _skipped, ...counts } = result;
+            log.info({ provider: provider.id, ...counts }, '[providers] Synced sources');
+          }
+          const skippedKey = JSON.stringify(result.skipped);
+          if (skippedKey !== lastSkipped.get(provider.id)) {
+            lastSkipped.set(provider.id, skippedKey);
+            if (result.skipped.length > 0) {
+              log.warn({ provider: provider.id, skipped: result.skipped }, '[providers] Skipped invalid source candidates');
+            }
+          }
+        } catch (err) {
+          if (!failing.has(provider.id)) {
+            failing.add(provider.id);
+            log.error({ err, provider: provider.id }, '[providers] Sync failed — keeping existing sources until the provider recovers');
+          }
+        }
+      }
+    } else {
+      log.debug('[providers] Database not connected — skipping sync');
+    }
+    if (!stopped) timer = setTimeout(tick, pollMs);
+  };
+
+  log.info({ providers: providers.map((p) => p.id), pollMs }, '[providers] Source provider sync started');
+  void tick();
+
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+  };
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,24 @@
+/**
+ * A source provider lists source candidates produced by another system.
+ * The registry materialises them as ordinary, read-only SourceDocs so the rest
+ * of open-live (assignment, activation, the studio UI) needs no knowledge of
+ * where they came from. Providers are polled; there is no push API.
+ */
+
+export interface ProviderSource {
+  /** Stable within the provider. Slugged into the source id, so keep it short. */
+  externalId: string;
+  name: string;
+  streamType: 'srt' | 'efp' | 'whip';
+  /** Validated with srtUrl() for srt/efp before it is stored. */
+  address: string;
+  latency?: number;
+  /** Defaults to 'active'. */
+  status?: 'active' | 'inactive';
+}
+
+export interface SourceProvider {
+  /** Short slug such as 'weave'; becomes part of every source id the provider owns. */
+  readonly id: string;
+  list(): Promise<ProviderSource[]>;
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -10,7 +10,7 @@ export interface ProviderSource {
   externalId: string;
   name: string;
   streamType: 'srt' | 'efp' | 'whip';
-  /** Validated with srtUrl() for srt/efp before it is stored. */
+  /** Validated before it is stored: srtUrl() for srt/efp, httpUrlOnly() for whip. */
   address: string;
   latency?: number;
   /** Defaults to 'active'. */

--- a/src/providers/weave.ts
+++ b/src/providers/weave.ts
@@ -50,6 +50,24 @@ function srtLatency(destination: { srt?: { latency?: number } } | null | undefin
   return latency;
 }
 
+/**
+ * The northbound base URL is operator config, so its host is the operator's
+ * choice — a node-local weave on `http://localhost:29080` is the documented
+ * setup. Only the scheme is checked, so the Bearer token cannot be sent over
+ * something that is not HTTP at all.
+ */
+function assertHttpBaseUrl(raw: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`WEAVE_NORTHBOUND_URL is not a valid URL: ${raw}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`WEAVE_NORTHBOUND_URL must use http or https, got "${parsed.protocol}"`);
+  }
+}
+
 export function weaveProviderFromEnv(): SourceProvider {
   return createWeaveProvider({
     baseUrl: requireEnv('WEAVE_NORTHBOUND_URL'),
@@ -58,6 +76,7 @@ export function weaveProviderFromEnv(): SourceProvider {
 }
 
 export function createWeaveProvider(options: WeaveProviderOptions): SourceProvider {
+  assertHttpBaseUrl(options.baseUrl);
   const baseUrl = options.baseUrl.replace(/\/+$/, '');
   const fetchImpl = options.fetch ?? fetch;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;

--- a/src/providers/weave.ts
+++ b/src/providers/weave.ts
@@ -1,0 +1,121 @@
+/**
+ * Source provider for open-weave. Lists every enabled stream on the northbound
+ * API and turns each placed, node-hosted output into an SRT source that
+ * open-live dials (`?mode=caller`). Remote outputs (empty `node`) are
+ * destinations weave dials out to itself, and `null` outputs are device ends
+ * (a node's own screen) with no socket at all, so neither is offered.
+ */
+
+import { requireEnv } from '../config.js';
+import type { ProviderSource, SourceProvider } from './types.js';
+
+export interface WeaveProviderOptions {
+  baseUrl: string;
+  token: string;
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+}
+
+interface WeaveStream {
+  name: string;
+  enabled?: boolean;
+  /** Positionally aligned with the endpoints response `outputs`, one entry per
+   *  destination — weave builds both from `stream.destinations` in order. */
+  destinations?: Array<{ srt?: { latency?: number } } | null>;
+}
+
+interface WeaveEndpoint {
+  node: string;
+  host: string;
+  port: number;
+  url: string;
+}
+
+interface WeaveEndpoints {
+  ingress: WeaveEndpoint | null;
+  outputs: Array<WeaveEndpoint | null>;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/** Matches the bounds the REST schema enforces in routes/sources.ts, so a
+ *  provider-owned latency cannot reach Strom by a path that skips them. */
+const MIN_LATENCY_MS = 20;
+const MAX_LATENCY_MS = 8000;
+
+function srtLatency(destination: { srt?: { latency?: number } } | null | undefined): number | undefined {
+  const latency = destination?.srt?.latency;
+  if (latency === undefined) return undefined;
+  if (!Number.isInteger(latency) || latency < MIN_LATENCY_MS || latency > MAX_LATENCY_MS) return undefined;
+  return latency;
+}
+
+export function weaveProviderFromEnv(): SourceProvider {
+  return createWeaveProvider({
+    baseUrl: requireEnv('WEAVE_NORTHBOUND_URL'),
+    token: requireEnv('WEAVE_NORTHBOUND_TOKEN'),
+  });
+}
+
+export function createWeaveProvider(options: WeaveProviderOptions): SourceProvider {
+  const baseUrl = options.baseUrl.replace(/\/+$/, '');
+  const fetchImpl = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  async function get(path: string): Promise<Response> {
+    const res = await fetchImpl(`${baseUrl}${path}`, {
+      headers: { authorization: `Bearer ${options.token}`, accept: 'application/json' },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.status === 401) {
+      throw new Error('open-weave northbound rejected WEAVE_NORTHBOUND_TOKEN (401)');
+    }
+    return res;
+  }
+
+  async function listStreams(): Promise<WeaveStream[]> {
+    const res = await get('/v1/streams');
+    if (!res.ok) throw new Error(`open-weave northbound GET /v1/streams failed with ${res.status}`);
+    const body: unknown = await res.json();
+    if (!Array.isArray(body)) throw new Error('open-weave northbound GET /v1/streams returned a non-array body');
+    return body as WeaveStream[];
+  }
+
+  /** null when the stream is known but unplaced (503) or unknown (404). */
+  async function getEndpoints(name: string): Promise<WeaveEndpoints | null> {
+    const path = `/v1/streams/${encodeURIComponent(name)}/endpoints`;
+    const res = await get(path);
+    if (res.status === 404 || res.status === 503) return null;
+    if (!res.ok) throw new Error(`open-weave northbound GET ${path} failed with ${res.status}`);
+    return (await res.json()) as WeaveEndpoints;
+  }
+
+  return {
+    id: 'weave',
+    async list(): Promise<ProviderSource[]> {
+      const streams = (await listStreams()).filter((s) => s.enabled !== false);
+      const perStream = await Promise.all(streams.map(async (stream) => {
+        const endpoints = await getEndpoints(stream.name);
+        return endpoints ? toSources(stream.name, endpoints.outputs, stream.destinations) : [];
+      }));
+      return perStream.flat();
+    },
+  };
+}
+
+export function toSources(
+  streamName: string,
+  outputs: Array<WeaveEndpoint | null>,
+  destinations: WeaveStream['destinations'] = [],
+): ProviderSource[] {
+  const hosted = outputs
+    .flatMap((output, index) => (output && output.node ? [{ output, index }] : []));
+  return hosted.map(({ output, index }) => ({
+    externalId: `${streamName}/${index}`,
+    name: hosted.length === 1 ? streamName : `${streamName} (${output.node})`,
+    streamType: 'srt',
+    address: output.url.includes('?') ? `${output.url}&mode=caller` : `${output.url}?mode=caller`,
+    status: 'active',
+    latency: srtLatency(destinations[index]),
+  }));
+}

--- a/src/routes/sources.ts
+++ b/src/routes/sources.ts
@@ -73,7 +73,16 @@ function toApi(doc: SourceDoc) {
   // Passphrases are stored encrypted (encv1:...); decrypt before masking so the
   // mask matches on the "passphrase=" param regardless of storage form. Legacy
   // plaintext passphrases pass through decryption unchanged.
-  return { id: _id, ...rest, address: maskSrtPassphrase(decryptAddressPassphrase(rest.address)) };
+  return {
+    id: _id,
+    ...rest,
+    address: maskSrtPassphrase(decryptAddressPassphrase(rest.address)),
+    ...(rest.provider ? { readOnly: true } : {}),
+  };
+}
+
+function providerManagedError(doc: SourceDoc) {
+  return { error: `Source is managed by provider ${doc.provider!.id}` };
 }
 
 const sourcesRoutes: FastifyPluginAsync = async (fastify) => {
@@ -126,6 +135,7 @@ const sourcesRoutes: FastifyPluginAsync = async (fastify) => {
     const body = SourcePatch.parse(req.body);
     try {
       const doc = await getSourcesDb().get(req.params.id);
+      if (doc.provider) return reply.status(409).send(providerManagedError(doc));
       // Determine effective streamType and address after the patch. Validate
       // against the plaintext form — a new body.address is already plaintext,
       // while the stored doc.address may hold an encrypted passphrase.
@@ -162,6 +172,7 @@ const sourcesRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.delete<{ Params: { id: string } }>('/api/v1/sources/:id', async (req, reply) => {
     try {
       const doc = await getSourcesDb().get(req.params.id);
+      if (doc.provider) return reply.status(409).send(providerManagedError(doc));
 
       // Block deletion if source is used by an active/activating production
       const activeProductions = await getDb().find({


### PR DESCRIPTION
## Summary

Adds a source provider mechanism: a provider lists source candidates produced by
another system, and a poller reconciles them into CouchDB as ordinary source
documents. Assignment, activation and the studio UI need no knowledge of where a
source came from. The first provider lists sources from
[open-weave](https://github.com/Eyevinn/open-weave).

Providers are off by default. Nothing changes unless `SOURCE_PROVIDERS` is set.

## What is in here

**Provider interface** (`src/providers/types.ts`) — a provider is an id plus
`list(): Promise<ProviderSource[]>`. There is no push API; the registry polls. Every
candidate address is validated before it is stored: `srtUrl()` for `srt`/`efp`,
`httpUrlOnly()` for `whip`. The dispatch is exhaustive, so adding a stream type
to `ProviderSource` is a compile error until it has a validator.

**Registry and poller** (`src/providers/registry.ts`) — one reconciliation pass
per provider per tick:

| Candidate state | Action |
|---|---|
| Not in the DB | Create |
| Name, address, stream type, latency or status changed | Update |
| Unchanged | No write, so CouchDB is not touched every tick |
| Provider-owned doc no longer listed | Status set to `inactive`, doc kept |
| Provider or DB failure | Docs left as they are until the next tick |

A source that stops being listed is deactivated rather than deleted, because
deleting it would break the assignment of a production that still references it.
Invalid candidates are skipped with a reason and logged once per change, rather
than at the poll rate. Sync failures are logged on the transition into and out
of the failing state for the same reason.

**Read-only via the API** (`src/routes/sources.ts`) — provider-owned sources
carry `provider: { id, externalId, syncedAt }` and `readOnly: true` in responses.
`PATCH` and `DELETE` on them return `409`.

**The `weave` provider** (`src/providers/weave.ts`) — lists every enabled stream
on the northbound API and offers each placed, node-hosted output as an SRT source
with `?mode=caller` appended, which is the address open-live's
`builtin.mpegtssrt_input` block dials. Outputs weave dials out to, and streams
that are not yet placed, are skipped. The matching destination's declared SRT
latency is carried onto the source so the input block and the vision mixer's
`min_upstream_latency` agree with what weave configured; a value outside the
20–8000 ms the REST schema allows falls back to the default.

**Unknown provider ids fail startup** — `createSourceProviders` runs before the
server and DB come up, so a typo in `SOURCE_PROVIDERS` is a startup error rather
than a silently missing provider.

## The private-host flag

`srtUrl()` rejects private, loopback and link-local hosts so that an address in a
request body cannot make the pipeline dial internal services. A provider that
places media on a container or cluster network lists RFC1918 addresses for every
source — open-weave puts its SRT outputs on a node subnet — so the rule rejects
all of them.

`SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS=true` waives the rule for provider-listed
addresses only. Such an address is not attacker-supplied: it comes from the
system named in `SOURCE_PROVIDERS`, over the URL the operator configured. The
flag is off by default.

`srtUrl` and `httpUrlOnly` take the rule as an option rather than reading config,
so the REST routes keep it unconditionally and each caller states its own trust
assumption at the call site. `BLOCKED_HOSTNAMES` (`localhost`,
`metadata.google.internal`) still applies even when the flag is on.

## Configuration

| Variable | Purpose | Default |
|---|---|---|
| `SOURCE_PROVIDERS` | Comma-separated provider ids to poll | empty (disabled) |
| `SOURCE_PROVIDER_POLL_MS` | Poll interval in ms | `5000` |
| `SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS` | Accept provider-listed private hosts | `false` |
| `WEAVE_NORTHBOUND_URL` | open-weave northbound base URL | unset |
| `WEAVE_NORTHBOUND_TOKEN` | open-weave northbound bearer token | unset |

```bash
SOURCE_PROVIDERS=weave \
SOURCE_PROVIDER_ALLOW_PRIVATE_HOSTS=true \
WEAVE_NORTHBOUND_URL=http://localhost:29080 \
WEAVE_NORTHBOUND_TOKEN=<token> \
pnpm dev
```

README and `docs/openapi.yaml` are updated to match.

## Testing

`pnpm test` (196 tests, 19 files) and `pnpm typecheck` pass on this branch rebased
on `main` (`3293352`). New coverage:

- `src/__tests__/providers-registry.test.ts` — create, update, no-op, deactivate,
  duplicate and invalid candidates, `_rev` conflict retry, poll loop and stop.
- `src/__tests__/providers-weave.test.ts` — endpoint mapping, skipped outputs,
  latency handling.
- `src/__tests__/sources.test.ts` — `readOnly` in responses, `409` on `PATCH` and
  `DELETE`.
- Whip candidates: non-http scheme rejected, public https accepted, the
  private-host flag applied to whip, metadata hostname still blocked.

