### PR TITLE
fix(productions): validate WHIP callback host / configure trustProxy

### DIFF
--- a/src/__tests__/whip-callback-host.test.ts
+++ b/src/__tests__/whip-callback-host.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Security tests for WHIP callback URL host resolution (#50).
+ *
+ * When PUBLIC_BASE_URL is not set, the activation endpoint previously built the
+ * WHIP callback URL directly from the raw X-Forwarded-Proto / X-Forwarded-Host
+ * request headers, bypassing Fastify's trustProxy mechanism. A client could
+ * inject `X-Forwarded-Host: attacker.com` to persist `http://attacker.com` as
+ * the WHIP callback URL in CouchDB, redirecting WHIP clients to an
+ * attacker-controlled endpoint.
+ *
+ * These tests assert that an untrusted / injected host is NOT persisted and NOT
+ * returned — the request is rejected (400) or falls back to the configured URL.
+ *
+ * CouchDB, Strom client, and flow-generator are mocked — no real services required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../server.js';
+import { resolvePublicBaseUrl, UntrustedHostError } from '../routes/productions.js';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockInsert = vi.fn();
+const mockFind = vi.fn();
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: mockGet, insert: mockInsert, find: mockFind }),
+  getSourcesDb: () => ({ get: mockGet }),
+  getOutputsDb: () => ({ get: mockGet }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+const mockActivateStromFlow = vi.fn();
+const mockDeactivateStromFlow = vi.fn();
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: (...args: unknown[]) => mockActivateStromFlow(...args),
+  deactivateStromFlow: (...args: unknown[]) => mockDeactivateStromFlow(...args),
+}));
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = { version: vi.fn(), iceServers: vi.fn() };
+    flows = {
+      get: vi.fn().mockResolvedValue({ flow: { id: 'flow-abc', running: false } }),
+      start: vi.fn().mockResolvedValue({}),
+      stop: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    mixer = { multiviewEndpoint: vi.fn() };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+function makeProductionDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'prod-test-1',
+    _rev: '1-abc',
+    type: 'production',
+    name: 'Test Production',
+    status: 'inactive',
+    sources: [],
+    pipeline: { stromConfig: null, status: 'stopped' },
+    graphics: [],
+    macros: [],
+    tally: { pgm: null, pvw: null },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: resolvePublicBaseUrl helper
+// ---------------------------------------------------------------------------
+
+describe('resolvePublicBaseUrl', () => {
+  it('prefers PUBLIC_BASE_URL and ignores the request host entirely', () => {
+    const url = resolvePublicBaseUrl(
+      { protocol: 'http', hostname: 'attacker.com' },
+      { publicBaseUrl: 'https://live.example.com', trustedHosts: [] },
+    );
+    expect(url).toBe('https://live.example.com');
+  });
+
+  it('allows a loopback host when no PUBLIC_BASE_URL / allow-list is set', () => {
+    const url = resolvePublicBaseUrl(
+      { protocol: 'http', hostname: 'localhost' },
+      { publicBaseUrl: undefined, trustedHosts: [] },
+    );
+    expect(url).toBe('http://localhost');
+  });
+
+  it('rejects an injected non-loopback host when no allow-list is configured', () => {
+    expect(() =>
+      resolvePublicBaseUrl(
+        { protocol: 'http', hostname: 'attacker.com' },
+        { publicBaseUrl: undefined, trustedHosts: [] },
+      ),
+    ).toThrow(UntrustedHostError);
+  });
+
+  it('allows a host that is on the TRUSTED_HOSTS allow-list', () => {
+    const url = resolvePublicBaseUrl(
+      { protocol: 'https', hostname: 'live.example.com' },
+      { publicBaseUrl: undefined, trustedHosts: ['live.example.com'] },
+    );
+    expect(url).toBe('https://live.example.com');
+  });
+
+  it('rejects a host that is NOT on the TRUSTED_HOSTS allow-list', () => {
+    expect(() =>
+      resolvePublicBaseUrl(
+        { protocol: 'http', hostname: 'attacker.com' },
+        { publicBaseUrl: undefined, trustedHosts: ['live.example.com'] },
+      ),
+    ).toThrow(UntrustedHostError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test: POST /activate with a spoofed X-Forwarded-Host
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/productions/:id/activate — X-Forwarded-Host injection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFind.mockResolvedValue({ docs: [] });
+    delete process.env['PUBLIC_BASE_URL'];
+    delete process.env['TRUSTED_HOSTS'];
+  });
+
+  it('does not persist attacker.com and rejects the injected host with 400', async () => {
+    const doc = makeProductionDoc();
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+    mockActivateStromFlow.mockResolvedValue({
+      flowId: 'flow-abc',
+      sourceOffsetBlockIds: {},
+      sourceAudioOffsetBlockIds: {},
+      whepOutputEntries: [],
+    });
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/activate',
+      headers: {
+        'x-forwarded-proto': 'http',
+        'x-forwarded-host': 'attacker.com',
+      },
+    });
+
+    // The injected host must be rejected, not accepted as an 'activating' response.
+    expect(res.statusCode).toBe(400);
+
+    // No WHIP callback URL containing attacker.com may have been written to CouchDB,
+    // and the production must not have been transitioned to 'activating'.
+    const wroteAttackerHost = mockInsert.mock.calls.some((call) =>
+      JSON.stringify(call[0]).includes('attacker.com'),
+    );
+    expect(wroteAttackerHost).toBe(false);
+    const wroteActivating = mockInsert.mock.calls.some(
+      (call) => (call[0] as { status?: string }).status === 'activating',
+    );
+    expect(wroteActivating).toBe(false);
+  });
+
+  it('still activates normally (200) for a legitimate loopback request', async () => {
+    // No spoofed headers: Fastify inject resolves req.hostname to a loopback
+    // host, which the resolver accepts. This proves the fix does not break the
+    // legitimate local/dev activation path.
+    const doc = makeProductionDoc();
+    mockGet.mockResolvedValue(doc);
+    mockInsert.mockResolvedValue({ rev: '2-bcd', ok: true, id: doc._id });
+    mockActivateStromFlow.mockResolvedValue({
+      flowId: 'flow-abc',
+      sourceOffsetBlockIds: {},
+      sourceAudioOffsetBlockIds: {},
+      whepOutputEntries: [],
+    });
+
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/productions/prod-test-1/activate',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('activating');
+
+    // The legitimate path must never smuggle an attacker host in either.
+    const wroteAttackerHost = mockInsert.mock.calls.some((call) =>
+      JSON.stringify(call[0]).includes('attacker.com'),
+    );
+    expect(wroteAttackerHost).toBe(false);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,4 +46,16 @@ export const config = {
    * when Fastify's trustProxy is configured correctly for your reverse proxy setup.
    */
   publicBaseUrl: process.env['PUBLIC_BASE_URL'] ?? undefined,
+  /**
+   * Optional allow-list of hostnames that may be used to build request-derived
+   * WHIP callback URLs when PUBLIC_BASE_URL is not set. Comma-separated
+   * (e.g. "live.example.com,live2.example.com"). When set, a request whose
+   * derived host (from X-Forwarded-Host / Host, via Fastify's trustProxy) is
+   * not on this list is rejected rather than persisted — preventing an attacker
+   * from injecting X-Forwarded-Host: attacker.com to redirect WHIP clients.
+   */
+  trustedHosts: (process.env['TRUSTED_HOSTS'] ?? '')
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean),
 } as const;

--- a/src/routes/productions.ts
+++ b/src/routes/productions.ts
@@ -32,6 +32,86 @@ const activationAbortControllers = new Map<string, AbortController>();
 // ---------------------------------------------------------------------------
 
 /**
+ * Error thrown when the WHIP callback base URL cannot be safely resolved from
+ * an incoming request (e.g. an untrusted X-Forwarded-Host was supplied and
+ * neither PUBLIC_BASE_URL nor a TRUSTED_HOSTS allow-list vouches for it).
+ * Carries statusCode 400 so Fastify's error handler surfaces it as a client
+ * error rather than a 500.
+ */
+export class UntrustedHostError extends Error {
+  statusCode = 400;
+  constructor(message: string) {
+    super(message);
+    this.name = 'UntrustedHostError';
+  }
+}
+
+/**
+ * Resolve the public base URL used to build WHIP callback URLs that get
+ * persisted in CouchDB.
+ *
+ * Security (#50): the previous implementation read the raw X-Forwarded-Proto /
+ * X-Forwarded-Host headers, bypassing Fastify's trustProxy mechanism and
+ * letting any client inject `X-Forwarded-Host: attacker.com` to persist an
+ * attacker-controlled WHIP callback endpoint.
+ *
+ * Resolution order:
+ *   1. If PUBLIC_BASE_URL is configured, always use it (never trust the request).
+ *   2. Otherwise derive proto/host from `req.protocol` / `req.hostname`, which
+ *      honour X-Forwarded-* only for trusted proxies (Fastify trustProxy).
+ *      - If a TRUSTED_HOSTS allow-list is configured, the derived host must be
+ *        on it, else the request is rejected (UntrustedHostError → 400).
+ *      - If no allow-list is configured, only loopback/localhost hosts are
+ *        accepted; any other (proxy-forwarded) host is rejected so an attacker
+ *        cannot persist an arbitrary host. This keeps local dev working while
+ *        refusing to trust an unvalidated forwarded host in a proxied setup.
+ */
+export function resolvePublicBaseUrl(
+  req: { protocol?: string; hostname?: string },
+  cfg: { publicBaseUrl?: string; trustedHosts: readonly string[] } = config,
+): string {
+  if (cfg.publicBaseUrl) return cfg.publicBaseUrl;
+
+  const proto = req.protocol ?? 'https';
+  // req.hostname respects trustProxy: it reflects X-Forwarded-Host only when the
+  // connecting peer is a trusted proxy. It still cannot vouch for *which* host is
+  // legitimate, so we validate it below.
+  const host = (req.hostname ?? '').toLowerCase();
+  if (!host) {
+    throw new UntrustedHostError(
+      'Cannot determine request host to build the WHIP callback URL. ' +
+      'Set PUBLIC_BASE_URL to the externally reachable URL of this service.',
+    );
+  }
+
+  const hostname = host.split(':')[0]!;
+  const isLoopback =
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '[::1]';
+
+  if (cfg.trustedHosts.length > 0) {
+    if (!cfg.trustedHosts.includes(hostname)) {
+      throw new UntrustedHostError(
+        `Request host "${hostname}" is not in the TRUSTED_HOSTS allow-list. ` +
+        'Set PUBLIC_BASE_URL or add the host to TRUSTED_HOSTS to build WHIP callback URLs.',
+      );
+    }
+  } else if (!isLoopback) {
+    // No allow-list and a non-loopback (proxy-forwarded) host: refuse to persist
+    // it, since we have no way to distinguish a legitimate host from an injected one.
+    throw new UntrustedHostError(
+      `Refusing to build a WHIP callback URL from untrusted host "${hostname}". ` +
+      'Set PUBLIC_BASE_URL to the externally reachable URL of this service, ' +
+      'or list allowed hosts in TRUSTED_HOSTS.',
+    );
+  }
+
+  return `${proto}://${host}`;
+}
+
+/**
  * Write a partial update to ProductionDoc with retry-on-409.
  * Re-reads the document before each retry to get the latest _rev.
  */
@@ -548,6 +628,15 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
         }
       }
 
+      // Resolve the public base URL for WHIP callback URLs BEFORE mutating any
+      // state. Prefers the explicitly configured PUBLIC_BASE_URL; otherwise
+      // derives it from trustProxy-aware request fields and validates the host
+      // to prevent X-Forwarded-Host injection (#50). Throws UntrustedHostError
+      // (→ 400) rather than persisting an attacker-controlled host into CouchDB.
+      // Resolving here (before the 'activating' write) means a rejected host
+      // does not leave the production stuck mid-activation.
+      const publicBaseUrl = resolvePublicBaseUrl(req);
+
       // Transition to 'activating' immediately and respond; clear any deletion warnings
       const activatingDoc: ProductionDoc = {
         ...doc,
@@ -563,19 +652,6 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
       const abortController = new AbortController();
       activationAbortControllers.set(doc._id, abortController);
 
-      // Prefer the explicitly configured PUBLIC_BASE_URL to avoid X-Forwarded-Host injection.
-      // Only fall back to request-derived values when PUBLIC_BASE_URL is not set.
-      const publicBaseUrl = config.publicBaseUrl
-        ?? (() => {
-          const proto = (req.headers['x-forwarded-proto'] as string | undefined)?.split(',')[0]?.trim()
-            ?? req.protocol
-            ?? 'https';
-          const host = (req.headers['x-forwarded-host'] as string | undefined)
-            ?? (req.headers.host as string | undefined)
-            ?? req.hostname;
-          return `${proto}://${host}`;
-        })()
-
       // Fire-and-forget — must never let a rejection escape to the global handler
       void runActivationFlow(doc._id, abortController.signal, fastify.log, publicBaseUrl).catch((err) => {
         fastify.log.error({ err, productionId: doc._id }, 'Unhandled error in runActivationFlow');
@@ -589,6 +665,12 @@ const productionsRoutes: FastifyPluginAsync = async (fastify) => {
         _rev: insertResponse.rev,
       });
     } catch (err) {
+      // Untrusted / missing host for the WHIP callback URL is a client-input
+      // problem (host-header injection attempt or misconfiguration), not a
+      // server fault — surface it as a 400 rather than a generic 500.
+      if (err instanceof UntrustedHostError) {
+        return reply.status(400).send({ error: err.message, statusCode: 400 });
+      }
       req.log.error({ err }, 'Activation failed');
       return reply.status(500).send({ error: 'Activation failed — check server logs', statusCode: 500 });
     }


### PR DESCRIPTION
Closes #50

## Summary
When `PUBLIC_BASE_URL` is unset, the activation endpoint built the WHIP callback URL (persisted in CouchDB) directly from the raw `X-Forwarded-Proto` / `X-Forwarded-Host` headers, bypassing Fastify's trustProxy mechanism. Any client could inject `X-Forwarded-Host: attacker.com` to persist `http://attacker.com/...` as the WHIP callback endpoint and redirect WHIP clients to an attacker-controlled server (OWASP A04:2021, host-header injection).

Fastify already sets `trustProxy: true` (added for rate-limit IP resolution) and `main.ts` already throws in production when `PUBLIC_BASE_URL` is unset (#39). This PR closes the remaining gap: the fallback path no longer reads raw forwarded headers and no longer persists an unvalidated host.

## Changes
- **`src/routes/productions.ts`**: New exported `resolvePublicBaseUrl(req)` helper + `UntrustedHostError`. Resolution order:
  1. Use `PUBLIC_BASE_URL` if configured (request host is ignored entirely).
  2. Otherwise derive proto/host from trustProxy-aware `req.protocol` / `req.hostname`, then validate:
     - If `TRUSTED_HOSTS` is set, the host must be on the allow-list, else reject.
     - If no allow-list, only loopback/localhost hosts are accepted; any other (proxy-forwarded) host is rejected.
  - Called **before** the production is transitioned to `activating`, so a rejected host returns `400` without leaving the doc mid-activation. Raw `x-forwarded-*` header reads removed.
- **`src/config.ts`**: New optional `TRUSTED_HOSTS` config (comma-separated host allow-list) for request-derived WHIP URLs.

## Test Plan
New `src/__tests__/whip-callback-host.test.ts`:
- [x] Unit: `resolvePublicBaseUrl` prefers `PUBLIC_BASE_URL` and ignores a spoofed host; accepts loopback; accepts allow-listed host; rejects injected non-loopback host with no allow-list; rejects host not on `TRUSTED_HOSTS`.
- [x] Integration: `POST /activate` with `X-Forwarded-Host: attacker.com` returns `400`, and `attacker.com` is never written to CouchDB and the doc is not transitioned to `activating`.
- [x] Integration: legitimate loopback request still returns `200 activating`.

Quality gates (all pass): `pnpm install --frozen-lockfile`, `pnpm run typecheck`, `pnpm run build`, `npx vitest run` (17 files, 164 tests passed — includes 7 new).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>