### PR TITLE
fix(ws): add per-connection WebSocket message rate limiting

### DIFF
--- a/src/__tests__/ws-rate-limit.test.ts
+++ b/src/__tests__/ws-rate-limit.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for per-connection WebSocket message rate limiting (issue #52).
+ *
+ * HTTP routes are protected by @fastify/rate-limit, but WS message throughput
+ * used to be unbounded — a single client could flood commands and saturate the
+ * Strom backend. handleMessage now enforces a sliding-window limit per
+ * connection: a general cap (20/s) plus a stricter cap (5/s) on expensive
+ * commands (MACRO_EXEC, GO_LIVE, CUT_STREAM).
+ *
+ * These tests drive real inbound messages through handleMessage sharing a
+ * single per-connection ctx (as the live plugin does) and assert that once a
+ * cap is hit the controller emits an ERROR frame and stops processing. Time is
+ * controlled with vi.setSystemTime so the sliding window is deterministic.
+ * CouchDB is mocked; the production doc is intentionally NOT activated so cheap
+ * commands short-circuit before any Strom call.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn().mockResolvedValue({ ok: true });
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getSourcesDb: () => ({ get: mockGet, insert: mockInsert, find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../routes/productions.js', () => ({
+  updateProductionDoc: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/tally.service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/tally.service.js')>();
+  return { ...actual, broadcast: () => {} };
+});
+
+const { handleMessage } = await import('../ws/controller.js');
+
+const PROD = 'prod-rate-1';
+
+// A non-activated production: GO_LIVE short-circuits with an ERROR and never
+// calls Strom, so every accepted message is a pure control-path exercise.
+function makeDoc() {
+  return {
+    _id: PROD,
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Rate Test',
+    status: 'idle',
+    // no stromFlowId → GO_LIVE returns "not activated" without Strom
+    sources: [],
+    pipeline: { stromConfig: null, status: 'idle' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeWs() {
+  const sent: Array<Record<string, unknown>> = [];
+  const ws = {
+    send: (data: string) => { sent.push(JSON.parse(data)); },
+  } as unknown as import('@fastify/websocket').WebSocket;
+  return { ws, sent };
+}
+
+function rateLimitFrames(sent: Array<Record<string, unknown>>) {
+  return sent.filter((m) => m.type === 'ERROR' && m.error === 'Rate limit exceeded');
+}
+
+describe('WebSocket per-connection rate limiting', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    mockGet.mockReset();
+    mockGet.mockResolvedValue(makeDoc());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows up to the general cap then drops excess with an ERROR frame', async () => {
+    const { ws, sent } = makeWs();
+    const ctx: Record<string, unknown> = {};
+
+    // 25 cheap SET_OVL messages within the same window. First 20 pass, rest drop.
+    for (let i = 0; i < 25; i++) {
+      await handleMessage(PROD, ws, JSON.stringify({ type: 'SET_OVL', alpha: 0.5 }), ctx);
+    }
+
+    expect(rateLimitFrames(sent)).toHaveLength(5);
+  });
+
+  it('does not process a message that exceeds the limit', async () => {
+    const { ws } = makeWs();
+    const ctx: Record<string, unknown> = {};
+
+    for (let i = 0; i < 25; i++) {
+      await handleMessage(PROD, ws, JSON.stringify({ type: 'SET_OVL', alpha: 0.5 }), ctx);
+    }
+
+    // The DB was fetched only for the 20 accepted messages; the 5 dropped ones
+    // never reached the switch (db.get is called after the rate check).
+    expect(mockGet).toHaveBeenCalledTimes(20);
+  });
+
+  it('applies a stricter cap to expensive commands (GO_LIVE)', async () => {
+    const { ws, sent } = makeWs();
+    const ctx: Record<string, unknown> = {};
+
+    // 6 GO_LIVE (expensive, cap 5). Under the general cap of 20, so only the
+    // expensive limit can trip: the 6th is dropped.
+    for (let i = 0; i < 6; i++) {
+      await handleMessage(PROD, ws, JSON.stringify({ type: 'GO_LIVE' }), ctx);
+    }
+
+    expect(rateLimitFrames(sent)).toHaveLength(1);
+  });
+
+  it('refills after the sliding window elapses', async () => {
+    const { ws, sent } = makeWs();
+    const ctx: Record<string, unknown> = {};
+
+    for (let i = 0; i < 6; i++) {
+      await handleMessage(PROD, ws, JSON.stringify({ type: 'GO_LIVE' }), ctx);
+    }
+    expect(rateLimitFrames(sent)).toHaveLength(1);
+
+    // Advance past the window; earlier timestamps age out and new sends pass.
+    vi.setSystemTime(new Date('2026-01-01T00:00:02.000Z'));
+    await handleMessage(PROD, ws, JSON.stringify({ type: 'GO_LIVE' }), ctx);
+
+    expect(rateLimitFrames(sent)).toHaveLength(1);
+  });
+
+  it('keeps rate-limit state independent per connection', async () => {
+    const a = makeWs();
+    const b = makeWs();
+    const ctxA: Record<string, unknown> = {};
+    const ctxB: Record<string, unknown> = {};
+
+    for (let i = 0; i < 6; i++) {
+      await handleMessage(PROD, a.ws, JSON.stringify({ type: 'GO_LIVE' }), ctxA);
+    }
+    // Connection B is fresh and unaffected by A's flood.
+    await handleMessage(PROD, b.ws, JSON.stringify({ type: 'GO_LIVE' }), ctxB);
+
+    expect(rateLimitFrames(a.sent)).toHaveLength(1);
+    expect(rateLimitFrames(b.sent)).toHaveLength(0);
+  });
+});

--- a/src/ws/controller.ts
+++ b/src/ws/controller.ts
@@ -18,6 +18,54 @@ function stromErrorMessage(err: unknown): string {
   return String(err);
 }
 
+// ---------------------------------------------------------------------------
+// Per-connection message rate limiting
+// ---------------------------------------------------------------------------
+//
+// HTTP routes are protected by @fastify/rate-limit, but WebSocket message
+// throughput was previously unbounded: a single authenticated client could
+// flood commands (each of which may trigger a downstream Strom API call),
+// causing DoS for other operators. We apply a sliding-window limit per
+// connection — a general cap plus a stricter cap on expensive commands.
+
+/** General cap: max inbound messages per connection per window. */
+const RATE_LIMIT_GENERAL_MAX = 20;
+/** Stricter cap for expensive commands (each triggers heavy Strom work). */
+const RATE_LIMIT_EXPENSIVE_MAX = 5;
+/** Sliding-window size in milliseconds. */
+const RATE_LIMIT_WINDOW_MS = 1000;
+
+/** Message types whose processing is expensive enough to warrant a tighter cap. */
+const EXPENSIVE_MESSAGE_TYPES = new Set(['MACRO_EXEC', 'GO_LIVE', 'CUT_STREAM']);
+
+/** Per-connection sliding-window timestamps. Lives on the connection ctx so it
+ * is garbage-collected when the socket closes (no global registry to leak). */
+interface RateLimitState {
+  general: number[];
+  expensive: number[];
+}
+
+/**
+ * Records the message against the sliding windows and reports whether it is
+ * allowed. Old timestamps outside the window are pruned on every call, so state
+ * stays bounded for the lifetime of the connection.
+ */
+function checkRateLimit(state: RateLimitState, isExpensive: boolean, now: number): boolean {
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+
+  state.general = state.general.filter((t) => t > cutoff);
+  if (state.general.length >= RATE_LIMIT_GENERAL_MAX) return false;
+
+  if (isExpensive) {
+    state.expensive = state.expensive.filter((t) => t > cutoff);
+    if (state.expensive.length >= RATE_LIMIT_EXPENSIVE_MAX) return false;
+    state.expensive.push(now);
+  }
+
+  state.general.push(now);
+  return true;
+}
+
 // Mirror of MAX_DB_WRITE_RETRIES in routes/productions.ts — the number of
 // insert attempts a mixer write makes before giving up on a CouchDB 409.
 const MAX_DB_WRITE_RETRIES = 3;
@@ -602,7 +650,7 @@ export async function handleMessage(
   productionId: string,
   ws: WebSocket,
   raw: string,
-  ctx: { audioBlockId?: string },
+  ctx: { audioBlockId?: string; rateLimit?: RateLimitState },
 ): Promise<void> {
   let rawParsed: unknown;
   try {
@@ -617,6 +665,14 @@ export async function handleMessage(
     return;
   }
   const msg: InboundMessage = parseResult.data as unknown as InboundMessage;
+
+  // Per-connection rate limiting: drop (do not process) messages that exceed
+  // the sliding-window caps and inform the client via the standard ERROR frame.
+  if (!ctx.rateLimit) ctx.rateLimit = { general: [], expensive: [] };
+  if (!checkRateLimit(ctx.rateLimit, EXPENSIVE_MESSAGE_TYPES.has(msg.type), Date.now())) {
+    ws.send(JSON.stringify({ type: 'ERROR', error: 'Rate limit exceeded' }));
+    return;
+  }
 
 
   const db = getDb();
@@ -1520,7 +1576,7 @@ const controllerWs: FastifyPluginAsync = async (fastify) => {
 
       // Per-connection context — mutable so the audio block ID can be populated
       // at connect time and reused on every subsequent AUDIO_SET without a flow fetch.
-      const ctx: { audioBlockId?: string } = {};
+      const ctx: { audioBlockId?: string; rateLimit?: RateLimitState } = {};
 
       // Register message/close handlers immediately so no messages are dropped
       // while we perform the async connect-time sync below.


### PR DESCRIPTION
## Summary
HTTP routes are protected by `@fastify/rate-limit`, but WebSocket message throughput was unbounded. A single authenticated client could flood commands (`MACRO_EXEC`/`GO_LIVE`/`CUT_STREAM`/etc.), each triggering a downstream Strom API call, causing DoS for other operators. This adds a per-connection sliding-window rate limit in the WS message handler.

Closes #52

## Changes
- `src/ws/controller.ts`
  - New sliding-window rate limiter (`checkRateLimit`) with per-connection state.
  - General cap: **20 messages/second** per connection.
  - Stricter cap: **5/second** for expensive commands (`MACRO_EXEC`, `GO_LIVE`, `CUT_STREAM`).
  - On exceed: emits the existing `{ type: 'ERROR', error: 'Rate limit exceeded' }` frame and drops the message before it reaches the `switch` (no processing, no Strom call).
  - State lives on the per-connection `ctx` object (already threaded through `handleMessage`), so it is garbage-collected when the socket closes — no global registry, no leak. Stale timestamps are pruned on every call so state stays bounded.
- `src/__tests__/ws-rate-limit.test.ts` (new)
  - General cap enforcement, dropped messages not processed (`db.get` not called), stricter expensive cap, sliding-window refill, and per-connection isolation.

## Test Plan
Ran locally on the branch:
- `pnpm install --frozen-lockfile` — OK
- `pnpm run typecheck` (`tsc --noEmit`) — **passed**, no errors
- `pnpm run build` (`tsc`) — **passed**, no errors
- `npx vitest run` — **passed: 12 test files, 124 tests** (includes 5 new rate-limit tests); no existing tests broken

## Checklist
- [x] Branched from `main`, not committed directly to `main`
- [x] Imperative commit message with `Co-Authored-By` trailer
- [x] Matches existing outbound `{ type: 'ERROR', error }` convention
- [x] No unrelated refactoring
- [x] Per-connection state cleaned up on socket close (GC via ctx scope)
- [x] typecheck / build / tests pass

🤖 Generated with Claude Code