### PR TITLE
feat(port-lease): lease SRT listener ports from the shared Strom

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,8 @@ API_KEY=change-me-before-use
 # Client id sent to Strom. Defaults to the hostname of PUBLIC_BASE_URL, or
 # open-live-<hostname> when PUBLIC_BASE_URL is unset. Keep it stable across restarts.
 # STROM_PORT_LEASE_CLIENT_ID=
-# Set to true to skip leasing entirely (single-tenant Strom, or a Strom without the API).
+# Set to true to skip leasing entirely. Not needed for a Strom with no port broker in
+# front of it: the 404 is detected and no restriction is applied.
 # STROM_PORT_LEASE_DISABLED=false
 
 # AES-256 key (32 bytes, base64 or hex) used to encrypt SRT source passphrases at

--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,16 @@ API_KEY=change-me-before-use
 # If not set, the URL is derived from the incoming request (safe only with trustProxy configured).
 # PUBLIC_BASE_URL=https://your-open-live-instance.example.com
 
+# SRT port lease on a shared Strom instance. At startup Open Live reserves a range
+# of consecutive SRT listener ports from Strom and only accepts listener sources
+# (srt://:PORT?mode=listener) whose port falls inside that range.
+# STROM_PORT_LEASE_SIZE=20
+# Client id sent to Strom. Defaults to the hostname of PUBLIC_BASE_URL, or
+# open-live-<hostname> when PUBLIC_BASE_URL is unset. Keep it stable across restarts.
+# STROM_PORT_LEASE_CLIENT_ID=
+# Set to true to skip leasing entirely (single-tenant Strom, or a Strom without the API).
+# STROM_PORT_LEASE_DISABLED=false
+
 # AES-256 key (32 bytes, base64 or hex) used to encrypt SRT source passphrases at
 # rest in CouchDB. REQUIRED in production (NODE_ENV=production) — the server fails
 # to start without it. Left unset in local dev, passphrases are stored in plaintext

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Copy `.env.example` to `.env` and fill in the values:
 | `STROM_TOKEN` | OSC Personal Access Token for authenticating against an OSC-hosted Strom instance | _(empty — not needed for local Strom)_ |
 | `API_KEY` | Static API key protecting all `/api/v1` routes, the WebSocket controller, and the Swagger UI. **Required for any network-accessible deployment** (see below) | _(empty — routes unauthenticated)_ |
 | `LOG_LEVEL` | Fastify log level (`trace`, `debug`, `info`, `warn`, `error`) | `info` |
+| `STROM_PORT_LEASE_SIZE` | Number of SRT listener ports to lease from a shared Strom — see [`docs/port-lease.md`](docs/port-lease.md) | `20` |
+| `STROM_PORT_LEASE_CLIENT_ID` | Stable lease client id sent to Strom | hostname of `PUBLIC_BASE_URL`, else `open-live-<hostname>` |
+| `STROM_PORT_LEASE_DISABLED` | Set to `true` to turn off port leasing | `false` |
 
 > **Never commit `.env`** — it is gitignored. Use `.env.example` as the reference.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -592,8 +592,10 @@ paths:
                     nullable: true
                     description: >-
                       SRT listener ports this instance has leased on the shared Strom.
-                      Hostless listener sources (`srt://:PORT?mode=listener`) must use a
-                      port in this range. Null unless `srtPortLease` is `leased`.
+                      Hostless listener sources and outputs (`srt://:PORT?mode=listener`)
+                      must use a port in this range; `srt://:0?mode=listener` asks the
+                      server to assign the lowest free one. Null unless `srtPortLease`
+                      is `leased`.
                     required: [first, last]
                     properties:
                       first:
@@ -674,6 +676,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '409':
+          description: >-
+            Hostless SRT listener port is already held by another source or output, or no
+            port is free in the range for a port-0 assignment request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           description: SRT port range not yet allocated from Strom — retry shortly
           content:
@@ -722,6 +732,14 @@ paths:
           description: Not found
         '422':
           description: Hostless SRT listener port is outside this instance's leased range (see /api/v1/server-info)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: >-
+            Hostless SRT listener port is already held by another source or output, or no
+            port is free in the range for a port-0 assignment request
           content:
             application/json:
               schema:
@@ -868,6 +886,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '409':
+          description: >-
+            Hostless SRT listener port is already held by another source or output, or no
+            port is free in the range for a port-0 assignment request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           description: SRT port range not yet allocated from Strom — retry shortly
           content:
@@ -916,6 +942,14 @@ paths:
           description: Not found
         '422':
           description: Hostless SRT listener port is outside this instance's leased range (see /api/v1/server-info)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: >-
+            Hostless SRT listener port is already held by another source or output, or no
+            port is free in the range for a port-0 assignment request
           content:
             application/json:
               schema:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -582,10 +582,32 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [stromHost, srtPortRange, srtPortLease]
                 properties:
                   stromHost:
                     type: string
                     description: Hostname of the Strom media server
+                  srtPortRange:
+                    type: object
+                    nullable: true
+                    description: >-
+                      SRT listener ports this instance has leased on the shared Strom.
+                      Hostless listener sources (`srt://:PORT?mode=listener`) must use a
+                      port in this range. Null unless `srtPortLease` is `leased`.
+                    required: [first, last]
+                    properties:
+                      first:
+                        type: integer
+                      last:
+                        type: integer
+                  srtPortLease:
+                    type: string
+                    enum: [leased, pending, unsupported, disabled]
+                    description: >-
+                      State of the Strom port lease. `pending` — not yet acquired, listener
+                      sources are rejected with 503 until it is; `unsupported` — Strom has no
+                      port lease API, ports are not enforced; `disabled` — turned off via
+                      STROM_PORT_LEASE_DISABLED.
 
   /api/v1/reconnect:
     post:
@@ -646,6 +668,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '422':
+          description: Hostless SRT listener port is outside this instance's leased range (see /api/v1/server-info)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: SRT port range not yet allocated from Strom — retry shortly
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/v1/sources/{id}:
     parameters:
@@ -686,6 +720,18 @@ paths:
                 $ref: '#/components/schemas/Source'
         '404':
           description: Not found
+        '422':
+          description: Hostless SRT listener port is outside this instance's leased range (see /api/v1/server-info)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: SRT port range not yet allocated from Strom — retry shortly
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     delete:
       summary: Delete source
       operationId: deleteSource

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -862,6 +862,18 @@ paths:
                 $ref: '#/components/schemas/Output'
         '400':
           description: Validation error
+        '422':
+          description: Hostless SRT listener port is outside this instance's leased range (see /api/v1/server-info)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: SRT port range not yet allocated from Strom — retry shortly
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/v1/outputs/{id}:
     parameters:
@@ -902,6 +914,18 @@ paths:
                 $ref: '#/components/schemas/Output'
         '404':
           description: Not found
+        '422':
+          description: Hostless SRT listener port is outside this instance's leased range (see /api/v1/server-info)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: SRT port range not yet allocated from Strom — retry shortly
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     delete:
       summary: Delete output
       operationId: deleteOutput

--- a/docs/port-lease.md
+++ b/docs/port-lease.md
@@ -1,0 +1,66 @@
+# SRT port lease on a shared Strom
+
+When several Open Live instances share one Strom, every SRT *listener* source
+(`srt://:PORT?mode=listener`) binds a port on that same Strom. Two instances
+picking the same port would collide. To prevent that, each Open Live instance
+leases a contiguous range of SRT listener ports from Strom and only accepts
+listener sources inside its range.
+
+Caller sources (`srt://host:PORT?mode=caller`), WHIP and HTML sources are not
+affected.
+
+## What the server does
+
+- **At startup** it asks Strom for `STROM_PORT_LEASE_SIZE` consecutive ports
+  under a stable client id. Strom hands back the same range on every restart as
+  long as the client id is unchanged and the lease has not expired.
+- **Every minute** it renews the lease. If Strom has forgotten the lease
+  (for example after a restart without persistence) the server re-acquires one
+  under the same client id and logs a warning if the range changed.
+- **On `SIGTERM` / `SIGINT`** it releases the lease so the ports are free for
+  the next instance.
+- **If Strom is too old** to have the port lease API, the server logs one
+  warning, stops enforcing ports, and re-checks every 10 minutes.
+
+## Effect on the API
+
+`GET /api/v1/server-info` reports the range so gateways can pick ports for the
+sources they register:
+
+```json
+{
+  "stromHost": "strom.example.com",
+  "srtPortRange": { "first": 47100, "last": 47119 },
+  "srtPortLease": "leased"
+}
+```
+
+`srtPortLease` is one of:
+
+| Value | Meaning | Listener sources |
+|---|---|---|
+| `leased` | Range acquired; `srtPortRange` is set | Must use a port in the range, otherwise `422` |
+| `pending` | Not acquired yet (Strom unreachable or pool full) | Rejected with `503` until the lease is acquired |
+| `unsupported` | Strom has no port lease API | Accepted, not checked |
+| `disabled` | `STROM_PORT_LEASE_DISABLED=true` | Accepted, not checked |
+
+`POST /api/v1/sources` and `PATCH /api/v1/sources/:id` apply the check when the
+address is a hostless SRT listener. A `422` response names the allowed range.
+
+## Environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `STROM_PORT_LEASE_SIZE` | Number of consecutive SRT listener ports to lease | `20` |
+| `STROM_PORT_LEASE_CLIENT_ID` | Client id sent to Strom. Keep it stable across restarts so the instance gets its range back | hostname of `PUBLIC_BASE_URL`, else `open-live-<hostname>` |
+| `STROM_PORT_LEASE_DISABLED` | `true` turns the feature off entirely (single-tenant Strom) | `false` |
+
+## Operator notes
+
+- Size the range for the number of listener sources the instance will have
+  active at once; the pool on Strom is shared, so do not over-allocate.
+- If the server logs `Failed to acquire SRT port range` with a `409` from Strom,
+  the pool cannot fit the request: lower `STROM_PORT_LEASE_SIZE`, release
+  leases from decommissioned instances, or grow the pool on Strom.
+- Sources created before the lease existed are not re-validated on rename. They
+  are checked again the next time their address or stream type is edited.

--- a/docs/port-lease.md
+++ b/docs/port-lease.md
@@ -28,6 +28,23 @@ affected.
   front of it), the server logs one warning, stops enforcing ports, and
   re-checks every 10 minutes.
 
+## Ports inside the range
+
+The lease keeps instances apart; inside one instance every listener source and
+output must also have its own port, because each binds it on the same Strom.
+Open Live assigns those ports:
+
+- A listener address with port `0`, such as `srt://:0?mode=listener`, asks the
+  server to choose. The lowest port in the range not held by any other source
+  or output is written into the stored address and returned. Gateways register
+  this way, so several gateways can feed one instance without coordinating.
+- An explicit port must be inside the range and not held by another source or
+  output; otherwise the request fails with `422` or `409` naming the holder.
+- A `PATCH` with port `0` keeps the port the document already has when it is
+  still valid, so re-registering after a restart is stable.
+- Without a range (`unsupported` or `disabled`) explicit ports still have to be
+  unique, and port `0` is refused with `400` since there is nothing to choose from.
+
 ## Effect on the API
 
 `GET /api/v1/server-info` reports the range so gateways can pick ports for the
@@ -50,9 +67,9 @@ sources they register:
 | `unsupported` | No port broker answers at `STROM_URL` | Accepted, not checked |
 | `disabled` | `STROM_PORT_LEASE_DISABLED=true` | Accepted, not checked |
 
-`POST`/`PATCH` on `/api/v1/sources` and `/api/v1/outputs` apply the check when
-the address or URL is a hostless SRT listener. A `422` response names the
-allowed range.
+`POST`/`PATCH` on `/api/v1/sources` and `/api/v1/outputs` apply the checks when
+the address or URL is a hostless SRT listener. A `422` names the allowed range,
+a `409` names the source or output that already holds the port.
 
 ## Environment variables
 
@@ -72,4 +89,4 @@ allowed range.
 - Sources and outputs created before the lease existed are not re-validated on
   rename. They are checked again the next time their address or URL is edited.
 - Size the range for sources and outputs together: a production's SRT outputs
-  in listener mode take ports from the same block.
+  in listener mode take ports from the same block, one port per document.

--- a/docs/port-lease.md
+++ b/docs/port-lease.md
@@ -1,12 +1,12 @@
 # SRT port lease on a shared Strom
 
 When several Open Live instances share one Strom, every SRT *listener* source
-(`srt://:PORT?mode=listener`) binds a port on that same Strom. Two instances
-picking the same port would collide. To prevent that, each Open Live instance
-leases a contiguous range of SRT listener ports from Strom and only accepts
-listener sources inside its range.
+or output (`srt://:PORT?mode=listener`) binds a port on that same Strom. Two
+instances picking the same port would collide. To prevent that, each Open Live
+instance leases a contiguous range of SRT listener ports from Strom and only
+accepts listener sources and outputs inside its range.
 
