### PR TITLE
fix(ci): bump pinned @osaas/cli to latest in sync-fork workflow

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -36,7 +36,7 @@ jobs:
           esac
 
       - name: Install OSC CLI
-        run: npm install -g @osaas/cli@4.31.3
+        run: npm install -g @osaas/cli@4.33.2
 
       - name: Trigger sync fork
         env:


### PR DESCRIPTION
## Summary

`.github/workflows/sync-fork.yml` pins `@osaas/cli@4.31.3` (from #210). That version predates the `--wait` flag on `admin sync-fork`, so every run of the workflow now fails:

```
error: unknown option '--wait'
```

See the failing run: https://github.com/Eyevinn/open-live/actions/runs/34481631796/job/102885588722

## Fix

Bump the pin to `4.33.2` (current latest on npm), which supports `--wait` on `admin sync-fork` (verified in the CLI source, `src/admin/cmd.ts`).

## Note

#210 pinned the CLI version for supply-chain reasons (issue #166) — this PR keeps that pin in place, just moves it forward to a version where the command the workflow actually uses exists.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
