### PR TITLE
fix(ws): authenticate WebSocket upgrade via header, not query string

### DIFF
--- a/src/__tests__/ws-apikey-header-auth.test.ts
+++ b/src/__tests__/ws-apikey-header-auth.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for API-key auth on the WebSocket upgrade (#49).
+ *
+ * Previously the server accepted the API key via a `?key=<secret>` query
+ * parameter on the WS upgrade. Reverse proxies, CDNs, and browser DevTools log
+ * the full request URL, so a static (non-expiring) key placed there leaks into
+ * access logs as permanent credentials.
+ *
+ * The key is now carried in a header instead, and `?key=` is no longer accepted:
+ *   - `Authorization: Bearer <key>` for REST / non-browser WS clients, and
+ *   - the `Sec-WebSocket-Protocol` subprotocol `openlive.bearer.<key>` for
+ *     browser WebSocket clients (which can't set arbitrary headers). The client
+ *     also offers the plain `openlive.bearer` marker, which the server echoes
+ *     back so the secret is never reflected into the handshake response.
+ *
+ * The API-key check lives in the server's onRequest hook (src/server.ts), which
+ * runs for the WS upgrade GET request before the socket is upgraded. We mock the
+ * WS controller with a plain GET handler so `app.inject` can drive the upgrade
+ * request through the real auth hook without needing a live socket: a 401 means
+ * the hook rejected the request, any other status means auth passed and the
+ * request reached the (mocked) handler.
+ *
+ * CouchDB, Strom, and the WS controller are mocked — no real services required.
+ * API_KEY is set before importing the server so config.apiKey (read once at
+ * module load) picks it up.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+const TEST_API_KEY = 'test-secret-key';
+process.env['API_KEY'] = TEST_API_KEY;
+
+const WS_PATH = '/ws/productions/prod-1/controller';
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn().mockResolvedValue(null), insert: vi.fn(), find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  getSourcesDb: () => ({ get: vi.fn(), find: vi.fn().mockResolvedValue({ docs: [] }) }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the WS controller with a plain GET handler on the same path so the auth
+// hook can be exercised via app.inject (no live socket required). Reaching this
+// handler (non-401) proves the onRequest auth hook let the request through.
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async (fastify: import('fastify').FastifyInstance) => {
+    fastify.get('/ws/productions/:id/controller', async () => ({ upgraded: true }));
+  },
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient / flow-generator (imported transitively via routes)
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: vi.fn(),
+  deactivateStromFlow: vi.fn(),
+}));
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = { version: vi.fn().mockResolvedValue({ version: '1.0.0' }), iceServers: vi.fn() };
+    flows = { get: vi.fn(), start: vi.fn().mockResolvedValue({}), stop: vi.fn().mockResolvedValue({}), delete: vi.fn().mockResolvedValue({}) };
+    mixer = { multiviewEndpoint: vi.fn() };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeAll(async () => {
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('WebSocket upgrade API-key auth (#49)', () => {
+  it('accepts the upgrade with the key in the Sec-WebSocket-Protocol subprotocol', async () => {
+    const app = await buildServer();
+    // Browser pattern: new WebSocket(url, ['openlive.bearer', `openlive.bearer.${key}`]).
+    const res = await app.inject({
+      method: 'GET',
+      url: WS_PATH,
+      headers: { 'sec-websocket-protocol': `openlive.bearer, openlive.bearer.${TEST_API_KEY}` },
+    });
+    expect(res.statusCode).not.toBe(401);
+  });
+
+  it('accepts the upgrade with the key in the Authorization header', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: WS_PATH,
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(res.statusCode).not.toBe(401);
+  });
+
+  it('rejects an upgrade that carries the key only in the ?key= query string', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'GET', url: `${WS_PATH}?key=${TEST_API_KEY}` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects an upgrade with a wrong subprotocol key', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: WS_PATH,
+      headers: { 'sec-websocket-protocol': 'openlive.bearer, openlive.bearer.wrong-key' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects an upgrade offering only the plain marker (no key)', async () => {
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: WS_PATH,
+      headers: { 'sec-websocket-protocol': 'openlive.bearer' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects an upgrade with no credentials at all', async () => {
+    const app = await buildServer();
+    const res = await app.inject({ method: 'GET', url: WS_PATH });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,39 @@ const DB_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status', '/api/v1
 // api client, so requiring the API key here does not break the legitimate caller.
 const AUTH_EXEMPT_PATHS = new Set(['/health', '/ready', '/api/v1/status']);
 
+// Sentinel subprotocols used to carry the API key through the
+// Sec-WebSocket-Protocol header on browser WebSocket upgrades (#49). Browsers
+// cannot set arbitrary headers on a WS handshake but can offer subprotocols via
+// `new WebSocket(url, protocols)`, keeping the key out of the request URL (and
+// therefore out of proxy/CDN/DevTools access logs).
+//
+// The client offers TWO subprotocols:
+//   - WS_SUBPROTOCOL_MARKER            ("openlive.bearer") — a plain marker
+//   - `${WS_SUBPROTOCOL_KEY_PREFIX}<key>` — carries the actual key
+// The server reads the key from the second and echoes back only the plain
+// marker, so the secret is never reflected into the handshake *response*
+// header (which some proxies also log).
+const WS_SUBPROTOCOL_MARKER = 'openlive.bearer';
+const WS_SUBPROTOCOL_KEY_PREFIX = 'openlive.bearer.';
+
+/**
+ * Extracts the API key from a Sec-WebSocket-Protocol header value, if present.
+ * The header is a comma-separated list of client-offered subprotocols; we look
+ * for the `openlive.bearer.<key>` sentinel and return the `<key>` portion.
+ * Returns undefined when the header is absent or carries no bearer subprotocol.
+ */
+function extractSubprotocolKey(header: string | string[] | undefined): string | undefined {
+  if (!header) return undefined;
+  const values = Array.isArray(header) ? header : header.split(',');
+  for (const raw of values) {
+    const proto = raw.trim();
+    if (proto.startsWith(WS_SUBPROTOCOL_KEY_PREFIX)) {
+      return proto.slice(WS_SUBPROTOCOL_KEY_PREFIX.length);
+    }
+  }
+  return undefined;
+}
+
 export async function buildServer() {
   const fastify = Fastify({
     logger: {
@@ -147,7 +180,21 @@ export async function buildServer() {
     uiConfig: { docExpansion: 'list', deepLinking: true },
   });
 
-  await fastify.register(websocket);
+  // The browser WebSocket API rejects the handshake unless the server echoes
+  // one of the client-offered subprotocols back in Sec-WebSocket-Protocol. When
+  // a client authenticates by offering the `openlive.bearer.<key>` subprotocol
+  // (#49), we must select it so the connection is not torn down by the browser.
+  await fastify.register(websocket, {
+    options: {
+      handleProtocols: (protocols: Set<string>) => {
+        // Select the plain marker when offered so the response header does not
+        // reflect the secret-bearing subprotocol. Never echo the key itself.
+        if (protocols.has(WS_SUBPROTOCOL_MARKER)) return WS_SUBPROTOCOL_MARKER;
+        // No bearer subprotocol offered: don't select any (behaves as before).
+        return false;
+      },
+    },
+  });
 
   // Add basic JSON body parsing (built-in to Fastify)
   fastify.addContentTypeParser('application/json', { parseAs: 'string' }, (_req, body, done) => {
@@ -160,7 +207,19 @@ export async function buildServer() {
 
   // Optional API key authentication — enabled when API_KEY env var is set.
   // Exempt: health/ready probes and the read-only status endpoint.
-  // WS connections: pass key via Authorization header or ?key= query param on upgrade.
+  //
+  // How to pass the key:
+  //   - REST / non-browser WS clients: `Authorization: Bearer <API_KEY>`.
+  //   - Browser WebSocket clients: the JS `WebSocket` API cannot set custom
+  //     headers, so the key travels in the `Sec-WebSocket-Protocol` request
+  //     header (populated from the `new WebSocket(url, protocols)` subprotocol
+  //     list) using the sentinel subprotocol `openlive.bearer.<API_KEY>`.
+  //
+  // The key is NEVER accepted via the `?key=` query string (#49): reverse
+  // proxies, CDNs, and browser DevTools log the full request URL, so a static,
+  // non-expiring key placed there leaks into access logs as permanent creds.
+  // Both the Authorization header and Sec-WebSocket-Protocol header are already
+  // redacted / omitted from request logging.
   if (config.apiKey) {
     // Captured here, outside the closure: TS narrows `config.apiKey` from
     // `string | undefined` to `string` at this `if`, but that narrowing does
@@ -189,9 +248,13 @@ export async function buildServer() {
 
       const authHeader = req.headers['authorization'];
       const keyFromHeader = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
-      // WS upgrade carries key in query string since JS WebSocket API doesn't support custom headers
-      const keyFromQuery = (req.query as Record<string, string>)?.['key'];
-      const provided = keyFromHeader ?? keyFromQuery;
+      // Browsers can't set the Authorization header on a WebSocket upgrade, but
+      // they can set Sec-WebSocket-Protocol via `new WebSocket(url, protocols)`.
+      // We carry the key there as the sentinel subprotocol
+      // `openlive.bearer.<API_KEY>` instead of the (proxy-logged) ?key= query
+      // string. The header is a comma-separated list of offered subprotocols.
+      const keyFromSubprotocol = extractSubprotocolKey(req.headers['sec-websocket-protocol']);
+      const provided = keyFromHeader ?? keyFromSubprotocol;
 
       const a = Buffer.from(provided ?? '');
       const b = Buffer.from(apiKey);


### PR DESCRIPTION
Closes #49

## Summary
When `API_KEY` is configured, the server accepted WebSocket-upgrade auth via a `?key=<secret>` query parameter. Reverse proxies (nginx, ALB, Cloudflare), CDNs, and browser DevTools log the full request URL, so a static, non-expiring key placed there leaks into access logs as permanent credentials (#49, OWASP A02:2021).

This moves API-key auth for the WS upgrade off the query string and onto request **headers**, which are already redacted/omitted from logging.

## Changes
- `src/server.ts`
  - **Removed** the `?key=` query-string auth path entirely (it was the only reference to it in this repo). The key is no longer read from the URL.
  - `Authorization: Bearer <key>` remains supported (REST + non-browser WS clients).
  - **Added** browser-compatible WS auth via `Sec-WebSocket-Protocol`. Browsers can't set arbitrary headers on a WS handshake but can offer subprotocols via `new WebSocket(url, protocols)`. The client offers two subprotocols:
    - `openlive.bearer` — a plain marker
    - `openlive.bearer.<key>` — carries the key
    The server reads the key from the second and echoes back **only** the plain marker (via `handleProtocols`), so the secret is never reflected into the handshake response header either.
  - Added an `extractSubprotocolKey` helper and configured `@fastify/websocket` with `handleProtocols` so the browser handshake isn't torn down for lack of a selected subprotocol.

## Client-compat follow-up
The `?key=` path is **removed**, not deprecated (nothing in this backend repo depended on it). The **`open-live-studio`** browser client connects from a separate repo; if it currently appends `?key=`, it needs a follow-up to switch to:
```js
new WebSocket(url, ['openlive.bearer', `openlive.bearer.${apiKey}`])
```
Filing/handling that studio change is recommended before rollout to any deployment that sets `API_KEY`.

Note: I implemented the header/subprotocol remediation (browser-compatible, no new server state) rather than the issue's alternative short-lived-token suggestion; it directly removes the log-leak vector with a smaller surface and no `/ws/token` endpoint to secure.

## Test Plan
New `src/__tests__/ws-apikey-header-auth.test.ts` drives the WS-upgrade GET through the real onRequest auth hook via `app.inject` (WS controller mocked with a plain handler):
- [x] accepts upgrade with key in `Sec-WebSocket-Protocol` subprotocol
- [x] accepts upgrade with `Authorization: Bearer <key>`
- [x] rejects (401) upgrade carrying the key only in `?key=`
- [x] rejects (401) wrong subprotocol key
- [x] rejects (401) plain marker with no key
- [x] rejects (401) no credentials

Gates (repo root): `pnpm run typecheck`, `pnpm run build` clean; `npx vitest run` → 17 files / 163 tests pass (incl. the 6 new). No new failures.