-Caller sources (`srt://host:PORT?mode=caller`), WHIP and HTML sources are not
+Caller addresses (`srt://host:PORT?mode=caller`), WHIP, WHEP and HTML are not
 affected.
 
 ## What the server does
@@ -37,15 +37,16 @@ sources they register:
 
 `srtPortLease` is one of:
 
-| Value | Meaning | Listener sources |
+| Value | Meaning | Listener sources and outputs |
 |---|---|---|
 | `leased` | Range acquired; `srtPortRange` is set | Must use a port in the range, otherwise `422` |
 | `pending` | Not acquired yet (Strom unreachable or pool full) | Rejected with `503` until the lease is acquired |
 | `unsupported` | Strom has no port lease API | Accepted, not checked |
 | `disabled` | `STROM_PORT_LEASE_DISABLED=true` | Accepted, not checked |
 
-`POST /api/v1/sources` and `PATCH /api/v1/sources/:id` apply the check when the
-address is a hostless SRT listener. A `422` response names the allowed range.
+`POST`/`PATCH` on `/api/v1/sources` and `/api/v1/outputs` apply the check when
+the address or URL is a hostless SRT listener. A `422` response names the
+allowed range.
 
 ## Environment variables
 
@@ -62,5 +63,7 @@ address is a hostless SRT listener. A `422` response names the allowed range.
 - If the server logs `Failed to acquire SRT port range` with a `409` from Strom,
   the pool cannot fit the request: lower `STROM_PORT_LEASE_SIZE`, release
   leases from decommissioned instances, or grow the pool on Strom.
-- Sources created before the lease existed are not re-validated on rename. They
-  are checked again the next time their address or stream type is edited.
+- Sources and outputs created before the lease existed are not re-validated on
+  rename. They are checked again the next time their address or URL is edited.
+- Size the range for sources and outputs together: a production's SRT outputs
+  in listener mode take ports from the same block.

--- a/docs/port-lease.md
+++ b/docs/port-lease.md
@@ -3,8 +3,13 @@
 When several Open Live instances share one Strom, every SRT *listener* source
 or output (`srt://:PORT?mode=listener`) binds a port on that same Strom. Two
 instances picking the same port would collide. To prevent that, each Open Live
-instance leases a contiguous range of SRT listener ports from Strom and only
-accepts listener sources and outputs inside its range.
+instance leases a contiguous range of SRT listener ports and only accepts
+listener sources and outputs inside its range.
+
+The lease requests go to `STROM_URL` under `/api/port-leases`. On a shared
+Strom a proxy in front of it routes that path to a port broker service, which
+owns the pool; everything else passes through to Strom. A self-hosted Strom
+with no proxy answers 404, and Open Live then applies no port restriction.
 
 Caller addresses (`srt://host:PORT?mode=caller`), WHIP, WHEP and HTML are not
 affected.
@@ -19,8 +24,9 @@ affected.
   under the same client id and logs a warning if the range changed.
 - **On `SIGTERM` / `SIGINT`** it releases the lease so the ports are free for
   the next instance.
-- **If Strom is too old** to have the port lease API, the server logs one
-  warning, stops enforcing ports, and re-checks every 10 minutes.
+- **If nothing answers the lease routes** (a Strom with no port broker in
+  front of it), the server logs one warning, stops enforcing ports, and
+  re-checks every 10 minutes.
 
 ## Effect on the API
 
@@ -41,7 +47,7 @@ sources they register:
 |---|---|---|
 | `leased` | Range acquired; `srtPortRange` is set | Must use a port in the range, otherwise `422` |
 | `pending` | Not acquired yet (Strom unreachable or pool full) | Rejected with `503` until the lease is acquired |
-| `unsupported` | Strom has no port lease API | Accepted, not checked |
+| `unsupported` | No port broker answers at `STROM_URL` | Accepted, not checked |
 | `disabled` | `STROM_PORT_LEASE_DISABLED=true` | Accepted, not checked |
 
 `POST`/`PATCH` on `/api/v1/sources` and `/api/v1/outputs` apply the check when
@@ -62,7 +68,7 @@ allowed range.
   active at once; the pool on Strom is shared, so do not over-allocate.
 - If the server logs `Failed to acquire SRT port range` with a `409` from Strom,
   the pool cannot fit the request: lower `STROM_PORT_LEASE_SIZE`, release
-  leases from decommissioned instances, or grow the pool on Strom.
+  leases from decommissioned instances, or grow the pool on the port broker.
 - Sources and outputs created before the lease existed are not re-validated on
   rename. They are checked again the next time their address or URL is edited.
 - Size the range for sources and outputs together: a production's SRT outputs

--- a/src/__tests__/listener-ports.test.ts
+++ b/src/__tests__/listener-ports.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The pure parts of port assignment inside the leased block.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { PortLease } from '../lib/strom.js';
+import {
+  clashesAfterWrite,
+  listenerPortRequest,
+  lowestFreePort,
+  resolveListenerAddress,
+  withListenerPort,
+} from '../services/listener-ports.js';
+import type { ListenerPortUse } from '../services/listener-ports.js';
+
+const LEASE: PortLease = {
+  id: 'lease-1',
+  client_id: 'test',
+  first_port: 47100,
+  last_port: 47104,
+  created_at: '2026-01-01T00:00:00Z',
+  expires_at: '2026-01-01T00:10:00Z',
+};
+const leased = { status: 'leased' as const, lease: LEASE };
+const used: ListenerPortUse[] = [
+  { kind: 'source', id: 's1', name: 'Cam 1', port: 47100 },
+  { kind: 'output', id: 'o1', name: 'Program', port: 47102 },
+];
+
+describe('listenerPortRequest', () => {
+  it('reads the port, with 0 meaning assign', () => {
+    expect(listenerPortRequest('srt://:47100?mode=listener')).toBe(47100);
+    expect(listenerPortRequest('srt://:0?mode=listener&passphrase=abc')).toBe(0);
+    expect(listenerPortRequest('srt://:0')).toBe(0);
+  });
+  it('is null for anything that binds nothing here', () => {
+    expect(listenerPortRequest('srt://cdn.example.com:9000?mode=caller')).toBeNull();
+    expect(listenerPortRequest('srt://:9000?mode=caller')).toBeNull();
+    expect(listenerPortRequest('https://example.com')).toBeNull();
+    expect(listenerPortRequest('srt://:70000')).toBeNull();
+  });
+});
+
+describe('withListenerPort', () => {
+  it('replaces only the port', () => {
+    expect(withListenerPort('srt://:0?mode=listener&latency=200', 47103)).toBe('srt://:47103?mode=listener&latency=200');
+    expect(withListenerPort(' srt://:47100 ', 47101)).toBe('srt://:47101');
+  });
+});
+
+describe('lowestFreePort', () => {
+  it('finds the first gap and reports a full range', () => {
+    expect(lowestFreePort(LEASE, new Set([47100, 47101]))).toBe(47102);
+    expect(lowestFreePort(LEASE, new Set([47100, 47101, 47102, 47103, 47104]))).toBeNull();
+  });
+});
+
+describe('resolveListenerAddress', () => {
+  it('passes non-listener addresses through', () => {
+    expect(resolveListenerAddress('srt://cdn.example.com:9000?mode=caller', leased, used)).toEqual({
+      ok: true, address: 'srt://cdn.example.com:9000?mode=caller', port: null,
+    });
+  });
+
+  it('assigns the lowest free port, skipping sources and outputs alike', () => {
+    expect(resolveListenerAddress('srt://:0?mode=listener', leased, used)).toEqual({
+      ok: true, address: 'srt://:47101?mode=listener', port: 47101,
+    });
+  });
+
+  it('keeps a valid current port on an assignment request', () => {
+    const r = resolveListenerAddress('srt://:0?mode=listener', leased, used, { exclude: { kind: 'source', id: 's1' }, keep: 47100 });
+    expect(r).toEqual({ ok: true, address: 'srt://:47100?mode=listener', port: 47100 });
+  });
+
+  it('does not keep a current port that is now out of range or taken', () => {
+    const out = resolveListenerAddress('srt://:0', leased, used, { keep: 9000 });
+    expect(out).toMatchObject({ ok: true, port: 47101 });
+    const taken = resolveListenerAddress('srt://:0', leased, used, { exclude: { kind: 'source', id: 'other' }, keep: 47102 });
+    expect(taken).toMatchObject({ ok: true, port: 47101 });
+  });
+
+  it('refuses an explicit port outside the range, or held by someone else', () => {
+    expect(resolveListenerAddress('srt://:9000?mode=listener', leased, used)).toMatchObject({ ok: false, statusCode: 422 });
+    const held = resolveListenerAddress('srt://:47102?mode=listener', leased, used);
+    expect(held).toMatchObject({ ok: false, statusCode: 409 });
+    expect((held as { error: string }).error).toContain('output "Program"');
+  });
+
+  it('lets a document keep its own explicit port', () => {
+    expect(resolveListenerAddress('srt://:47100?mode=listener', leased, used, { exclude: { kind: 'source', id: 's1' } }))
+      .toMatchObject({ ok: true, port: 47100 });
+  });
+
+  it('answers 409 when nothing is free', () => {
+    const full: ListenerPortUse[] = [47100, 47101, 47102, 47103, 47104].map((port, i) => ({ kind: 'source', id: `s${i}`, name: `S${i}`, port }));
+    expect(resolveListenerAddress('srt://:0', leased, full)).toMatchObject({ ok: false, statusCode: 409 });
+  });
+
+  it('waits while the lease is pending, for explicit and assigned ports alike', () => {
+    expect(resolveListenerAddress('srt://:0', { status: 'pending' }, [])).toMatchObject({ ok: false, statusCode: 503 });
+    expect(resolveListenerAddress('srt://:47100', { status: 'pending' }, [])).toMatchObject({ ok: false, statusCode: 503 });
+  });
+
+  it('without a range: explicit ports only need to be unique, and nothing can be assigned', () => {
+    for (const status of ['unsupported', 'disabled'] as const) {
+      expect(resolveListenerAddress('srt://:47100', { status }, used)).toMatchObject({ ok: false, statusCode: 409 });
+      expect(resolveListenerAddress('srt://:9000', { status }, used)).toMatchObject({ ok: true, port: 9000 });
+      expect(resolveListenerAddress('srt://:0', { status }, used)).toMatchObject({ ok: false, statusCode: 400 });
+    }
+  });
+});
+
+describe('clashesAfterWrite', () => {
+  it('finds another holder of our port but not ourselves', () => {
+    expect(clashesAfterWrite(used, { kind: 'source', id: 's1' }, 47100)).toBeUndefined();
+    expect(clashesAfterWrite(used, { kind: 'source', id: 'me' }, 47100)?.id).toBe('s1');
+  });
+});

