### PR TITLE
feat(auth): server-side SAT-exchange endpoint

### DIFF
--- a/src/__tests__/auth-token.test.ts
+++ b/src/__tests__/auth-token.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for POST /api/v1/auth/token — the server-side SAT-exchange endpoint
+ * (issue #204). The endpoint holds the OSC PAT server-side and returns only a
+ * short-lived SAT so browser clients (open-live-studio#10) never hold the PAT.
+ *
+ * Covers:
+ *   - 401 without the API key (endpoint is API-key-guarded, NOT exempt)
+ *   - 400 on a bad body (Zod .strict() rejects unexpected fields)
+ *   - success path with the upstream `servicetoken` exchange mocked, asserting
+ *     only the SAT + expiry are returned and the PAT never appears
+ *   - 502 when the upstream token service fails
+ *
+ * The upstream exchange is mocked, so no real network / OSC token service is
+ * required. API_KEY and OSC_PAT are set before importing the server so
+ * config (read once at module load) picks them up.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const TEST_API_KEY = 'test-secret-key';
+const TEST_PAT = 'super-secret-pat-value';
+process.env['API_KEY'] = TEST_API_KEY;
+process.env['OSC_PAT'] = TEST_PAT;
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB (route never touches it, but server startup imports it)
+// ---------------------------------------------------------------------------
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  getSourcesDb: () => ({ get: vi.fn() }),
+  getOutputsDb: () => ({ get: vi.fn() }),
+  getGraphicsDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// Avoid WS controller startup side effects
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the upstream SAT exchange so the test never hits the real token service.
+// This stands in for the `servicetoken` call against token.svc.prod.osaas.io.
+// ---------------------------------------------------------------------------
+
+const { exchangeMock, TokenExchangeError } = vi.hoisted(() => {
+  class TokenExchangeError extends Error {}
+  return { exchangeMock: vi.fn(), TokenExchangeError };
+});
+
+vi.mock('../lib/osc-token.js', () => ({
+  exchangeServiceToken: exchangeMock,
+  TokenExchangeError,
+  TOKEN_EXCHANGE_URL: 'https://token.svc.prod.osaas.io/servicetoken',
+}));
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeAll(async () => {
+  ({ buildServer } = await import('../server.js'));
+});
+
+beforeEach(() => {
+  exchangeMock.mockReset();
+});
+
+describe('POST /api/v1/auth/token (#204)', () => {
+  it('rejects the request without an API key', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'POST', url: '/api/v1/auth/token', payload: {} });
+    expect(res.statusCode).toBe(401);
+    expect(exchangeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body with unexpected fields (400)', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/token',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+      // serviceId must NOT be caller-supplied — an unexpected field is a 400.
+      payload: { serviceId: 'attacker-controlled-service' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(exchangeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns only the SAT + expiry on success, never the PAT', async () => {
+    exchangeMock.mockResolvedValue({ token: 'short-lived-sat', expiry: 1_800_000_000 });
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/token',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toEqual({ token: 'short-lived-sat', expiry: 1_800_000_000 });
+
+    // The exchange is scoped to the fixed server-side serviceId, using the
+    // server-held PAT — neither comes from the request.
+    expect(exchangeMock).toHaveBeenCalledWith(TEST_PAT, 'eyevinn-strom');
+
+    // The PAT must never appear anywhere in the response payload.
+    expect(res.body).not.toContain(TEST_PAT);
+    expect(body).not.toHaveProperty('pat');
+  });
+
+  it('returns 502 when the upstream token service fails', async () => {
+    exchangeMock.mockRejectedValue(new TokenExchangeError('token service unreachable'));
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/token',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(502);
+    // Generic message — no upstream internals leaked.
+    expect(res.body).not.toContain('unreachable');
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,20 @@ export const config = {
    */
   apiKey: process.env['API_KEY'] ?? undefined,
   /**
+   * OSC Personal Access Token, held server-side only. Exchanged for a
+   * short-lived SAT via POST /api/v1/auth/token (issue #204) so browser
+   * clients (e.g. open-live-studio) never hold the PAT. NEVER returned to a
+   * client.
+   */
+  oscPat: process.env['OSC_PAT'] ?? undefined,
+  /**
+   * The OSC serviceId that SATs minted via /api/v1/auth/token are scoped to.
+   * Fixed server-side config (never caller-supplied) so the token endpoint
+   * cannot be redirected at an arbitrary service (anti-SSRF / privilege
+   * escalation).
+   */
+  oscSatServiceId: process.env['OSC_SAT_SERVICE_ID'] ?? 'eyevinn-strom',
+  /**
    * Allowed CORS origin(s). Comma-separated list or '*' (wildcard).
    * Defaults to unset (no wildcard): when omitted, cross-origin requests are
    * not permitted rather than being opened to any origin. Set an explicit

--- a/src/lib/osc-token.ts
+++ b/src/lib/osc-token.ts
@@ -1,0 +1,70 @@
+/**
+ * OSC service-token (SAT) exchange helper.
+ *
+ * Exchanges a long-lived OSC Personal Access Token (PAT) for a short-lived
+ * Service Access Token (SAT) via the OSC token service. Mirrors the exchange
+ * performed in src/lib/strom-token.ts, but is generic over the target
+ * serviceId so it can be reused by the auth endpoint (issue #204).
+ *
+ * SECURITY: the exchange endpoint is a fixed constant (not caller-supplied) so
+ * this cannot be turned into an SSRF against arbitrary token endpoints. The
+ * PAT is only ever sent to this fixed URL and is never returned to callers.
+ */
+
+/** Fixed OSC token-exchange endpoint. Never caller-controlled (anti-SSRF). */
+export const TOKEN_EXCHANGE_URL = 'https://token.svc.prod.osaas.io/servicetoken'
+
+export interface ServiceToken {
+  /** The short-lived Service Access Token (SAT). */
+  token: string
+  /** Expiry as a unix timestamp in seconds (as returned by the token service). */
+  expiry: number
+}
+
+/** Raised when the upstream token service is unreachable or returns an error. */
+export class TokenExchangeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TokenExchangeError'
+  }
+}
+
+/**
+ * Exchange a PAT for a short-lived SAT scoped to `serviceId`.
+ *
+ * @throws {TokenExchangeError} if the upstream token service is unreachable or
+ *   responds with a non-2xx status. Callers should surface this as a 502.
+ */
+export async function exchangeServiceToken(pat: string, serviceId: string): Promise<ServiceToken> {
+  let res: Response
+  try {
+    res = await fetch(TOKEN_EXCHANGE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        accept: 'application/json',
+        'x-pat-jwt': `Bearer ${pat}`,
+      },
+      body: JSON.stringify({ serviceId }),
+    })
+  } catch (err) {
+    // Network-level failure (DNS, connection refused, timeout, …).
+    throw new TokenExchangeError(
+      `token service unreachable: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new TokenExchangeError(
+      `SAT exchange failed: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`,
+    )
+  }
+
+  const data = (await res.json()) as { token?: unknown; expiry?: unknown }
+  if (typeof data.token !== 'string' || typeof data.expiry !== 'number') {
+    throw new TokenExchangeError('token service returned a malformed response')
+  }
+
+  return { token: data.token, expiry: data.expiry }
+}

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,97 @@
+import type { FastifyPluginAsync } from 'fastify'
+import { z } from 'zod'
+import { config } from '../config.js'
+import { exchangeServiceToken, TokenExchangeError } from '../lib/osc-token.js'
+
+/**
+ * Auth routes — server-side SAT exchange (issue #204).
+ *
+ * POST /api/v1/auth/token
+ *   Exchanges the server-held OSC PAT for a short-lived Service Access Token
+ *   (SAT) and returns ONLY the SAT + its expiry. The PAT is never sent to the
+ *   client. This lets browser clients (e.g. open-live-studio, see
+ *   open-live-studio#10) obtain a SAT without ever holding the PAT.
+ *
+ *   The target serviceId is fixed server-side config (config.oscSatServiceId),
+ *   never taken from the request body, so this endpoint cannot be turned into
+ *   an SSRF / used to mint SATs for an arbitrary service.
+ *
+ *   Guarded by the global API-key auth hook in server.ts (the path is NOT in
+ *   AUTH_EXEMPT_PATHS) and rate-limited below.
+ */
+
+// The body carries no security-relevant input: the serviceId and target URL
+// are both fixed server-side. We still validate with Zod (repo convention) and
+// use .strict() so any unexpected field is a 400 rather than silently ignored.
+const TokenRequest = z
+  .object({})
+  .strict()
+
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post(
+    '/api/v1/auth/token',
+    {
+      // Tighter than the global 200/min limit: token minting is low-frequency
+      // and each call consumes an upstream PAT exchange.
+      config: { rateLimit: { max: 20, timeWindow: '1 minute' } },
+      schema: {
+        summary: 'Exchange the server-held OSC PAT for a short-lived SAT',
+        tags: ['auth'],
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              token: { type: 'string' },
+              expiry: { type: 'number' },
+            },
+          },
+          502: {
+            type: 'object',
+            properties: {
+              error: { type: 'string' },
+              statusCode: { type: 'number' },
+            },
+          },
+          503: {
+            type: 'object',
+            properties: {
+              error: { type: 'string' },
+              statusCode: { type: 'number' },
+            },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      // Validate the body — throws ZodError (→ 400 via the global handler) on
+      // any unexpected field.
+      TokenRequest.parse(req.body ?? {})
+
+      if (!config.oscPat) {
+        // Misconfiguration: no PAT is available to exchange.
+        fastify.log.error('POST /api/v1/auth/token — OSC_PAT is not configured')
+        return reply
+          .status(503)
+          .send({ error: 'Token exchange is not configured', statusCode: 503 })
+      }
+
+      try {
+        const sat = await exchangeServiceToken(config.oscPat, config.oscSatServiceId)
+        // Return ONLY the short-lived SAT + expiry. Never the PAT.
+        return reply.status(200).send({ token: sat.token, expiry: sat.expiry })
+      } catch (err) {
+        if (err instanceof TokenExchangeError) {
+          // Upstream token service unreachable or returned an error → 502.
+          // Log the detail server-side; return a generic message to the client.
+          fastify.log.error({ err }, 'POST /api/v1/auth/token — SAT exchange failed')
+          return reply
+            .status(502)
+            .send({ error: 'Failed to obtain a service token', statusCode: 502 })
+        }
+        throw err
+      }
+    },
+  )
+}
+
+export default authRoutes

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,10 +23,14 @@ import whipRoutes from './routes/whip.js';
 import productionConfigsRoutes from './routes/production-configs.js';
 import graphicsRoutes from './routes/graphics.js';
 import outputsRoutes from './routes/outputs.js';
+import authRoutes from './routes/auth.js';
 import controllerWs from './ws/controller.js';
 
-// Routes exempt from the DB-availability guard (don't touch the DB)
-const DB_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status', '/api/v1/server-info', '/api/v1/reconnect']);
+// Routes exempt from the DB-availability guard (don't touch the DB).
+// /api/v1/auth/token performs a SAT exchange and never touches CouchDB, so it
+// must remain available even when the DB is down. It is deliberately NOT added
+// to AUTH_EXEMPT_PATHS: it still requires the API key.
+const DB_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status', '/api/v1/server-info', '/api/v1/reconnect', '/api/v1/auth/token']);
 // Routes exempt from API key auth (health probes + reconnect/status used by the UI before auth is set up)
 const AUTH_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status', '/api/v1/reconnect']);
 
@@ -246,6 +250,7 @@ export async function buildServer() {
   await fastify.register(productionConfigsRoutes);
   await fastify.register(graphicsRoutes);
   await fastify.register(outputsRoutes);
+  await fastify.register(authRoutes);
   await fastify.register(controllerWs);
 
   return fastify;


### PR DESCRIPTION
Closes #204.

## Summary
Adds an authenticated, server-side SAT-exchange endpoint so browser clients never hold the OSC PAT. The PAT stays server-side; only the short-lived Service Access Token (SAT) and its expiry are returned to the caller. This unblocks **open-live-studio#10**, which can now fetch a SAT from this backend instead of embedding `OSC_PAT` client-side.

## Changes
- `POST /api/v1/auth/token` (`src/routes/auth.ts`): exchanges the server-held `OSC_PAT` for a SAT and returns `{ token, expiry }` only. Never returns the PAT.
  - Guarded by the existing API-key auth hook in `src/server.ts` (deliberately **not** added to `AUTH_EXEMPT_PATHS` — it requires the API key).
  - Rate-limited via the existing `@fastify/rate-limit` per-route config (20/min; tighter than the global 200/min since each call consumes an upstream exchange).
  - Body validated with a Zod schema using `.strict()` — unexpected fields (e.g. a caller-supplied `serviceId`) are rejected with 400.
  - Added to `DB_EXEMPT_PATHS` since it never touches CouchDB.
- `src/lib/osc-token.ts`: reusable `exchangeServiceToken(pat, serviceId)` helper mirroring the exchange in `src/lib/strom-token.ts`, against the **fixed** `token.svc.prod.osaas.io/servicetoken` URL. The target URL and `serviceId` are fixed server-side config, never caller-supplied — this cannot be turned into an SSRF or used to mint SATs for an arbitrary service.
- `src/config.ts`: adds `oscPat` (`OSC_PAT`) and `oscSatServiceId` (`OSC_SAT_SERVICE_ID`, default `eyevinn-strom`).

### Failure behaviour
- Upstream token service unreachable / non-2xx → **502** with a generic message (upstream internals logged server-side, not leaked).
- `OSC_PAT` unconfigured → **503**.

## Test Plan
Added `src/__tests__/auth-token.test.ts` (upstream exchange mocked, no real network):
- 401 without the API key.
- 400 on a bad body (unexpected `serviceId` field rejected by Zod `.strict()`).
- Success path: asserts response is exactly `{ token, expiry }`, that the exchange is called with the server PAT + fixed serviceId, and that the PAT never appears in the response.
- 502 when the upstream token service fails.

Ran locally, all green:
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck` — pass
- `pnpm run build` — pass
- `npx vitest run` — 148 passed (15 files), including the 4 new tests