### PR TITLE
feat(ws): add server-side timestamps to mixer broadcast events

### DIFF
--- a/src/__tests__/broadcast-timestamp.test.ts
+++ b/src/__tests__/broadcast-timestamp.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for server-side event timestamps on controller broadcasts (issue #169).
+ *
+ * The `broadcast()` helper stamps every outbound event with a server-side `ts`
+ * (ISO 8601 UTC) taken at handle time, so consumers no longer fold WebSocket /
+ * scheduling latency into their own measurements. The field is added centrally
+ * so all message types (TALLY, PIP_STATE, ON_AIR, ...) inherit it consistently.
+ * Shape matches the automation-control-contract spec envelope.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { WebSocket } from '@fastify/websocket';
+import { broadcast, subscribe, unsubscribe } from '../services/tally.service.js';
+
+/** Minimal fake WebSocket that records everything sent to it. */
+class FakeWs {
+  readonly OPEN = 1;
+  readyState = 1;
+  sent: string[] = [];
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+}
+
+const PRODUCTION_ID = 'prod-ts-test';
+
+function makeSub(): { ws: FakeWs; last: () => Record<string, unknown> } {
+  const ws = new FakeWs();
+  subscribe(PRODUCTION_ID, ws as unknown as WebSocket);
+  return {
+    ws,
+    last: () => JSON.parse(ws.sent[ws.sent.length - 1]) as Record<string, unknown>,
+  };
+}
+
+describe('broadcast() server-side timestamp (#169)', () => {
+  let sub: ReturnType<typeof makeSub>;
+
+  beforeEach(() => {
+    sub = makeSub();
+  });
+
+  it('adds a well-formed ISO-8601 ts to TALLY broadcasts', () => {
+    const before = Date.now();
+    broadcast(PRODUCTION_ID, { type: 'TALLY', pgm: 'cam-1', pvw: 'cam-2' });
+    const after = Date.now();
+
+    const msg = sub.last();
+    expect(msg.type).toBe('TALLY');
+    // existing fields preserved (additive / backward-compatible)
+    expect(msg.pgm).toBe('cam-1');
+    expect(msg.pvw).toBe('cam-2');
+
+    expect(typeof msg.ts).toBe('string');
+    // round-trips as a valid date and is in ISO-8601 UTC form
+    const parsed = new Date(msg.ts as string);
+    expect(Number.isNaN(parsed.getTime())).toBe(false);
+    expect(msg.ts).toBe(parsed.toISOString());
+    // stamped at handle time, within the broadcast window
+    expect(parsed.getTime()).toBeGreaterThanOrEqual(before);
+    expect(parsed.getTime()).toBeLessThanOrEqual(after);
+
+    unsubscribe(PRODUCTION_ID, sub.ws as unknown as WebSocket);
+  });
+
+  it('stamps every message type consistently (PIP_STATE, ON_AIR)', () => {
+    broadcast(PRODUCTION_ID, { type: 'PIP_STATE', pgmPip: null, pvwPip: null, pips: [] });
+    expect(typeof sub.last().ts).toBe('string');
+
+    broadcast(PRODUCTION_ID, { type: 'ON_AIR', value: true });
+    const onAir = sub.last();
+    expect(onAir.value).toBe(true);
+    expect(typeof onAir.ts).toBe('string');
+
+    unsubscribe(PRODUCTION_ID, sub.ws as unknown as WebSocket);
+  });
+
+  it('does not overwrite a caller-provided ts', () => {
+    const explicit = '2020-01-01T00:00:00.000Z';
+    broadcast(PRODUCTION_ID, { type: 'TALLY', ts: explicit, pgm: null, pvw: null });
+    expect(sub.last().ts).toBe(explicit);
+
+    unsubscribe(PRODUCTION_ID, sub.ws as unknown as WebSocket);
+  });
+});

--- a/src/services/tally.service.ts
+++ b/src/services/tally.service.ts
@@ -31,7 +31,17 @@ export function getSubscriberCount(productionId: string): number {
 export function broadcast(productionId: string, message: unknown): void {
   const subs = subscribers.get(productionId);
   if (!subs) return;
-  const payload = JSON.stringify(message);
+  // Stamp every outbound event with a server-side timestamp taken at handle
+  // time, so consumers do not fold WebSocket/scheduling latency into their own
+  // measurements (issue #169). Added centrally here so all message types get it
+  // consistently and future events inherit it. Additive/backward-compatible; an
+  // explicit `ts` on the message (if ever provided) is preserved. Shape matches
+  // the automation-control-contract spec envelope (`ts: '<ISO 8601 UTC>'`).
+  const stamped =
+    message !== null && typeof message === 'object' && !Array.isArray(message)
+      ? { ts: new Date().toISOString(), ...(message as Record<string, unknown>) }
+      : message;
+  const payload = JSON.stringify(stamped);
   for (const ws of subs) {
     if (ws.readyState === ws.OPEN) {
       ws.send(payload);


### PR DESCRIPTION
Closes #169

## Summary

Controller WebSocket broadcast events (`TALLY`, `PIP_STATE`, `GRAPHIC`, `DSK_STATE`, `FTB_STATE`, `ON_AIR`, and all the audio/aux/grp state events) carried no time field, so consumers could only timestamp at receipt — folding network and scheduling latency into their own measurements. This adds a server-side `ts` taken at the moment the action is handled. The most important case is `TALLY`, which marks the interval boundary; every broadcast message type gets it for completeness.

## Changes

**Approach: central injection in the `broadcast()` helper.** Every outbound event in `src/ws/controller.ts` (40+ call sites across all message types) funnels through the single `broadcast(productionId, message)` helper in `src/services/tally.service.ts`. Rather than editing every call site by hand (error-prone, easy to miss a type, and future messages wouldn't inherit it), I inject `ts` once in that helper:

```ts
const stamped =
  message !== null && typeof message === 'object' && !Array.isArray(message)
    ? { ts: new Date().toISOString(), ...(message as Record<string, unknown>) }
    : message;
```

- `ts` is an ISO-8601 UTC string (`new Date().toISOString()`), taken server-side at handle time.
- Additive and backward-compatible: no existing field is removed or renamed; clients that ignore unknown fields keep working.
- The `ts`-first spread means an explicit `ts` on a message (should one ever be provided) is preserved rather than overwritten.
- Shape/semantics match the just-merged `docs/specs/automation-control-contract.md` envelope, which specifies `ts` (server-side, ISO-8601 UTC) added "uniformly at the `broadcast()` layer". This PR intentionally implements only `ts` from that envelope; `seq` and the full envelope (`HELLO`/`ACK`/`SNAPSHOT_END`/contribution tally) are out of scope for #169 and left for the epic.

## Test Plan

- `pnpm run typecheck` — passes
- `pnpm run build` — passes
- `npx vitest run` — 147 tests across 15 files pass

Added `src/__tests__/broadcast-timestamp.test.ts` exercising the real `broadcast()` helper via a fake subscriber WebSocket:
- asserts `TALLY` broadcasts include a well-formed ISO-8601 `ts` stamped within the handle window, with existing `pgm`/`pvw` fields preserved
- asserts other message types (`PIP_STATE`, `ON_AIR`) are stamped consistently
- asserts a caller-provided `ts` is not overwritten

Note: the existing `ws-macro-pip.test.ts` mocks the `broadcast` helper, so it does not (and should not) observe the timestamp; the new test covers the real timestamping path directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)