--- a/src/__tests__/port-lease-routes.test.ts
+++ b/src/__tests__/port-lease-routes.test.ts
@@ -1,6 +1,7 @@
 /**
  * Route tests for the SRT port lease: /api/v1/server-info exposes the leased
- * range, and /api/v1/sources and /api/v1/outputs reject listener ports outside it.
+ * range, /api/v1/sources and /api/v1/outputs reject listener ports outside it or
+ * held by another document, and assign one when asked with port 0.
  *
  * CouchDB, Strom client, and the WS controller are mocked — no real services
  * required. The lease state is set directly through the service's test hook.
@@ -17,13 +18,17 @@ import type { OutputDoc, SourceDoc } from '../db/types.js';
 
 const mockSourcesGet = vi.fn();
 const mockSourcesInsert = vi.fn();
+const mockSourcesFind = vi.fn();
+const mockSourcesDestroy = vi.fn();
 const mockOutputsGet = vi.fn();
 const mockOutputsInsert = vi.fn();
+const mockOutputsFind = vi.fn();
+const mockOutputsDestroy = vi.fn();
 
 vi.mock('../db/index.js', () => ({
   getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
-  getSourcesDb: () => ({ get: mockSourcesGet, insert: mockSourcesInsert }),
-  getOutputsDb: () => ({ get: mockOutputsGet, insert: mockOutputsInsert }),
+  getSourcesDb: () => ({ get: mockSourcesGet, insert: mockSourcesInsert, find: mockSourcesFind, destroy: mockSourcesDestroy }),
+  getOutputsDb: () => ({ get: mockOutputsGet, insert: mockOutputsInsert, find: mockOutputsFind, destroy: mockOutputsDestroy }),
   connectDb: vi.fn().mockResolvedValue(undefined),
   isDbReady: vi.fn().mockResolvedValue(true),
   isDbConnected: vi.fn().mockReturnValue(true),
@@ -117,12 +122,18 @@ beforeAll(async () => {
 beforeEach(() => {
   mockSourcesGet.mockReset();
   mockSourcesInsert.mockReset();
-  mockSourcesInsert.mockResolvedValue({ ok: true });
+  mockSourcesInsert.mockResolvedValue({ ok: true, rev: '1-new' });
   mockSourcesGet.mockResolvedValue(EXISTING_SOURCE);
+  mockSourcesFind.mockReset();
+  mockSourcesFind.mockResolvedValue({ docs: [EXISTING_SOURCE] });
+  mockSourcesDestroy.mockReset();
   mockOutputsGet.mockReset();
   mockOutputsInsert.mockReset();
-  mockOutputsInsert.mockResolvedValue({ ok: true });
+  mockOutputsInsert.mockResolvedValue({ ok: true, rev: '1-new' });
   mockOutputsGet.mockResolvedValue(EXISTING_OUTPUT);
+  mockOutputsFind.mockReset();
+  mockOutputsFind.mockResolvedValue({ docs: [EXISTING_OUTPUT] });
+  mockOutputsDestroy.mockReset();
 });
 
 describe('GET /api/v1/server-info', () => {
@@ -197,6 +208,78 @@ describe('POST /api/v1/sources port lease enforcement', () => {
   });
 });
 
+describe('POST /api/v1/sources port assignment', () => {
+  const post = (address: string) =>
+    app.inject({ method: 'POST', url: '/api/v1/sources', payload: { name: 'Cam', address, streamType: 'srt' } });
+
+  it('assigns the lowest free port in the range for port 0', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    // 47105 is held by the existing source, 47118 by the existing output.
+    const res = await post('srt://:0?mode=listener&latency=200');
+    expect(res.statusCode).toBe(201);
+    expect(res.json().address).toBe('srt://:47100?mode=listener&latency=200');
+  });
+
+  it('skips ports held by other sources and outputs', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    mockSourcesFind.mockResolvedValue({ docs: [
+      { ...EXISTING_SOURCE, _id: 's1', address: 'srt://:47100?mode=listener' },
+      { ...EXISTING_SOURCE, _id: 's2', address: 'srt://:47101?mode=listener' },
+    ] });
+    mockOutputsFind.mockResolvedValue({ docs: [{ ...EXISTING_OUTPUT, url: 'srt://:47102?mode=listener' }] });
+    const res = await post('srt://:0?mode=listener');
+    expect(res.statusCode).toBe(201);
+    expect(res.json().address).toBe('srt://:47103?mode=listener');
+  });
+
+  it('rejects an explicit port another source holds with 409 naming it', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:47105?mode=listener');
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain('Camera 1');
+    expect(mockSourcesInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an explicit port an output holds even without a lease', async () => {
+    _resetPortLeaseState({ status: 'unsupported' });
+    const res = await post('srt://:47118?mode=listener');
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain('Program');
+  });
+
+  it('answers 409 when the range is full', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: { ...LEASE, first_port: 47100, last_port: 47101 } });
+    mockSourcesFind.mockResolvedValue({ docs: [
+      { ...EXISTING_SOURCE, _id: 's1', address: 'srt://:47100?mode=listener' },
+      { ...EXISTING_SOURCE, _id: 's2', address: 'srt://:47101?mode=listener' },
+    ] });
+    mockOutputsFind.mockResolvedValue({ docs: [] });
+    const res = await post('srt://:0?mode=listener');
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain('No free SRT listener port');
+  });
+
+  it('cannot assign without a range and says so', async () => {
+    _resetPortLeaseState({ status: 'unsupported' });
+    const res = await post('srt://:0?mode=listener');
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('retries with another port when the assigned one was taken meanwhile', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    mockSourcesFind
+      .mockResolvedValueOnce({ docs: [] })                                                        // before the write: all free
+      .mockResolvedValueOnce({ docs: [{ ...EXISTING_SOURCE, _id: 'racer', name: 'Racer', address: 'srt://:47100?mode=listener' }] }) // after: someone took 47100
+      .mockResolvedValue({ docs: [{ ...EXISTING_SOURCE, _id: 'racer', name: 'Racer', address: 'srt://:47100?mode=listener' }] });
+    mockOutputsFind.mockResolvedValue({ docs: [] });
+    const res = await post('srt://:0?mode=listener');
+    expect(res.statusCode).toBe(201);
+    expect(res.json().address).toBe('srt://:47101?mode=listener');
+    expect(mockSourcesDestroy).toHaveBeenCalledTimes(1);
+    expect(mockSourcesInsert).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('PATCH /api/v1/sources/:id port lease enforcement', () => {
   const patch = (payload: Record<string, unknown>) =>
     app.inject({ method: 'PATCH', url: '/api/v1/sources/src-1', payload });
@@ -227,6 +310,20 @@ describe('PATCH /api/v1/sources/:id port lease enforcement', () => {
     const res = await patch({ name: 'Camera 1 (renamed)' });
     expect(res.statusCode).toBe(200);
     expect(mockSourcesInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the current port when patched with port 0', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await patch({ address: 'srt://:0?mode=listener&latency=300' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().address).toBe('srt://:47105?mode=listener&latency=300');
+  });
+
+  it('rejects a move onto a port another document holds', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await patch({ address: 'srt://:47118?mode=listener' });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain('Program');
   });
 
   it('re-checks the stored address when the stream type changes to srt', async () => {
@@ -273,6 +370,22 @@ describe('POST /api/v1/outputs port lease enforcement', () => {
     _resetPortLeaseState({ status: 'leased', lease: LEASE });
     const res = await post('srt://cdn.example.com:9000?mode=caller');
     expect(res.statusCode).toBe(201);
+  });
+
+  it('assigns a port for port 0, skipping the ports sources hold', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    mockSourcesFind.mockResolvedValue({ docs: [{ ...EXISTING_SOURCE, address: 'srt://:47100?mode=listener' }] });
+    mockOutputsFind.mockResolvedValue({ docs: [] });
+    const res = await post('srt://:0?mode=listener');
+    expect(res.statusCode).toBe(201);
+    expect(res.json().url).toBe('srt://:47101?mode=listener');
+  });
+
+  it('rejects an explicit port a source holds with 409', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:47105?mode=listener');
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain('Camera 1');
   });
 
   it('does not check WHEP outputs', async () => {

--- a/src/__tests__/port-lease-routes.test.ts
+++ b/src/__tests__/port-lease-routes.test.ts
@@ -1,6 +1,6 @@
 /**
  * Route tests for the SRT port lease: /api/v1/server-info exposes the leased
- * range, and /api/v1/sources rejects listener ports outside it.
+ * range, and /api/v1/sources and /api/v1/outputs reject listener ports outside it.
  *
  * CouchDB, Strom client, and the WS controller are mocked — no real services
  * required. The lease state is set directly through the service's test hook.
@@ -9,7 +9,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import type { PortLease } from '../lib/strom.js';
-import type { SourceDoc } from '../db/types.js';
+import type { OutputDoc, SourceDoc } from '../db/types.js';
 
 // ---------------------------------------------------------------------------
 // Mock CouchDB
@@ -17,10 +17,13 @@ import type { SourceDoc } from '../db/types.js';
 
 const mockSourcesGet = vi.fn();
 const mockSourcesInsert = vi.fn();
+const mockOutputsGet = vi.fn();
+const mockOutputsInsert = vi.fn();
 
 vi.mock('../db/index.js', () => ({
   getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
   getSourcesDb: () => ({ get: mockSourcesGet, insert: mockSourcesInsert }),
+  getOutputsDb: () => ({ get: mockOutputsGet, insert: mockOutputsInsert }),
   connectDb: vi.fn().mockResolvedValue(undefined),
   isDbReady: vi.fn().mockResolvedValue(true),
   isDbConnected: vi.fn().mockReturnValue(true),
@@ -91,6 +94,17 @@ const EXISTING_SOURCE: SourceDoc = {
   updatedAt: '2026-01-01T00:00:00Z',
 };
 
+const EXISTING_OUTPUT: OutputDoc = {
+  _id: 'output-1',
+  _rev: '1-abc',
+  type: 'output',
+  name: 'Program',
+  outputType: 'mpegtssrt',
+  url: 'srt://:47118?mode=listener',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
 let app: FastifyInstance;
 let _resetPortLeaseState: typeof import('../services/port-lease.js')._resetPortLeaseState;
 
@@ -105,6 +119,10 @@ beforeEach(() => {
   mockSourcesInsert.mockReset();
   mockSourcesInsert.mockResolvedValue({ ok: true });
   mockSourcesGet.mockResolvedValue(EXISTING_SOURCE);
+  mockOutputsGet.mockReset();
+  mockOutputsInsert.mockReset();
+  mockOutputsInsert.mockResolvedValue({ ok: true });
+  mockOutputsGet.mockResolvedValue(EXISTING_OUTPUT);
 });
 
 describe('GET /api/v1/server-info', () => {
@@ -216,5 +234,82 @@ describe('PATCH /api/v1/sources/:id port lease enforcement', () => {
     mockSourcesGet.mockResolvedValue({ ...EXISTING_SOURCE, streamType: 'efp', address: 'srt://:9000?mode=listener' });
     const res = await patch({ streamType: 'srt' });
     expect(res.statusCode).toBe(422);
+  });
+});
+
+describe('POST /api/v1/outputs port lease enforcement', () => {
+  const post = (url: string, outputType = 'mpegtssrt') =>
+    app.inject({ method: 'POST', url: '/api/v1/outputs', payload: { name: 'Program', url, outputType } });
+
+  it('accepts an in-range listener port', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:47119?mode=listener');
+    expect(res.statusCode).toBe(201);
+    expect(mockOutputsInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an out-of-range listener port with 422 naming the range', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:43524?mode=listener');
+    expect(res.statusCode).toBe(422);
+    expect(res.json().error).toContain('47100-47119');
+    expect(mockOutputsInsert).not.toHaveBeenCalled();
+  });
+
+  it('applies the same check to efpsrt outputs', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:43524?mode=listener', 'efpsrt');
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('rejects listener outputs with 503 while the lease is pending', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await post('srt://:47119?mode=listener');
+    expect(res.statusCode).toBe(503);
+    expect(mockOutputsInsert).not.toHaveBeenCalled();
+  });
+
+  it('does not check caller-form URLs', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://cdn.example.com:9000?mode=caller');
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('does not check WHEP outputs', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await app.inject({ method: 'POST', url: '/api/v1/outputs', payload: { name: 'Web', outputType: 'whep' } });
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe('PATCH /api/v1/outputs/:id port lease enforcement', () => {
+  const patch = (payload: Record<string, unknown>) =>
+    app.inject({ method: 'PATCH', url: '/api/v1/outputs/output-1', payload });
+
+  it('rejects a new out-of-range listener URL with 422', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await patch({ url: 'srt://:9000?mode=listener' });
+    expect(res.statusCode).toBe(422);
+    expect(mockOutputsInsert).not.toHaveBeenCalled();
+  });
+
+  it('accepts a new in-range listener URL', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await patch({ url: 'srt://:47110?mode=listener' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().url).toBe('srt://:47110?mode=listener');
+  });
+
+  it('returns 503 for a listener URL while the lease is pending', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await patch({ url: 'srt://:47110?mode=listener' });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('does not re-check the stored URL on a rename', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await patch({ name: 'Program (renamed)' });
+    expect(res.statusCode).toBe(200);
+    expect(mockOutputsInsert).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/port-lease-routes.test.ts
+++ b/src/__tests__/port-lease-routes.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Route tests for the SRT port lease: /api/v1/server-info exposes the leased
+ * range, and /api/v1/sources rejects listener ports outside it.
+ *
+ * CouchDB, Strom client, and the WS controller are mocked — no real services
+ * required. The lease state is set directly through the service's test hook.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type { PortLease } from '../lib/strom.js';
+import type { SourceDoc } from '../db/types.js';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+const mockSourcesGet = vi.fn();
+const mockSourcesInsert = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  getSourcesDb: () => ({ get: mockSourcesGet, insert: mockSourcesInsert }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket controller (avoids startup side effects)
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient / flow-generator (imported transitively via routes)
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: vi.fn(),
+  deactivateStromFlow: vi.fn(),
+}));
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = { version: vi.fn(), iceServers: vi.fn() };
+    flows = {
+      get: vi.fn(),
+      start: vi.fn().mockResolvedValue({}),
+      stop: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    mixer = { multiviewEndpoint: vi.fn() };
+    portLeases = { acquire: vi.fn(), renew: vi.fn(), release: vi.fn(), list: vi.fn(), get: vi.fn() };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const LEASE: PortLease = {
+  id: 'lease-1',
+  client_id: 'open-live-test',
+  first_port: 47100,
+  last_port: 47119,
+  created_at: '2026-01-01T00:00:00Z',
+  expires_at: '2026-01-01T00:10:00Z',
+};
+
+const EXISTING_SOURCE: SourceDoc = {
+  _id: 'src-1',
+  _rev: '1-abc',
+  type: 'source',
+  name: 'Camera 1',
+  address: 'srt://:47105?mode=listener',
+  streamType: 'srt',
+  status: 'inactive',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+let app: FastifyInstance;
+let _resetPortLeaseState: typeof import('../services/port-lease.js')._resetPortLeaseState;
+
+beforeAll(async () => {
+  ({ _resetPortLeaseState } = await import('../services/port-lease.js'));
+  const { buildServer } = await import('../server.js');
+  app = await buildServer();
+});
+
+beforeEach(() => {
+  mockSourcesGet.mockReset();
+  mockSourcesInsert.mockReset();
+  mockSourcesInsert.mockResolvedValue({ ok: true });
+  mockSourcesGet.mockResolvedValue(EXISTING_SOURCE);
+});
+
+describe('GET /api/v1/server-info', () => {
+  it('reports the leased range', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/server-info' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      stromHost: 'localhost',
+      srtPortRange: { first: 47100, last: 47119 },
+      srtPortLease: 'leased',
+    });
+  });
+
+  it.each(['pending', 'unsupported', 'disabled'] as const)('reports %s with a null range', async (status) => {
+    _resetPortLeaseState({ status });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/server-info' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ stromHost: 'localhost', srtPortRange: null, srtPortLease: status });
+  });
+});
+
+describe('POST /api/v1/sources port lease enforcement', () => {
+  const post = (address: string, streamType = 'srt') =>
+    app.inject({ method: 'POST', url: '/api/v1/sources', payload: { name: 'Cam', address, streamType } });
+
+  it('accepts an in-range listener port', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:47110?mode=listener');
+    expect(res.statusCode).toBe(201);
+    expect(mockSourcesInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an out-of-range listener port with 422 naming the range', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:9000?mode=listener');
+    expect(res.statusCode).toBe(422);
+    expect(res.json().error).toContain('47100-47119');
+    expect(mockSourcesInsert).not.toHaveBeenCalled();
+  });
+
+  it('applies the same check to efp sources', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://:9000?mode=listener', 'efp');
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('rejects listener sources with 503 while the lease is pending', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await post('srt://:47110?mode=listener');
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toMatchObject({ error: 'SRT port range not yet allocated from Strom, retry shortly' });
+    expect(mockSourcesInsert).not.toHaveBeenCalled();
+  });
+
+  it('does not check caller-form addresses', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await post('srt://ingest.example.com:9000?mode=caller');
+    expect(res.statusCode).toBe(201);
+  });
+
+  it.each(['unsupported', 'disabled'] as const)('does not check when the lease is %s', async (status) => {
+    _resetPortLeaseState({ status });
+    const res = await post('srt://:9000?mode=listener');
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('still runs the SRT URL validation before the lease check', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await post('srt://127.0.0.1:47110?mode=caller');
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('PATCH /api/v1/sources/:id port lease enforcement', () => {
+  const patch = (payload: Record<string, unknown>) =>
+    app.inject({ method: 'PATCH', url: '/api/v1/sources/src-1', payload });
+
+  it('rejects a new out-of-range listener address with 422', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await patch({ address: 'srt://:9000?mode=listener' });
+    expect(res.statusCode).toBe(422);
+    expect(res.json().error).toContain('47100-47119');
+    expect(mockSourcesInsert).not.toHaveBeenCalled();
+  });
+
+  it('accepts a new in-range listener address', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    const res = await patch({ address: 'srt://:47111?mode=listener' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().address).toBe('srt://:47111?mode=listener');
+  });
+
+  it('returns 503 for a listener address while the lease is pending', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await patch({ address: 'srt://:47111?mode=listener' });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('does not re-check the stored address on a rename', async () => {
+    _resetPortLeaseState({ status: 'pending' });
+    const res = await patch({ name: 'Camera 1 (renamed)' });
+    expect(res.statusCode).toBe(200);
+    expect(mockSourcesInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-checks the stored address when the stream type changes to srt', async () => {
+    _resetPortLeaseState({ status: 'leased', lease: LEASE });
+    mockSourcesGet.mockResolvedValue({ ...EXISTING_SOURCE, streamType: 'efp', address: 'srt://:9000?mode=listener' });
+    const res = await patch({ streamType: 'srt' });
+    expect(res.statusCode).toBe(422);
+  });
+});

--- a/src/__tests__/port-lease.test.ts
+++ b/src/__tests__/port-lease.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the Strom SRT port lease service.
+ *
+ * Pure helpers are tested directly. The acquire / renew / re-acquire cycle is
+ * driven through tickPortLease() with a fake Strom client — no real Strom.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FastifyBaseLogger } from 'fastify';
+import { StromClientError } from '../lib/strom.js';
+import type { PortLease } from '../lib/strom.js';
+import {
+  deriveClientId,
+  parseListenerPort,
+  isPortInLease,
+  evaluateListenerPort,
+  getPortLease,
+  tickPortLease,
+  stopPortLease,
+  _setStromClientFactory,
+  _resetPortLeaseState,
+} from '../services/port-lease.js';
+
+const LEASE: PortLease = {
+  id: 'lease-1',
+  client_id: 'open-live-test',
+  first_port: 47100,
+  last_port: 47119,
+  created_at: '2026-01-01T00:00:00Z',
+  expires_at: '2026-01-01T00:10:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('deriveClientId', () => {
+  it('prefers the explicit override', () => {
+    expect(deriveClientId({ stromPortLeaseClientId: 'custom', publicBaseUrl: 'https://live.example.com' }, 'box')).toBe('custom');
+  });
+
+  it('uses the hostname of PUBLIC_BASE_URL when set', () => {
+    expect(deriveClientId({ publicBaseUrl: 'https://live.example.com:8443/base' }, 'box')).toBe('live.example.com');
+  });
+
+  it('falls back to open-live-<hostname> when PUBLIC_BASE_URL is unset', () => {
+    expect(deriveClientId({}, 'box')).toBe('open-live-box');
+  });
+
+  it('falls back to open-live-<hostname> when PUBLIC_BASE_URL is not a URL', () => {
+    expect(deriveClientId({ publicBaseUrl: 'not a url' }, 'box')).toBe('open-live-box');
+  });
+});
+
+describe('parseListenerPort', () => {
+  it('returns the port for a hostless listener address', () => {
+    expect(parseListenerPort('srt://:47110?mode=listener')).toBe(47110);
+    expect(parseListenerPort('srt://:47110?mode=listener&latency=200&passphrase=abc')).toBe(47110);
+    expect(parseListenerPort('srt://:47110?latency=200&mode=listener')).toBe(47110);
+  });
+
+  it('treats a hostless address without a mode as a listener', () => {
+    expect(parseListenerPort('srt://:47110')).toBe(47110);
+    expect(parseListenerPort('srt://:47110?latency=200')).toBe(47110);
+  });
+
+  it('returns null for caller form with a host', () => {
+    expect(parseListenerPort('srt://ingest.example.com:47110?mode=caller')).toBeNull();
+    expect(parseListenerPort('srt://203.0.113.5:47110?mode=listener')).toBeNull();
+  });
+
+  it('returns null for hostless addresses with a non-listener mode', () => {
+    expect(parseListenerPort('srt://:47110?mode=caller')).toBeNull();
+    expect(parseListenerPort('srt://:47110?mode=rendezvous')).toBeNull();
+  });
+
+  it('returns null for non-SRT or malformed addresses', () => {
+    expect(parseListenerPort('https://example.com/whip')).toBeNull();
+    expect(parseListenerPort('srt://:0')).toBeNull();
+    expect(parseListenerPort('srt://:70000')).toBeNull();
+    expect(parseListenerPort('srt://')).toBeNull();
+  });
+});
+
+describe('isPortInLease', () => {
+  it('is inclusive at both ends', () => {
+    expect(isPortInLease(47100, LEASE)).toBe(true);
+    expect(isPortInLease(47119, LEASE)).toBe(true);
+    expect(isPortInLease(47110, LEASE)).toBe(true);
+  });
+
+  it('rejects ports just outside the range', () => {
+    expect(isPortInLease(47099, LEASE)).toBe(false);
+    expect(isPortInLease(47120, LEASE)).toBe(false);
+  });
+});
+
+describe('evaluateListenerPort', () => {
+  it('passes non-listener addresses regardless of state', () => {
+    expect(evaluateListenerPort('srt://ingest.example.com:9000?mode=caller', { status: 'pending' })).toEqual({ ok: true });
+    expect(evaluateListenerPort('https://example.com/whip', { status: 'leased', lease: LEASE })).toEqual({ ok: true });
+  });
+
+  it('returns 422 naming the range for an out-of-range listener port', () => {
+    const verdict = evaluateListenerPort('srt://:9000?mode=listener', { status: 'leased', lease: LEASE });
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.statusCode).toBe(422);
+    expect(verdict.error).toContain('47100-47119');
+    expect(verdict.error).toContain('9000');
+  });
+
+  it('passes an in-range listener port', () => {
+    expect(evaluateListenerPort('srt://:47105?mode=listener', { status: 'leased', lease: LEASE })).toEqual({ ok: true });
+  });
+
+  it('returns 503 while the lease is pending', () => {
+    expect(evaluateListenerPort('srt://:47105?mode=listener', { status: 'pending' })).toEqual({
+      ok: false,
+      statusCode: 503,
+      error: 'SRT port range not yet allocated from Strom, retry shortly',
+    });
+  });
+
+  it('does not check when unsupported or disabled', () => {
+    expect(evaluateListenerPort('srt://:9000?mode=listener', { status: 'unsupported' })).toEqual({ ok: true });
+    expect(evaluateListenerPort('srt://:9000?mode=listener', { status: 'disabled' })).toEqual({ ok: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service lifecycle with a fake Strom client
+// ---------------------------------------------------------------------------
+
+function makeLog(): FastifyBaseLogger {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    silent: vi.fn(),
+    level: 'silent',
+    child: vi.fn(),
+  };
+  log.child.mockReturnValue(log);
+  return log as unknown as FastifyBaseLogger;
+}
+
+function notFound(message = 'Lease not found'): StromClientError {
+  return new StromClientError(404, message);
+}
+
+describe('port lease service', () => {
+  const acquire = vi.fn();
+  const renew = vi.fn();
+  const release = vi.fn();
+  let log: FastifyBaseLogger;
+
+  beforeEach(() => {
+    acquire.mockReset();
+    renew.mockReset();
+    release.mockReset();
+    log = makeLog();
+    _resetPortLeaseState({ status: 'pending' });
+    _setStromClientFactory(async () => ({
+      portLeases: { acquire, renew, release, list: vi.fn(), get: vi.fn() },
+    }));
+  });
+
+  afterEach(() => {
+    _setStromClientFactory(null);
+    _resetPortLeaseState({ status: 'pending' });
+  });
+
+  it('acquires on the first tick, renews afterwards, and re-acquires when the renew 404s', async () => {
+    acquire.mockResolvedValueOnce(LEASE);
+    await tickPortLease(log);
+    expect(acquire).toHaveBeenCalledTimes(1);
+    expect(acquire.mock.calls[0]![0]).toMatchObject({ size: 20 });
+    expect(getPortLease()).toEqual({ status: 'leased', lease: LEASE });
+    const clientId = (acquire.mock.calls[0]![0] as { client_id: string }).client_id;
+    expect(clientId).toMatch(/^open-live-/);
+
+    // Second tick: renew, not acquire.
+    const renewed = { ...LEASE, expires_at: '2026-01-01T00:20:00Z' };
+    renew.mockResolvedValueOnce(renewed);
+    await tickPortLease(log);
+    expect(renew).toHaveBeenCalledWith(LEASE.id);
+    expect(acquire).toHaveBeenCalledTimes(1);
+    expect(getPortLease()).toEqual({ status: 'leased', lease: renewed });
+
+    // Third tick: Strom forgot the lease — re-acquire with the same client id.
+    const fresh = { ...LEASE, id: 'lease-2', first_port: 47200, last_port: 47219 };
+    renew.mockRejectedValueOnce(notFound());
+    acquire.mockResolvedValueOnce(fresh);
+    await tickPortLease(log);
+    expect(acquire).toHaveBeenCalledTimes(2);
+    expect((acquire.mock.calls[1]![0] as { client_id: string }).client_id).toBe(clientId);
+    expect(getPortLease()).toEqual({ status: 'leased', lease: fresh });
+    // Range changed — operators are warned.
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ previous: '47100-47119', current: '47200-47219' }),
+      expect.stringContaining('different port range'),
+    );
+  });
+
+  it('stays pending and retries when acquisition fails', async () => {
+    acquire.mockRejectedValueOnce(new StromClientError(409, 'pool exhausted'));
+    await tickPortLease(log);
+    expect(getPortLease()).toEqual({ status: 'pending' });
+    expect(log.warn).toHaveBeenCalledTimes(1);
+
+    acquire.mockResolvedValueOnce(LEASE);
+    await tickPortLease(log);
+    expect(acquire).toHaveBeenCalledTimes(2);
+    expect(getPortLease()).toEqual({ status: 'leased', lease: LEASE });
+  });
+
+  it('keeps the last known range when a renew fails for a reason other than 404', async () => {
+    acquire.mockResolvedValueOnce(LEASE);
+    await tickPortLease(log);
+    renew.mockRejectedValueOnce(new StromClientError(0, 'Strom unreachable'));
+    await tickPortLease(log);
+    expect(getPortLease()).toEqual({ status: 'leased', lease: LEASE });
+    expect(acquire).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks an old Strom as unsupported after one warning and stops trying', async () => {
+    acquire.mockRejectedValue(new StromClientError(404, 'API endpoint not found'));
+    await tickPortLease(log);
+    expect(getPortLease()).toEqual({ status: 'unsupported' });
+    expect(log.warn).toHaveBeenCalledTimes(1);
+
+    // Subsequent ticks inside the 10 min back-off do not hit Strom again.
+    await tickPortLease(log);
+    await tickPortLease(log);
+    expect(acquire).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-probes an unsupported Strom after the back-off window', async () => {
+    vi.useFakeTimers();
+    try {
+      acquire.mockRejectedValueOnce(new StromClientError(404, 'API endpoint not found'));
+      await tickPortLease(log);
+      expect(getPortLease()).toEqual({ status: 'unsupported' });
+
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+      acquire.mockResolvedValueOnce(LEASE);
+      await tickPortLease(log);
+      expect(acquire).toHaveBeenCalledTimes(2);
+      expect(getPortLease()).toEqual({ status: 'leased', lease: LEASE });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does nothing when disabled', async () => {
+    _resetPortLeaseState({ status: 'disabled' });
+    await tickPortLease(log);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(getPortLease()).toEqual({ status: 'disabled' });
+  });
+
+  it('releases the lease on stop and tolerates a failing release', async () => {
+    acquire.mockResolvedValueOnce(LEASE);
+    await tickPortLease(log);
+    release.mockResolvedValueOnce(undefined);
+    await stopPortLease(log);
+    expect(release).toHaveBeenCalledWith(LEASE.id);
+    expect(getPortLease()).toEqual({ status: 'pending' });
+
+    // No lease held: nothing to release.
+    await stopPortLease(log);
+    expect(release).toHaveBeenCalledTimes(1);
+
+    // Failing release must not throw.
+    acquire.mockResolvedValueOnce(LEASE);
+    await tickPortLease(log);
+    release.mockRejectedValueOnce(notFound());
+    await expect(stopPortLease(log)).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/port-lease.test.ts
+++ b/src/__tests__/port-lease.test.ts
@@ -13,7 +13,6 @@ import {
   deriveClientId,
   parseListenerPort,
   isPortInLease,
-  evaluateListenerPort,
   getPortLease,
   tickPortLease,
   stopPortLease,
@@ -92,39 +91,6 @@ describe('isPortInLease', () => {
   it('rejects ports just outside the range', () => {
     expect(isPortInLease(47099, LEASE)).toBe(false);
     expect(isPortInLease(47120, LEASE)).toBe(false);
-  });
-});
-
-describe('evaluateListenerPort', () => {
-  it('passes non-listener addresses regardless of state', () => {
-    expect(evaluateListenerPort('srt://ingest.example.com:9000?mode=caller', { status: 'pending' })).toEqual({ ok: true });
-    expect(evaluateListenerPort('https://example.com/whip', { status: 'leased', lease: LEASE })).toEqual({ ok: true });
-  });
-
-  it('returns 422 naming the range for an out-of-range listener port', () => {
-    const verdict = evaluateListenerPort('srt://:9000?mode=listener', { status: 'leased', lease: LEASE });
-    expect(verdict.ok).toBe(false);
-    if (verdict.ok) return;
-    expect(verdict.statusCode).toBe(422);
-    expect(verdict.error).toContain('47100-47119');
-    expect(verdict.error).toContain('9000');
-  });
-
-  it('passes an in-range listener port', () => {
-    expect(evaluateListenerPort('srt://:47105?mode=listener', { status: 'leased', lease: LEASE })).toEqual({ ok: true });
-  });
-
-  it('returns 503 while the lease is pending', () => {
-    expect(evaluateListenerPort('srt://:47105?mode=listener', { status: 'pending' })).toEqual({
-      ok: false,
-      statusCode: 503,
-      error: 'SRT port range not yet allocated from Strom, retry shortly',
-    });
-  });
-
-  it('does not check when unsupported or disabled', () => {
-    expect(evaluateListenerPort('srt://:9000?mode=listener', { status: 'unsupported' })).toEqual({ ok: true });
-    expect(evaluateListenerPort('srt://:9000?mode=listener', { status: 'disabled' })).toEqual({ ok: true });
   });
 });
 

--- a/src/__tests__/port-lease.test.ts
+++ b/src/__tests__/port-lease.test.ts
@@ -240,6 +240,12 @@ describe('port lease service', () => {
     expect(log.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('treats any 404 on create as unsupported, whatever the body says', async () => {
+    acquire.mockRejectedValue(new StromClientError(404, '<html>nginx: not found</html>'));
+    await tickPortLease(log);
+    expect(getPortLease()).toEqual({ status: 'unsupported' });
+  });
+
   it('re-probes an unsupported Strom after the back-off window', async () => {
     vi.useFakeTimers();
     try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,22 @@ function requireEnv(name: string): string {
   return value;
 }
 
+function parseBoolEnv(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  return ['1', 'true', 'yes', 'on'].includes(raw.trim().toLowerCase());
+}
+
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`Environment variable ${name} must be a positive integer, got "${raw}"`);
+  }
+  return value;
+}
+
 function buildCouchdbUrl(): string {
   const raw = requireEnv('COUCHDB_URL');
   const url = new URL(raw);
@@ -58,4 +74,16 @@ export const config = {
     .split(',')
     .map((h) => h.trim().toLowerCase())
     .filter(Boolean),
+  /**
+   * Number of consecutive SRT listener ports to lease from the shared Strom
+   * instance at startup. Listener sources must use a port inside the leased range.
+   */
+  stromPortLeaseSize: parsePositiveIntEnv('STROM_PORT_LEASE_SIZE', 20),
+  /**
+   * Optional override for the lease client id sent to Strom. Defaults to the
+   * hostname of PUBLIC_BASE_URL, or `open-live-<hostname>` when that is unset.
+   */
+  stromPortLeaseClientId: process.env['STROM_PORT_LEASE_CLIENT_ID'] || undefined,
+  /** Set to true to skip port leasing entirely (single-tenant Strom setups). */
+  stromPortLeaseDisabled: parseBoolEnv('STROM_PORT_LEASE_DISABLED', false),
 } as const;

