### PR TITLE
fix(server): authenticate POST /api/v1/reconnect

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,7 +6,7 @@ info:
     REST API for the Open Live broadcast production platform.
 
     **Authentication**: Pass an API key via `Authorization: Bearer <key>` header or `?key=<key>` query parameter.
-    The following paths are exempt from authentication: `/health`, `/ready`, `/api/v1/status`, `/api/v1/server-info`, `/api/v1/reconnect`.
+    The following paths are exempt from authentication: `/health`, `/ready`, `/api/v1/status`, `/api/v1/server-info`.
 
 servers:
   - url: /
@@ -591,7 +591,6 @@ paths:
     post:
       summary: Reconnect to database and Strom
       operationId: reconnect
-      security: []
       tags: [Status]
       responses:
         '200':

--- a/src/__tests__/reconnect-auth.test.ts
+++ b/src/__tests__/reconnect-auth.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for API-key auth coverage of POST /api/v1/reconnect.
+ *
+ * Regression guard for #59 (OWASP A01 Broken Access Control): /api/v1/reconnect
+ * was in the auth-exempt set, letting unauthenticated callers trigger DB/Strom
+ * connection attempts and read {ok, db, strom} infrastructure status. It must
+ * require the API key when API_KEY is set, like other mutating endpoints.
+ *
+ * CouchDB, Strom client, and the WS controller are mocked — no real services
+ * required. API_KEY is set before importing the server so config.apiKey (read
+ * once at module load) picks it up.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+const TEST_API_KEY = 'test-secret-key';
+process.env['API_KEY'] = TEST_API_KEY;
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  getSourcesDb: () => ({ get: vi.fn() }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket controller (avoids startup side effects)
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient / flow-generator (imported transitively via routes)
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: vi.fn(),
+  deactivateStromFlow: vi.fn(),
+}));
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = { version: vi.fn().mockResolvedValue({ version: '1.0.0' }), iceServers: vi.fn() };
+    flows = {
+      get: vi.fn(),
+      start: vi.fn().mockResolvedValue({}),
+      stop: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    mixer = { multiviewEndpoint: vi.fn() };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeAll(async () => {
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('POST /api/v1/reconnect auth (#59)', () => {
+  it('rejects reconnect without an API key when API_KEY is set', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'POST', url: '/api/v1/reconnect' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects reconnect with a wrong API key', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/reconnect',
+      headers: { authorization: 'Bearer wrong-key' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('does not leak infrastructure status without a valid key', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'POST', url: '/api/v1/reconnect' });
+    const body = res.json();
+    expect(body).not.toHaveProperty('db');
+    expect(body).not.toHaveProperty('strom');
+    expect(body).not.toHaveProperty('ok');
+  });
+
+  it('succeeds with the correct API key', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/reconnect',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ ok: true, db: true, strom: true });
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,8 +27,12 @@ import controllerWs from './ws/controller.js';
 
 // Routes exempt from the DB-availability guard (don't touch the DB)
 const DB_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status', '/api/v1/server-info', '/api/v1/reconnect']);
-// Routes exempt from API key auth (health probes + reconnect/status used by the UI before auth is set up)
-const AUTH_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status', '/api/v1/reconnect']);
+// Routes exempt from API key auth (health probes + status used by the UI before auth is set up).
+// /api/v1/reconnect is intentionally NOT exempt (#59): it triggers DB/Strom connection attempts
+// and returns their reachability, so an unauthenticated caller could leak infrastructure status
+// or exhaust connections. It is a mutating POST and the studio calls it via its authenticated
+// api client, so requiring the API key here does not break the legitimate caller.
+const AUTH_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status']);
 
 export async function buildServer() {
   const fastify = Fastify({
@@ -155,7 +159,7 @@ export async function buildServer() {
   });
 
   // Optional API key authentication — enabled when API_KEY env var is set.
-  // Exempt: health/ready probes and status/reconnect endpoints.
+  // Exempt: health/ready probes and the read-only status endpoint.
   // WS connections: pass key via Authorization header or ?key= query param on upgrade.
   if (config.apiKey) {
     // Captured here, outside the closure: TS narrows `config.apiKey` from


### PR DESCRIPTION
Closes #59

## Summary
`POST /api/v1/reconnect` was in the API-key auth exempt set (`AUTH_EXEMPT_PATHS` in `src/server.ts`), so it bypassed the auth hook even when `API_KEY` was set. Unauthenticated callers could trigger DB/Strom connection attempts and read `{ok, db, strom}` infrastructure status — info disclosure (OWASP A01 Broken Access Control) plus a connection-exhaustion DoS vector.

## Remediation path taken
Preferred fix: removed `/api/v1/reconnect` from `AUTH_EXEMPT_PATHS`. It is a mutating `POST` and the studio calls it through its authenticated api client, so requiring the API key does not break the legitimate caller. It stays in `DB_EXEMPT_PATHS` (its whole job is to reconnect when the DB is down — unrelated to auth). The existing per-route 5 req/min rate limit on the endpoint is retained as defence-in-depth.

## Changes
- `src/server.ts`: drop `/api/v1/reconnect` from `AUTH_EXEMPT_PATHS`; update surrounding comments.
- `docs/openapi.yaml`: remove `reconnect` from the documented auth-exempt list and drop its `security: []` override so it inherits the global bearer-auth requirement.
- `src/__tests__/reconnect-auth.test.ts`: new regression test.

## Test Plan
Ran on the real TypeScript/pnpm stack:
- `pnpm install --frozen-lockfile` — ok
- `pnpm run typecheck` — passed
- `pnpm run build` — passed
- `npx vitest run` — 15 files / 148 tests passed

New test asserts: `POST /api/v1/reconnect` returns 401 without a key and with a wrong key when `API_KEY` is set; the unauthenticated response does not contain `db`/`strom`/`ok`; and it returns 200 with the correct key.