### PR TITLE
fix(url-validation): close IPv6/mapped-address SSRF bypasses

### DIFF
--- a/src/__tests__/url-validation.test.ts
+++ b/src/__tests__/url-validation.test.ts
@@ -101,6 +101,30 @@ describe('httpUrlOnly', () => {
   it('accepts a public hostname that happens to contain a private-looking substring', () => {
     expect(() => httpUrlOnly('https://10.0.0.1.example.com/')).not.toThrow();
   });
+
+  // Issue #58 regression: SSRF bypasses via IPv6 ULA, IPv4-mapped IPv6,
+  // 0.0.0.0, and the localhost hostname — exercised end-to-end through the
+  // WHATWG URL parser (bracketed literals get normalized), not just isPrivateHost.
+  it('rejects IPv6 ULA (fc00::/7) literals — Docker/K8s internal nets (#58)', () => {
+    expect(() => httpUrlOnly('http://[fd12::1]:8080/x')).toThrow(/SSRF/);
+    expect(() => httpUrlOnly('http://[fc00::1]/x')).toThrow(/SSRF/);
+  });
+
+  it('rejects IPv4-mapped IPv6 loopback literals (#58)', () => {
+    expect(() => httpUrlOnly('http://[::ffff:127.0.0.1]/')).toThrow(/SSRF/);
+  });
+
+  it('rejects 0.0.0.0 (#58)', () => {
+    expect(() => httpUrlOnly('http://0.0.0.0/')).toThrow(/SSRF/);
+  });
+
+  it('rejects the localhost hostname (#58)', () => {
+    expect(() => httpUrlOnly('http://localhost/')).toThrow(/SSRF|not allowed/);
+  });
+
+  it('still accepts a normal public host (#58 — no false positives)', () => {
+    expect(() => httpUrlOnly('https://example.com')).not.toThrow();
+  });
 });
 
 describe('isPrivateHost', () => {

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -24,6 +24,12 @@
  *
  * Non-IP hostnames (public DNS names) are NOT flagged here — DNS resolution is out
  * of scope for this synchronous validator; this blocks the direct-IP SSRF vector.
+ * The `localhost` hostname (not an IP literal) is handled separately by
+ * `BLOCKED_HOSTNAMES` in `httpUrlOnly`.
+ *
+ * Regression coverage for the #58 bypass set (IPv6 ULA fc00::/7, IPv4-mapped
+ * ::ffff: private ranges, 0.0.0.0, and the localhost hostname) lives in
+ * `src/__tests__/url-validation.test.ts`.
  */
 export function isPrivateHost(hostname: string): boolean {
   // Strip surrounding brackets from IPv6 literals and normalise case.


### PR DESCRIPTION
Closes #58

## Summary

Issue #58 (OWASP A10 SSRF, MEDIUM) reported that `isPrivateHost` in
`src/lib/url-validation.ts` could be bypassed via IPv6 ULA (`fc00::/7`),
IPv4-mapped IPv6 addresses (`::ffff:127.0.0.1`), `0.0.0.0`, and the bare
`localhost` hostname, letting an attacker-controlled HTML-source URL reach
internal Docker/K8s services.

On the current `main` these vectors are already blocked by the structured
`isPrivateHost` implementation (ULA/link-local hextet matching, both dotted and
hex-hextet `::ffff:` forms, `0.0.0.0/8`) and by the `BLOCKED_HOSTNAMES` set
(`localhost`). This PR **locks that behaviour in with explicit regression tests
for the exact #58 payloads** — including the end-to-end `httpUrlOnly` path where
the WHATWG URL parser normalizes bracketed literals — and adds a source comment
cross-referencing the coverage so the mitigation cannot silently regress.

## Changes

- `src/__tests__/url-validation.test.ts`: 6 new #58 regression cases under
  `httpUrlOnly` covering the full attack set plus a public-host false-positive
  guard.
- `src/lib/url-validation.ts`: doc comment tying the ULA / IPv4-mapped /
  `localhost` handling to issue #58 and its regression tests (no behavioural
  change).

## Test Plan

New cases (all asserting `httpUrlOnly(...)` throws, exercised through the URL parser):
- `http://[fd12::1]:8080/x` — blocked (IPv6 ULA)
- `http://[fc00::1]/x` — blocked (IPv6 ULA)
- `http://[::ffff:127.0.0.1]/` — blocked (IPv4-mapped IPv6 loopback)
- `http://0.0.0.0/` — blocked
- `http://localhost/` — blocked (hostname)
- `https://example.com` — still accepted (no false positive)

Verification (TypeScript/pnpm stack):
- `pnpm run typecheck` — passed
- `pnpm run build` — passed
- `npx vitest run` — passed (14 files, 149 tests, incl. the 6 new cases)