--- a/src/lib/strom.ts
+++ b/src/lib/strom.ts
@@ -617,6 +617,30 @@ export interface IceServersResponse {
   ice_servers: IceServer[]
 }
 
+// --- Port leases ---
+
+/** A range of SRT listener ports reserved for one client on a shared Strom instance. */
+export interface PortLease {
+  id: string
+  client_id: string
+  first_port: number
+  last_port: number
+  /** RFC 3339 timestamp */
+  created_at: string
+  /** RFC 3339 timestamp */
+  expires_at: string
+}
+
+export interface AcquirePortLeaseRequest {
+  client_id: string
+  size: number
+  ttl_secs?: number
+}
+
+export interface RenewPortLeaseRequest {
+  ttl_secs?: number
+}
+
 export interface WhepStreamsResponse {
   streams: Array<{ endpoint_id: string; mode: string; has_audio: boolean; has_video: boolean }>
 }
@@ -745,6 +769,20 @@ export class StromClient {
     version: () => this.get<SystemInfo>('/api/version'),
     iceServers: () => this.get<IceServersResponse>('/api/ice-servers'),
     networkInterfaces: () => this.get<NetworkInterfacesResponse>('/api/network/interfaces'),
+  }
+
+  // -------------------------------------------------------------------------
+  // Port leases
+  // -------------------------------------------------------------------------
+
+  portLeases = {
+    list: () => this.get<PortLease[]>('/api/port-leases'),
+    get: (id: string) => this.get<PortLease>(`/api/port-leases/${id}`),
+    /** Idempotent on client_id: returns the existing (renewed) lease if one is held. */
+    acquire: (body: AcquirePortLeaseRequest) => this.post<PortLease>('/api/port-leases', body),
+    renew: (id: string, body: RenewPortLeaseRequest = {}) =>
+      this.post<PortLease>(`/api/port-leases/${id}/renew`, body),
+    release: (id: string) => this.del<void>(`/api/port-leases/${id}`),
   }
 
   // -------------------------------------------------------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { config } from './config.js';
 import { startIdleWatchdog } from './services/idle-watchdog.js';
