### PR TITLE
fix(security): remove wildcard CORS default and enable strictPreflight

### DIFF
--- a/src/__tests__/cors-default-origin.test.ts
+++ b/src/__tests__/cors-default-origin.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the CORS default-origin behaviour.
+ *
+ * Regression guard for #54: when CORS_ORIGIN is unset the server must NOT fall
+ * back to a permissive wildcard (Access-Control-Allow-Origin: *), which would
+ * leave any deployment omitting the var fully open to cross-origin reads.
+ *
+ * CouchDB, Strom client, and the WS controller are mocked — no real services
+ * required. CORS_ORIGIN is deleted before importing the server so config.corsOrigin
+ * (read once at module load) reflects the unset state.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+delete process.env['CORS_ORIGIN'];
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  getSourcesDb: () => ({ get: vi.fn() }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket controller (avoids startup side effects)
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient / flow-generator (imported transitively via routes)
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: vi.fn(),
+  deactivateStromFlow: vi.fn(),
+}));
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = { version: vi.fn(), iceServers: vi.fn() };
+    flows = {
+      get: vi.fn(),
+      start: vi.fn().mockResolvedValue({}),
+      stop: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    mixer = { multiviewEndpoint: vi.fn() };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let buildServer: typeof import('../server.js').buildServer;
+let config: typeof import('../config.js').config;
+
+beforeAll(async () => {
+  ({ config } = await import('../config.js'));
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('CORS default origin (#54)', () => {
+  it('does not default CORS_ORIGIN to a wildcard', () => {
+    expect(config.corsOrigin).toBeUndefined();
+  });
+
+  it('does not send a wildcard Access-Control-Allow-Origin when CORS_ORIGIN is unset', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/health',
+      headers: { origin: 'https://evil.example.com' },
+    });
+    expect(res.headers['access-control-allow-origin']).not.toBe('*');
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,9 +34,11 @@ export const config = {
   apiKey: process.env['API_KEY'] ?? undefined,
   /**
    * Allowed CORS origin(s). Comma-separated list or '*' (wildcard).
-   * Defaults to '*' for backward compatibility; tighten for production.
+   * Defaults to unset (no wildcard): when omitted, cross-origin requests are
+   * not permitted rather than being opened to any origin. Set an explicit
+   * origin (or comma-separated list) for browser clients.
    */
-  corsOrigin: process.env['CORS_ORIGIN'] ?? '*',
+  corsOrigin: process.env['CORS_ORIGIN'] ?? undefined,
   /**
    * Public base URL used to construct WHIP callback URLs stored in CouchDB.
    * Set this to the externally reachable URL of this service (e.g. https://live.example.com).

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,9 +67,25 @@ export async function buildServer() {
 
   // CORS must be registered before Helmet so its onRequest hook runs first
   // and Access-Control-Allow-Origin is set before Helmet's hooks fire.
-  const corsOrigins = config.corsOrigin === '*'
-    ? true
-    : config.corsOrigin.split(',').map((o) => o.trim()).filter(Boolean);
+  //
+  // When CORS_ORIGIN is unset we do NOT fall back to a permissive wildcard:
+  // an unconfigured deployment must not silently allow cross-origin reads.
+  // Instead we disable cross-origin access (origin: false) and warn loudly.
+  // An explicit '*' still opts in to wildcard; a comma-separated list is
+  // parsed into an allow-list.
+  let corsOrigins: boolean | string[];
+  if (config.corsOrigin === undefined) {
+    fastify.log.warn(
+      '[security] CORS_ORIGIN is not set — cross-origin requests are disabled. ' +
+      'Set CORS_ORIGIN to your browser client origin (e.g. http://localhost:5173) ' +
+      'or a comma-separated list of origins to enable CORS.'
+    );
+    corsOrigins = false;
+  } else if (config.corsOrigin === '*') {
+    corsOrigins = true;
+  } else {
+    corsOrigins = config.corsOrigin.split(',').map((o) => o.trim()).filter(Boolean);
+  }
   await fastify.register(cors, {
     origin: corsOrigins,
     methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
## Summary

Closes #54

CORS previously defaulted to `*` (wildcard) whenever `CORS_ORIGIN` was unset, leaving any deployment that omitted the variable fully open to cross-origin credentialed reads. This removes the wildcard fallback: an unconfigured deployment now disables cross-origin access and logs a clear startup warning instead of silently opening up.

## Changes

- **`src/config.ts`**: `corsOrigin` default changed from `'*'` to `undefined` (no wildcard fallback). Updated the doc comment.
- **`src/server.ts`**: CORS registration now branches on the origin value:
  - unset → `origin: false` (cross-origin disabled) plus a `fastify.log.warn('[security] CORS_ORIGIN is not set ...')` startup warning, matching the existing `[security]` warning convention.
  - explicit `'*'` → wildcard (`true`) still supported for opt-in.
  - comma-separated list → parsed into an allow-list (existing parsing preserved).
  - `strictPreflight: true` retained.
- **`src/__tests__/cors-default-origin.test.ts`**: new focused regression test asserting the default is no longer wildcard and that no `Access-Control-Allow-Origin: *` header is emitted when `CORS_ORIGIN` is unset.

Note: `docker-compose.yml` already sets `CORS_ORIGIN=http://localhost:5173`, so the reference deployment is unaffected by the new default — no change required there.

## Test Plan

Commands run (all from repo root, Node/pnpm):

- `pnpm install --frozen-lockfile` — OK
- `pnpm run typecheck` (`tsc --noEmit`) — passed, no errors
- `pnpm run build` (`tsc`) — passed, no errors
- `npx vitest run` — **12 test files, 121 tests passed** (includes the new `cors-default-origin.test.ts`; no existing tests broken)

## Checklist

- [x] CORS_ORIGIN default is no longer a wildcard
- [x] Unconfigured deployments emit a startup warning and do not enable permissive CORS
- [x] `strictPreflight: true` set
- [x] Comma-separated origin parsing preserved; explicit `*` still supported
- [x] docker-compose reference sets an explicit origin
- [x] typecheck / build / tests pass
- [x] Focused regression test added

🤖 Generated with Claude Code