+import { startPortLease, stopPortLease } from './services/port-lease.js';
 import { connectDb, getDb, isDbConnected } from './db/index.js';
 import { cleanLegacyFixtures } from './db/seed.js';
 import { buildServer } from './server.js';
@@ -137,7 +138,22 @@ async function main() {
   }
 
   startIdleWatchdog(app.log);
+  startPortLease(app.log);
   await app.listen({ port: config.port, host: '0.0.0.0' });
+
+  // Graceful shutdown: release the Strom port lease so the range is free for
+  // the next instance, then close the server. Force-exit if it stalls.
+  const onSignal = (signal: NodeJS.Signals): void => {
+    app.log.info({ signal }, 'Shutting down');
+    setTimeout(() => process.exit(1), 5000).unref();
+    void (async () => {
+      await stopPortLease(app.log);
+      await app.close();
+      process.exit(0);
+    })();
+  };
+  process.once('SIGTERM', onSignal);
+  process.once('SIGINT', onSignal);
 }
 
 const shutdown = (err: unknown, origin: string): void => {

--- a/src/routes/outputs.ts
+++ b/src/routes/outputs.ts
@@ -5,6 +5,7 @@ import { getOutputsDb, getDb } from '../db/index.js';
 import type { OutputDoc, ProductionDoc } from '../db/types.js';
 import { updateProductionDoc } from './productions.js';
 import { srtUrl } from '../lib/url-validation.js';
+import { evaluateListenerPort, getPortLease } from '../services/port-lease.js';
 
 const SRT_OUTPUT_TYPES = new Set(['mpegtssrt', 'efpsrt']);
 
@@ -47,6 +48,13 @@ const outputsRoutes: FastifyPluginAsync = async (fastify) => {
 
   fastify.post('/api/v1/outputs', async (req, reply) => {
     const body = OutputInput.parse(req.body);
+    if (SRT_OUTPUT_TYPES.has(body.outputType) && body.url) {
+      // A listener output binds a port on the shared Strom, like a listener source does.
+      const verdict = evaluateListenerPort(body.url, getPortLease());
+      if (!verdict.ok) {
+        return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+      }
+    }
     const now = new Date().toISOString();
     const doc: OutputDoc = {
       _id: `output-${randomUUID()}`,
@@ -81,6 +89,14 @@ const outputsRoutes: FastifyPluginAsync = async (fastify) => {
           srtUrl(effectiveUrl);
         } catch (err) {
           return reply.status(400).send({ error: err instanceof Error ? err.message : 'Invalid SRT URL' });
+        }
+        // Re-check the lease only when the URL changes — a rename must not fail
+        // because an older output predates the lease.
+        if (body.url !== undefined) {
+          const verdict = evaluateListenerPort(effectiveUrl, getPortLease());
+          if (!verdict.ok) {
+            return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+          }
         }
       }
       const updated: OutputDoc = { ...doc, ...body, updatedAt: new Date().toISOString() };

--- a/src/routes/outputs.ts
+++ b/src/routes/outputs.ts
@@ -5,7 +5,8 @@ import { getOutputsDb, getDb } from '../db/index.js';
 import type { OutputDoc, ProductionDoc } from '../db/types.js';
 import { updateProductionDoc } from './productions.js';
 import { srtUrl } from '../lib/url-validation.js';
-import { evaluateListenerPort, getPortLease } from '../services/port-lease.js';
+import { getPortLease } from '../services/port-lease.js';
+import { clashesAfterWrite, listenerPortRequest, resolveListenerAddress, usedListenerPorts } from '../services/listener-ports.js';
 
 const SRT_OUTPUT_TYPES = new Set(['mpegtssrt', 'efpsrt']);
 
@@ -48,25 +49,42 @@ const outputsRoutes: FastifyPluginAsync = async (fastify) => {
 
   fastify.post('/api/v1/outputs', async (req, reply) => {
     const body = OutputInput.parse(req.body);
-    if (SRT_OUTPUT_TYPES.has(body.outputType) && body.url) {
-      // A listener output binds a port on the shared Strom, like a listener source does.
-      const verdict = evaluateListenerPort(body.url, getPortLease());
-      if (!verdict.ok) {
-        return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+    const isSrt = SRT_OUTPUT_TYPES.has(body.outputType) && !!body.url;
+    const id = `output-${randomUUID()}`;
+    // A listener output binds a port on the shared Strom, like a listener source
+    // does: same range, same uniqueness, same port-0 assignment, same re-check.
+    let used = isSrt ? await usedListenerPorts() : [];
+    for (let attempt = 0; ; attempt++) {
+      let url = body.url;
+      let port: number | null = null;
+      if (isSrt && url) {
+        const resolved = resolveListenerAddress(url, getPortLease(), used);
+        if (!resolved.ok) {
+          return reply.status(resolved.statusCode).send({ error: resolved.error, statusCode: resolved.statusCode });
+        }
+        ({ address: url, port } = resolved);
       }
+      const now = new Date().toISOString();
+      const doc: OutputDoc = {
+        _id: id,
+        type: 'output',
+        name: body.name,
+        outputType: body.outputType,
+        url,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const written = await getOutputsDb().insert(doc);
+      if (port === null) return reply.status(201).send(toApi(doc));
+      used = await usedListenerPorts();
+      const clash = clashesAfterWrite(used, { kind: 'output', id }, port);
+      if (!clash) return reply.status(201).send(toApi(doc));
+      await getOutputsDb().destroy(id, written.rev);
+      if (listenerPortRequest(body.url ?? '') !== 0 || attempt >= 3) {
+        return reply.status(409).send({ error: `SRT listener port ${port} is already used by ${clash.kind} "${clash.name}"`, statusCode: 409 });
+      }
+      fastify.log.warn({ port, clash }, 'listener port was taken while assigning it, choosing another');
     }
-    const now = new Date().toISOString();
-    const doc: OutputDoc = {
-      _id: `output-${randomUUID()}`,
-      type: 'output',
-      name: body.name,
-      outputType: body.outputType,
-      url: body.url,
-      createdAt: now,
-      updatedAt: now,
-    };
-    await getOutputsDb().insert(doc);
-    return reply.status(201).send(toApi(doc));
   });
 
   fastify.get<{ Params: { id: string } }>('/api/v1/outputs/:id', async (req, reply) => {
@@ -90,13 +108,17 @@ const outputsRoutes: FastifyPluginAsync = async (fastify) => {
         } catch (err) {
           return reply.status(400).send({ error: err instanceof Error ? err.message : 'Invalid SRT URL' });
         }
-        // Re-check the lease only when the URL changes — a rename must not fail
-        // because an older output predates the lease.
+        // Re-check the port only when the URL changes — a rename must not fail
+        // because an older output predates the lease. Port 0 keeps the current one.
         if (body.url !== undefined) {
-          const verdict = evaluateListenerPort(effectiveUrl, getPortLease());
-          if (!verdict.ok) {
-            return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+          const resolved = resolveListenerAddress(effectiveUrl, getPortLease(), await usedListenerPorts(), {
+            exclude: { kind: 'output', id: doc._id },
+            keep: doc.url ? listenerPortRequest(doc.url) : null,
+          });
+          if (!resolved.ok) {
+            return reply.status(resolved.statusCode).send({ error: resolved.error, statusCode: resolved.statusCode });
           }
+          body.url = resolved.address;
         }
       }
       const updated: OutputDoc = { ...doc, ...body, updatedAt: new Date().toISOString() };

--- a/src/routes/sources.ts
+++ b/src/routes/sources.ts
@@ -6,6 +6,7 @@ import type { SourceDoc, ProductionDoc } from '../db/types.js';
 import { updateProductionDoc } from './productions.js';
 import { graphicUrl, srtUrl } from '../lib/url-validation.js';
 import { encryptAddressPassphrase, decryptAddressPassphrase } from '../lib/srt-passphrase-crypto.js';
+import { evaluateListenerPort, getPortLease } from '../services/port-lease.js';
 
 const SourceInput = z.object({
   name: z.string().min(1).max(256),
@@ -93,6 +94,13 @@ const sourcesRoutes: FastifyPluginAsync = async (fastify) => {
   // Create a source
   fastify.post('/api/v1/sources', async (req, reply) => {
     const body = SourceInput.parse(req.body);
+    if (body.streamType === 'srt' || body.streamType === 'efp') {
+      // Listener sources bind a port on the shared Strom — it must be inside this instance's lease.
+      const verdict = evaluateListenerPort(body.address, getPortLease());
+      if (!verdict.ok) {
+        return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+      }
+    }
     const now = new Date().toISOString();
     const doc: SourceDoc = {
       _id: `src-${randomUUID()}`,
@@ -140,6 +148,17 @@ const sourcesRoutes: FastifyPluginAsync = async (fastify) => {
           }
         } catch (err) {
           return reply.status(400).send({ error: err instanceof Error ? err.message : 'Invalid source address' });
+        }
+        // Re-check the lease only when the address or stream type changes — a
+        // rename must not fail because an older source predates the lease.
+        if (
+          (body.address !== undefined || body.streamType !== undefined) &&
+          (effectiveStreamType === 'srt' || effectiveStreamType === 'efp')
+        ) {
+          const verdict = evaluateListenerPort(effectiveAddress, getPortLease());
+          if (!verdict.ok) {
+            return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+          }
         }
       }
       // Encrypt the passphrase in an updated address before persisting. When the

--- a/src/routes/sources.ts
+++ b/src/routes/sources.ts
@@ -6,7 +6,8 @@ import type { SourceDoc, ProductionDoc } from '../db/types.js';
 import { updateProductionDoc } from './productions.js';
 import { graphicUrl, srtUrl } from '../lib/url-validation.js';
 import { encryptAddressPassphrase, decryptAddressPassphrase } from '../lib/srt-passphrase-crypto.js';
-import { evaluateListenerPort, getPortLease } from '../services/port-lease.js';
+import { getPortLease } from '../services/port-lease.js';
+import { clashesAfterWrite, listenerPortRequest, resolveListenerAddress, usedListenerPorts } from '../services/listener-ports.js';
 
 const SourceInput = z.object({
   name: z.string().min(1).max(256),
@@ -94,29 +95,48 @@ const sourcesRoutes: FastifyPluginAsync = async (fastify) => {
   // Create a source
   fastify.post('/api/v1/sources', async (req, reply) => {
     const body = SourceInput.parse(req.body);
-    if (body.streamType === 'srt' || body.streamType === 'efp') {
-      // Listener sources bind a port on the shared Strom — it must be inside this instance's lease.
-      const verdict = evaluateListenerPort(body.address, getPortLease());
-      if (!verdict.ok) {
-        return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+    const isSrt = body.streamType === 'srt' || body.streamType === 'efp';
+    const id = `src-${randomUUID()}`;
+    // A listener source binds a port on the shared Strom: it must lie inside this
+    // instance's lease and no other source or output may hold it. Port 0 asks
+    // for the lowest free one. Written, then checked again, because two clients
+    // registering at once can both be handed the same free port.
+    let used = isSrt ? await usedListenerPorts() : [];
+    for (let attempt = 0; ; attempt++) {
+      let address = body.address;
+      let port: number | null = null;
+      if (isSrt) {
+        const resolved = resolveListenerAddress(body.address, getPortLease(), used);
+        if (!resolved.ok) {
+          return reply.status(resolved.statusCode).send({ error: resolved.error, statusCode: resolved.statusCode });
+        }
+        ({ address, port } = resolved);
       }
+      const now = new Date().toISOString();
+      const doc: SourceDoc = {
+        _id: id,
+        type: 'source',
+        name: body.name,
+        // Encrypt any embedded SRT passphrase before it touches CouchDB (issue #160).
+        address: encryptAddressPassphrase(address),
+        streamType: body.streamType,
+        status: body.status,
+        liveCamera: body.liveCamera,
+        latency: body.latency,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const written = await getSourcesDb().insert(doc);
+      if (port === null) return reply.status(201).send(toApi(doc));
+      used = await usedListenerPorts();
+      const clash = clashesAfterWrite(used, { kind: 'source', id }, port);
+      if (!clash) return reply.status(201).send(toApi(doc));
+      await getSourcesDb().destroy(id, written.rev);
+      if (listenerPortRequest(body.address) !== 0 || attempt >= 3) {
+        return reply.status(409).send({ error: `SRT listener port ${port} is already used by ${clash.kind} "${clash.name}"`, statusCode: 409 });
+      }
+      fastify.log.warn({ port, clash }, 'listener port was taken while assigning it, choosing another');
     }
-    const now = new Date().toISOString();
-    const doc: SourceDoc = {
-      _id: `src-${randomUUID()}`,
-      type: 'source',
-      name: body.name,
-      // Encrypt any embedded SRT passphrase before it touches CouchDB (issue #160).
-      address: encryptAddressPassphrase(body.address),
-      streamType: body.streamType,
-      status: body.status,
-      liveCamera: body.liveCamera,
-      latency: body.latency,
-      createdAt: now,
-      updatedAt: now,
-    };
-    await getSourcesDb().insert(doc);
-    return reply.status(201).send(toApi(doc));
   });
 
   // Get a source
@@ -149,16 +169,22 @@ const sourcesRoutes: FastifyPluginAsync = async (fastify) => {
         } catch (err) {
           return reply.status(400).send({ error: err instanceof Error ? err.message : 'Invalid source address' });
         }
-        // Re-check the lease only when the address or stream type changes — a
-        // rename must not fail because an older source predates the lease.
+        // Re-check the port only when the address or stream type changes — a
+        // rename must not fail because an older source predates the lease. Port 0
+        // keeps the port the source already has when that is still valid.
         if (
           (body.address !== undefined || body.streamType !== undefined) &&
           (effectiveStreamType === 'srt' || effectiveStreamType === 'efp')
         ) {
-          const verdict = evaluateListenerPort(effectiveAddress, getPortLease());
-          if (!verdict.ok) {
-            return reply.status(verdict.statusCode).send({ error: verdict.error, statusCode: verdict.statusCode });
+          const stored = doc.streamType === 'srt' || doc.streamType === 'efp' ? listenerPortRequest(doc.address) : null;
+          const resolved = resolveListenerAddress(effectiveAddress, getPortLease(), await usedListenerPorts(), {
+            exclude: { kind: 'source', id: doc._id },
+            keep: stored,
+          });
+          if (!resolved.ok) {
+            return reply.status(resolved.statusCode).send({ error: resolved.error, statusCode: resolved.statusCode });
           }
+          if (body.address !== undefined) body.address = resolved.address;
         }
       }
       // Encrypt the passphrase in an updated address before persisting. When the

--- a/src/routes/status.ts
+++ b/src/routes/status.ts
@@ -3,6 +3,7 @@ import { isDbReady, connectDb, isDbConnected } from '../db/index.js';
 import { StromClient } from '../lib/strom.js';
 import { getStromToken } from '../lib/strom-token.js';
 import { config } from '../config.js';
+import { getPortLease } from '../services/port-lease.js';
 
 const statusRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/v1/ping', async (_req, reply) => {
@@ -10,12 +11,19 @@ const statusRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   fastify.get('/api/v1/server-info', async (_req, reply) => {
+    let stromHost: string;
     try {
-      const stromHost = new URL(config.stromUrl).hostname;
-      return reply.send({ stromHost });
+      stromHost = new URL(config.stromUrl).hostname;
     } catch {
       return reply.status(500).send({ error: 'Invalid STROM_URL configured' });
     }
+    // SRT listener ports this instance may bind on the shared Strom. Gateways
+    // use the range to pick ports for the sources they register.
+    const lease = getPortLease();
+    const srtPortRange = lease.status === 'leased'
+      ? { first: lease.lease.first_port, last: lease.lease.last_port }
+      : null;
+    return reply.send({ stromHost, srtPortRange, srtPortLease: lease.status });
   });
 
   fastify.post(

--- a/src/services/listener-ports.ts
+++ b/src/services/listener-ports.ts
@@ -1,0 +1,154 @@
+/**
+ * Port assignment inside this instance's leased block.
+ *
+ * The broker keeps Open Live instances apart; this keeps the sources and
+ * outputs of one instance apart. Every hostless SRT listener address
+ * (`srt://:PORT?mode=listener`) binds PORT on the shared Strom, so no two
+ * documents may name the same one. A client that does not care which port it
+ * gets sends `srt://:0?...` and is handed the lowest free port in the block,
+ * which is how gateways register: several of them can then feed one instance
+ * without knowing about each other.
+ */
+
+import { getOutputsDb, getSourcesDb } from '../db/index.js';
+import type { PortLease } from '../lib/strom.js';
+import { isPortInLease } from './port-lease.js';
+import type { PortLeaseState } from './port-lease.js';
+
+/** The value of PORT in `srt://:PORT` that asks the server to choose. */
+export const ASSIGN_PORT = 0;
+
+/** A port some stored document already binds. */
+export interface ListenerPortUse {
+  kind: 'source' | 'output';
+  id: string;
+  name: string;
+  port: number;
+}
+
+/**
+ * The port of a hostless SRT listener address, `0` when the client asks the
+ * server to choose, or null for anything that binds nothing here: caller form
+ * with a host, other schemes, or an explicit non-listener mode. A hostless
+ * address without a `mode` is a listener, since hostless can only bind.
+ */
+export function listenerPortRequest(address: string): number | null {
+  const m = /^srt:\/\/:(\d{1,5})(?:\?([^#]*))?$/i.exec(address.trim());
+  if (!m) return null;
+  const port = Number(m[1]);
+  if (!Number.isInteger(port) || port > 65535) return null;
+  const mode = new URLSearchParams(m[2] ?? '').get('mode');
+  if (mode !== null && mode.toLowerCase() !== 'listener') return null;
+  return port;
+}
+
+/** The same address with its port replaced. */
+export function withListenerPort(address: string, port: number): string {
+  return address.trim().replace(/^srt:\/\/:\d{1,5}/i, `srt://:${port}`);
+}
+
+/** Every listener port a stored source or output binds. */
+export async function usedListenerPorts(): Promise<ListenerPortUse[]> {
+  const [sources, outputs] = await Promise.all([
+    getSourcesDb().find({ selector: { type: 'source' } }),
+    getOutputsDb().find({ selector: { type: 'output' } }),
+  ]);
+  const used: ListenerPortUse[] = [];
+  for (const doc of Array.isArray(sources?.docs) ? sources.docs : []) {
+    if (doc.streamType !== 'srt' && doc.streamType !== 'efp') continue;
+    const port = listenerPortRequest(doc.address);
+    if (port) used.push({ kind: 'source', id: doc._id, name: doc.name, port });
+  }
+  for (const doc of Array.isArray(outputs?.docs) ? outputs.docs : []) {
+    if (!doc.url || (doc.outputType !== 'mpegtssrt' && doc.outputType !== 'efpsrt')) continue;
+    const port = listenerPortRequest(doc.url);
+    if (port) used.push({ kind: 'output', id: doc._id, name: doc.name, port });
+  }
+  return used;
+}
+
+export function lowestFreePort(lease: Pick<PortLease, 'first_port' | 'last_port'>, taken: Set<number>): number | null {
+  for (let p = lease.first_port; p <= lease.last_port; p++) {
+    if (!taken.has(p)) return p;
+  }
+  return null;
+}
+
+export type ListenerAddressResolution =
+  | { ok: true; address: string; port: number | null }
+  | { ok: false; statusCode: 400 | 409 | 422 | 503; error: string };
+
+export interface ResolveOptions {
+  /** The document being edited, so its own current port does not count as taken. */
+  exclude?: { kind: 'source' | 'output'; id: string };
+  /**
+   * The port the document holds today. An assignment request keeps it when it
+   * is still valid, so a client that re-registers gets the same port back.
+   */
+  keep?: number | null;
+}
+
+/**
+ * Decide the address a source or output may be stored with.
+ *
+ * Non-listener addresses pass through. A listener port must be inside the
+ * leased block when there is one, and must not be bound by another document
+ * either way. Port 0 asks for the lowest free port in the block; without a
+ * block (no broker, or leasing disabled) there is nothing to choose from, and
+ * while the lease is still pending the answer is "not yet".
+ */
+export function resolveListenerAddress(
+  address: string,
+  lease: PortLeaseState,
+  used: ListenerPortUse[],
+  opts: ResolveOptions = {},
+): ListenerAddressResolution {
+  const requested = listenerPortRequest(address);
+  if (requested === null) return { ok: true, address, port: null };
+
+  const others = used.filter((u) => !(opts.exclude && u.kind === opts.exclude.kind && u.id === opts.exclude.id));
+  const taken = new Set(others.map((u) => u.port));
+  const range = lease.status === 'leased' ? lease.lease : null;
+  const rangeText = range ? `${range.first_port}-${range.last_port}` : '';
+
+  if (requested === ASSIGN_PORT) {
+    if (lease.status === 'pending') {
+      return { ok: false, statusCode: 503, error: 'SRT port range not yet allocated from Strom, retry shortly' };
+    }
+    if (!range) {
+      return { ok: false, statusCode: 400, error: 'No SRT port range to assign from on this instance; give the listener address an explicit port' };
+    }
+    if (opts.keep && isPortInLease(opts.keep, range) && !taken.has(opts.keep)) {
+      return { ok: true, address: withListenerPort(address, opts.keep), port: opts.keep };
+    }
+    const port = lowestFreePort(range, taken);
+    if (port === null) {
+      return { ok: false, statusCode: 409, error: `No free SRT listener port left in this instance's range ${rangeText}` };
+    }
+    return { ok: true, address: withListenerPort(address, port), port };
+  }
+
+  if (lease.status === 'pending') {
+    return { ok: false, statusCode: 503, error: 'SRT port range not yet allocated from Strom, retry shortly' };
+  }
+  if (range && !isPortInLease(requested, range)) {
+    return { ok: false, statusCode: 422, error: `SRT listener port ${requested} is outside this instance's allocated range ${rangeText}` };
+  }
+  const holder = others.find((u) => u.port === requested);
+  if (holder) {
+    return { ok: false, statusCode: 409, error: `SRT listener port ${requested} is already used by ${holder.kind} "${holder.name}"` };
+  }
+  return { ok: true, address, port: requested };
+}
+
+/**
+ * Two clients asking for a port at the same moment can both be handed the
+ * lowest free one, because the read and the write are separate CouchDB calls.
+ * After writing, look again: if another document now holds our assigned port
+ * and is older than ours, the caller should undo and retry. The chance is
+ * small (gateways register at start-up, one input at a time); the check keeps
+ * it from becoming a silent double booking.
+ */
+export function clashesAfterWrite(used: ListenerPortUse[], mine: { kind: 'source' | 'output'; id: string }, port: number): ListenerPortUse | undefined {
+  return used.find((u) => u.port === port && !(u.kind === mine.kind && u.id === mine.id));
+}

--- a/src/services/port-lease.ts
+++ b/src/services/port-lease.ts
@@ -89,33 +89,6 @@ export function isPortInLease(port: number, lease: Pick<PortLease, 'first_port' 
   return port >= lease.first_port && port <= lease.last_port;
 }
 
-export type ListenerPortVerdict =
-  | { ok: true }
-  | { ok: false; statusCode: 422 | 503; error: string };
-
-/**
- * Decide whether a source address may be stored given the current lease state.
- * Only hostless SRT listener addresses are checked; everything else passes.
- */
-export function evaluateListenerPort(address: string, lease: PortLeaseState): ListenerPortVerdict {
-  const port = parseListenerPort(address);
-  if (port === null) return { ok: true };
-  switch (lease.status) {
-    case 'leased':
-      if (isPortInLease(port, lease.lease)) return { ok: true };
-      return {
-        ok: false,
-        statusCode: 422,
-        error: `SRT listener port ${port} is outside this instance's allocated range ${lease.lease.first_port}-${lease.lease.last_port}`,
-      };
-    case 'pending':
-      return { ok: false, statusCode: 503, error: 'SRT port range not yet allocated from Strom, retry shortly' };
-    case 'unsupported':
-    case 'disabled':
-      return { ok: true };
-  }
-}
-
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------

--- a/src/services/port-lease.ts
+++ b/src/services/port-lease.ts
@@ -1,0 +1,277 @@
+/**
+ * Strom SRT port lease — always active unless STROM_PORT_LEASE_DISABLED is set.
+ *
+ * Several Open Live instances share one cloud Strom. Listener SRT sources
+ * (`srt://:PORT?mode=listener`) bind a port on that shared Strom, so each
+ * instance reserves a contiguous port range up front and only accepts listener
+ * sources inside it. The lease is acquired at boot, renewed on every tick, and
+ * re-acquired under the same client id if Strom forgets it (e.g. a restart
+ * without persistence). Strom instances without the API are detected and left
+ * alone, with a low-frequency retry in case Strom gets upgraded underneath us.
+ */
+
+import os from 'os';
+import type { FastifyBaseLogger } from 'fastify';
+import { config } from '../config.js';
+import { StromClient, StromClientError } from '../lib/strom.js';
+import type { PortLease } from '../lib/strom.js';
+import { getStromToken } from '../lib/strom-token.js';
+
+const TICK_INTERVAL_MS = 60 * 1000;                 // renew / retry cadence
+const UNSUPPORTED_RETRY_MS = 10 * 60 * 1000;        // re-probe an old Strom every 10 min
+
+export type PortLeaseState =
+  | { status: 'leased'; lease: PortLease }
+  | { status: 'pending' }
+  | { status: 'unsupported' }
+  | { status: 'disabled' };
+
+/** The slice of StromClient the service needs — lets tests inject a fake. */
+export type PortLeaseClient = Pick<StromClient, 'portLeases'>;
+export type PortLeaseClientFactory = () => Promise<PortLeaseClient>;
+
+export interface PortLeaseConfig {
+  stromPortLeaseClientId?: string | undefined;
+  publicBaseUrl?: string | undefined;
+}
+
+let state: PortLeaseState = config.stromPortLeaseDisabled ? { status: 'disabled' } : { status: 'pending' };
+let unsupportedSince: number | null = null;
+let leaseInterval: NodeJS.Timeout | null = null;
+let inflightTick: Promise<void> | null = null;
+
+const defaultClientFactory: PortLeaseClientFactory = async () => {
+  const token = await getStromToken(config.stromToken);
+  return new StromClient({ baseUrl: config.stromUrl, token });
+};
+
+let clientFactory: PortLeaseClientFactory = defaultClientFactory;
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Lease client id: explicit override, else the hostname of PUBLIC_BASE_URL,
+ * else `open-live-<os hostname>`. Must be stable across restarts so the same
+ * instance gets its existing lease back.
+ */
+export function deriveClientId(cfg: PortLeaseConfig, hostname: string = os.hostname()): string {
+  if (cfg.stromPortLeaseClientId) return cfg.stromPortLeaseClientId;
+  if (cfg.publicBaseUrl) {
+    try {
+      const host = new URL(cfg.publicBaseUrl).hostname;
+      if (host) return host;
+    } catch {
+      // fall through to the hostname default
+    }
+  }
+  return `open-live-${hostname}`;
+}
+
+/**
+ * Port of a hostless SRT listener address (`srt://:PORT[?...]`), or null for
+ * anything else: caller form with a host, non-SRT schemes, or an explicit
+ * non-listener mode. A hostless address with no `mode` parameter is treated
+ * as a listener since it can only bind, never connect.
+ */
+export function parseListenerPort(address: string): number | null {
+  const m = /^srt:\/\/:(\d{1,5})(?:\?([^#]*))?$/i.exec(address.trim());
+  if (!m) return null;
+  const port = Number(m[1]);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  const mode = new URLSearchParams(m[2] ?? '').get('mode');
+  if (mode !== null && mode.toLowerCase() !== 'listener') return null;
+  return port;
+}
+
+export function isPortInLease(port: number, lease: Pick<PortLease, 'first_port' | 'last_port'>): boolean {
+  return port >= lease.first_port && port <= lease.last_port;
+}
+
+export type ListenerPortVerdict =
+  | { ok: true }
+  | { ok: false; statusCode: 422 | 503; error: string };
+
+/**
+ * Decide whether a source address may be stored given the current lease state.
+ * Only hostless SRT listener addresses are checked; everything else passes.
+ */
+export function evaluateListenerPort(address: string, lease: PortLeaseState): ListenerPortVerdict {
+  const port = parseListenerPort(address);
+  if (port === null) return { ok: true };
+  switch (lease.status) {
+    case 'leased':
+      if (isPortInLease(port, lease.lease)) return { ok: true };
+      return {
+        ok: false,
+        statusCode: 422,
+        error: `SRT listener port ${port} is outside this instance's allocated range ${lease.lease.first_port}-${lease.lease.last_port}`,
+      };
+    case 'pending':
+      return { ok: false, statusCode: 503, error: 'SRT port range not yet allocated from Strom, retry shortly' };
+    case 'unsupported':
+    case 'disabled':
+      return { ok: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export function getPortLease(): PortLeaseState {
+  return state;
+}
+
+/** Old Strom without the feature: 404 with the generic "API endpoint not found" body. */
+function isUnsupportedError(err: unknown): boolean {
+  return err instanceof StromClientError && err.status === 404 && /API endpoint not found/i.test(err.message);
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof StromClientError && err.status === 404;
+}
+
+async function acquire(log: FastifyBaseLogger): Promise<void> {
+  const clientId = deriveClientId(config);
+  try {
+    const client = await clientFactory();
+    const lease = await client.portLeases.acquire({ client_id: clientId, size: config.stromPortLeaseSize });
+    const wasLeased = state.status === 'leased';
+    state = { status: 'leased', lease };
+    unsupportedSince = null;
+    if (!wasLeased) {
+      log.info(
+        { clientId, leaseId: lease.id, firstPort: lease.first_port, lastPort: lease.last_port, expiresAt: lease.expires_at },
+        '[port-lease] Acquired SRT port range from Strom',
+      );
+    }
+  } catch (err) {
+    if (isUnsupportedError(err)) {
+      if (state.status !== 'unsupported') {
+        log.warn(
+          { clientId },
+          '[port-lease] Strom does not support port leases (POST /api/port-leases returned 404) — listener ports are not enforced. Will re-check every 10 min',
+        );
+      }
+      state = { status: 'unsupported' };
+      unsupportedSince = Date.now();
+      return;
+    }
+    state = { status: 'pending' };
+    log.warn({ err, clientId, size: config.stromPortLeaseSize }, '[port-lease] Failed to acquire SRT port range — will retry');
+  }
+}
+
+async function renew(log: FastifyBaseLogger, current: PortLease): Promise<void> {
+  try {
+    const client = await clientFactory();
+    const lease = await client.portLeases.renew(current.id);
+    state = { status: 'leased', lease };
+    log.debug({ leaseId: lease.id, expiresAt: lease.expires_at }, '[port-lease] Renewed SRT port lease');
+  } catch (err) {
+    if (isNotFound(err)) {
+      log.warn({ leaseId: current.id }, '[port-lease] Lease vanished from Strom — re-acquiring under the same client id');
+      state = { status: 'pending' };
+      await acquire(log);
+      // Read through the getter: TS does not see acquire() reassigning the module variable.
+      const after = getPortLease();
+      if (after.status === 'leased') {
+        const fresh = after.lease;
+        if (fresh.first_port !== current.first_port || fresh.last_port !== current.last_port) {
+          log.warn(
+            { previous: `${current.first_port}-${current.last_port}`, current: `${fresh.first_port}-${fresh.last_port}` },
+            '[port-lease] Re-acquired a different port range — existing listener sources may be outside it',
+          );
+        }
+      }
+      return;
+    }
+    log.warn({ err, leaseId: current.id }, '[port-lease] Failed to renew SRT port lease — keeping last known range');
+  }
+}
+
+/** One scheduler step: renew a held lease, otherwise (re)try acquisition. */
+export async function tickPortLease(log: FastifyBaseLogger): Promise<void> {
+  if (inflightTick) return inflightTick;
+  inflightTick = (async () => {
+    switch (state.status) {
+      case 'disabled':
+        return;
+      case 'leased':
+        await renew(log, state.lease);
+        return;
+      case 'unsupported':
+        if (unsupportedSince !== null && Date.now() - unsupportedSince < UNSUPPORTED_RETRY_MS) return;
+        await acquire(log);
+        return;
+      case 'pending':
+        await acquire(log);
+        return;
+    }
+  })().finally(() => {
+    inflightTick = null;
+  });
+  return inflightTick;
+}
+
+export function startPortLease(log: FastifyBaseLogger): void {
+  if (leaseInterval !== null) return;
+  if (state.status === 'disabled') {
+    log.info('[port-lease] SRT port leasing disabled (STROM_PORT_LEASE_DISABLED)');
+    return;
+  }
+
+  log.info(
+    { clientId: deriveClientId(config), size: config.stromPortLeaseSize, renewIntervalSec: TICK_INTERVAL_MS / 1000 },
+    '[port-lease] SRT port leasing enabled',
+  );
+
+  void tickPortLease(log);
+
+  leaseInterval = setInterval(() => {
+    tickPortLease(log).catch((err) => log.error({ err }, '[port-lease] Tick error'));
+  }, TICK_INTERVAL_MS);
+
+  // Allow the process to exit even if the interval is still running
+  leaseInterval.unref();
+}
+
+/** Stop renewing and release the lease (best effort) — for graceful shutdown. */
+export async function stopPortLease(log: FastifyBaseLogger): Promise<void> {
+  if (leaseInterval !== null) {
+    clearInterval(leaseInterval);
+    leaseInterval = null;
+  }
+  if (state.status !== 'leased') return;
+  const { lease } = state;
+  state = { status: 'pending' };
+  try {
+    const client = await clientFactory();
+    await client.portLeases.release(lease.id);
+    log.info({ leaseId: lease.id }, '[port-lease] Released SRT port lease');
+  } catch (err) {
+    log.warn({ err, leaseId: lease.id }, '[port-lease] Failed to release SRT port lease — it will expire on its own');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test hooks
+// ---------------------------------------------------------------------------
+
+/** Replace the Strom client used by the service. Pass null to restore the default. */
+export function _setStromClientFactory(factory: PortLeaseClientFactory | null): void {
+  clientFactory = factory ?? defaultClientFactory;
+}
+
+/** Reset module state between tests. */
+export function _resetPortLeaseState(initial: PortLeaseState = { status: 'pending' }): void {
+  if (leaseInterval !== null) {
+    clearInterval(leaseInterval);
+    leaseInterval = null;
+  }
+  state = initial;
+  unsupportedSince = null;
+  inflightTick = null;
+}

--- a/src/services/port-lease.ts
+++ b/src/services/port-lease.ts
@@ -124,9 +124,14 @@ export function getPortLease(): PortLeaseState {
   return state;
 }
 
-/** Old Strom without the feature: 404 with the generic "API endpoint not found" body. */
+/**
+ * Nothing answers POST /api/port-leases: a Strom without the feature, or a
+ * self-hosted Strom with no port broker proxied in front of it. The body is
+ * whatever the responder (Strom, a proxy) puts in a 404, so only the status
+ * counts. Create never 404s for any other reason.
+ */
 function isUnsupportedError(err: unknown): boolean {
-  return err instanceof StromClientError && err.status === 404 && /API endpoint not found/i.test(err.message);
+  return err instanceof StromClientError && err.status === 404;
 }
 
 function isNotFound(err: unknown): boolean {

--- a/src/services/port-lease.ts
+++ b/src/services/port-lease.ts
@@ -98,15 +98,12 @@ export function getPortLease(): PortLeaseState {
 }
 
 /**
- * Nothing answers POST /api/port-leases: a Strom without the feature, or a
- * self-hosted Strom with no port broker proxied in front of it. The body is
- * whatever the responder (Strom, a proxy) puts in a 404, so only the status
- * counts. Create never 404s for any other reason.
+ * A 404 from the lease routes. What it means depends on the call: on create,
+ * nothing serves the routes at all (a Strom with no port broker proxied in
+ * front of it), so leasing is unsupported here; on renew, the routes work but
+ * this lease is gone, so it is re-acquired. The status is the whole signal
+ * either way; the body is whatever the responder (Strom, a proxy) puts in it.
  */
-function isUnsupportedError(err: unknown): boolean {
-  return err instanceof StromClientError && err.status === 404;
-}
-
 function isNotFound(err: unknown): boolean {
   return err instanceof StromClientError && err.status === 404;
 }
@@ -126,7 +123,8 @@ async function acquire(log: FastifyBaseLogger): Promise<void> {
       );
     }
   } catch (err) {
-    if (isUnsupportedError(err)) {
+    if (isNotFound(err)) {
+      // Create never 404s for any other reason: no broker answers here.
       if (state.status !== 'unsupported') {
         log.warn(
           { clientId },
@@ -150,6 +148,7 @@ async function renew(log: FastifyBaseLogger, current: PortLease): Promise<void> 
     log.debug({ leaseId: lease.id, expiresAt: lease.expires_at }, '[port-lease] Renewed SRT port lease');
   } catch (err) {
     if (isNotFound(err)) {
+      // The routes answered, so a broker is there; only this lease is gone.
       log.warn({ leaseId: current.id }, '[port-lease] Lease vanished from Strom — re-acquiring under the same client id');
       state = { status: 'pending' };
       await acquire(log);


### PR DESCRIPTION
## Why

Several Open Live instances share one Strom, and every hostless SRT listener source or output (`srt://:PORT?mode=listener`) binds a port on it. Nothing kept two instances, or the gateways behind them, from picking the same port; the second pipeline then failed at activation.

## What

Open Live now leases a block of consecutive ports and only accepts listener addresses inside it. The lease requests go to `STROM_URL` under `/api/port-leases`. On a shared Strom a proxy routes that path to a port broker service (strom-port-broker) that owns the pool; everything else passes through to Strom. A self-hosted Strom with no proxy answers 404, and Open Live applies no restriction there. Strom itself is unchanged.

- `src/services/port-lease.ts`: acquires at boot under a stable client id (`STROM_PORT_LEASE_CLIENT_ID`, else the `PUBLIC_BASE_URL` hostname, else `open-live-<hostname>`), renews every minute, re-acquires under the same id if the lease vanished, releases on `SIGTERM`/`SIGINT`. Any 404 on the create call means no broker: logged once, no enforcement, re-probed every 10 minutes.
- `GET /api/v1/server-info` publishes `srtPortRange: {first,last} | null` and `srtPortLease: leased | pending | unsupported | disabled`, so gateways (Eyevinn/open-live-ingest#1) pick ports from the leased block.
- Inside the block, Open Live assigns the ports (`src/services/listener-ports.ts`). A listener address with port 0 (`srt://:0?mode=listener`) asks for the lowest port no other source or output holds; the stored address and the response carry the assigned port. Gateways register this way, so several can feed one instance. An explicit port must be inside the block and unique, or the request fails with 422 naming the range or 409 naming the holder. A PATCH with port 0 keeps the document's current port when still valid. After writing an assigned port the routes look again and move to another if a concurrent request took the same one.
- `POST`/`PATCH /api/v1/sources` and `/api/v1/outputs` answer 503 while the lease is still pending. Caller addresses, WHIP/WHEP/HTML, and renames that leave the address alone are not checked, so existing documents keep working until their address is edited.
- Env: `STROM_PORT_LEASE_SIZE` (default 10, covering sources and outputs), `STROM_PORT_LEASE_CLIENT_ID`, `STROM_PORT_LEASE_DISABLED`.
- Docs: `docs/port-lease.md`, README env table, `.env.example`, `docs/openapi.yaml`.

Judgement calls worth a look: a hostless address with no `mode` parameter is treated as a listener, since it can only bind; on a non-404 renew failure the last known range is kept rather than dropping to `pending`, so sources keep validating against it while the broker is briefly unreachable.

Deploy note: once an instance holds a lease, gateways still on the old default range 47110-47129 get 422 unless that range falls inside the block. Upgrade the venue gateways together with this, or set `STROM_PORT_LEASE_DISABLED=true` until they are.

Studio follow-up (not in this PR): the outputs panel defaults to `srt://:43524?mode=listener`, which a shared Strom will now reject; Studio should propose a port from `srtPortRange`.

## Tests

- `pnpm typecheck`: clean
- `pnpm test`: 14 files, 190 passed. New: `src/__tests__/port-lease.test.ts` (service: acquire → renew → 404 → re-acquire, 409 retry, unsupported detection from any 404 body and back-off, disabled, stop/release), `src/__tests__/listener-ports.test.ts` (assignment, keep, uniqueness, exhaustion, no-range cases) and `src/__tests__/port-lease-routes.test.ts` (server-info in all four states; sources and outputs POST/PATCH: assignment, 422, 409, 503, pass-through, race retry, rename does not re-check).
- Smoke tested end to end on one machine (see comments below), and against the real broker deployed in front of the shared dev Strom: two gateways started 12 ms apart got 47110 and 47111, a crashed gateway got its port back on restart, and an activated production went on air.
- No lint script exists in the repo.

