### PR TITLE
fix: decouple production API_KEY guard from NODE_ENV (closes #234)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,17 @@ LOG_LEVEL=info
 
 # Required for self-hosted deployments: static API key protecting all /api/v1 routes.
 # All requests must include: Authorization: Bearer <API_KEY>
-# Leave unset ONLY when running on OSC (auth is handled by the OSC reverse proxy).
-# Starting with NODE_ENV=production without this set will cause a startup error.
+# Leave unset ONLY when an external layer handles auth instead (e.g. running on
+# OSC, behind the OSC reverse proxy) — and set TRUST_EXTERNAL_AUTH below in that
+# case. Starting in production with API_KEY unset and TRUST_EXTERNAL_AUTH not
+# set to true will cause a startup error.
 API_KEY=change-me-before-use
+
+# Set to true ONLY when API_KEY is intentionally left unset because another
+# layer in front of this service (e.g. OSC's reverse proxy) already handles
+# authentication. Do not set this for a self-hosted deployment with no auth
+# layer in front of it — that would leave every /api/v1 route unauthenticated.
+# TRUST_EXTERNAL_AUTH=true
 
 # Optional: restrict CORS allowed origins (comma-separated, or * for wildcard).
 # Default is * for backward compatibility. Tighten for production deployments.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Copy `.env.example` to `.env` and fill in the values:
 | `STROM_URL` | Base URL of the Strom pipeline engine | `http://localhost:7000` |
 | `STROM_TOKEN` | OSC Personal Access Token for authenticating against an OSC-hosted Strom instance | _(empty — not needed for local Strom)_ |
 | `API_KEY` | Static API key protecting all `/api/v1` routes, the WebSocket controller, and the Swagger UI. **Required for any network-accessible deployment** (see below) | _(empty — routes unauthenticated)_ |
+| `TRUST_EXTERNAL_AUTH` | Acknowledges that `API_KEY` is intentionally unset because another layer (e.g. OSC's reverse proxy) handles auth instead. See below | `false` |
 | `LOG_LEVEL` | Fastify log level (`trace`, `debug`, `info`, `warn`, `error`) | `info` |
 | `STROM_PORT_LEASE_SIZE` | Number of SRT listener ports to lease from a shared Strom — see [`docs/port-lease.md`](docs/port-lease.md) | `20` |
 | `STROM_PORT_LEASE_CLIENT_ID` | Stable lease client id sent to Strom | hostname of `PUBLIC_BASE_URL`, else `open-live-<hostname>` |
@@ -95,10 +96,12 @@ request, since the browser WebSocket API does not support custom headers.
 > **`API_KEY` must be set for any network-accessible deployment.** When `API_KEY` is
 > unset, every API route is unauthenticated — any client that can reach the service can
 > create, modify, delete, and activate productions. The server **refuses to start** when
-> `NODE_ENV=production` and `API_KEY` is unset, and logs a prominent warning otherwise.
-> Leave it unset **only** when running behind a trusted external auth layer (e.g. the OSC
-> reverse proxy). The reference `docker-compose.yml` requires `API_KEY` to be set in your
-> `.env` before the stack will start — generate a strong random value with
+> `NODE_ENV=production` and `API_KEY` is unset, unless `TRUST_EXTERNAL_AUTH=true`
+> acknowledges that a trusted external auth layer (e.g. the OSC reverse proxy) is handling
+> it instead — `NODE_ENV` reflects the deployment tier, not the auth architecture, so it
+> can't be used as that signal by itself. Outside production it logs a prominent warning
+> instead of refusing to start. The reference `docker-compose.yml` requires `API_KEY` to
+> be set in your `.env` before the stack will start — generate a strong random value with
 > `openssl rand -base64 32`.
 
 ### Strom authentication

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,15 @@ export const config = {
    */
   apiKey: process.env['API_KEY'] ?? undefined,
   /**
+   * Explicit acknowledgement that this deployment intentionally has no
+   * API_KEY because an external layer (e.g. OSC's reverse proxy) handles
+   * authentication instead. Must be set independently of NODE_ENV — the
+   * deployment tier (NODE_ENV=production) says nothing about whether an
+   * external auth layer is present, so it cannot double as this signal.
+   * Only meaningful when API_KEY is unset; ignored otherwise.
+   */
+  trustExternalAuth: parseBoolEnv('TRUST_EXTERNAL_AUTH', false),
+  /**
    * Allowed CORS origin(s). Comma-separated list or '*' (wildcard).
    * Defaults to unset (no wildcard): when omitted, cross-origin requests are
    * not permitted rather than being opened to any origin. Set an explicit

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,16 +87,21 @@ async function reconcileProductionStatuses(
 async function main() {
   // API_KEY is required in production. Without it every route is unauthenticated,
   // allowing any client that can reach port 3000 to create, modify, and delete
-  // productions. Omitting API_KEY is intentional only when running behind OSC's
-  // reverse-proxy auth wall or another trusted auth layer.
+  // productions. Omitting API_KEY is intentional only when TRUST_EXTERNAL_AUTH
+  // acknowledges that another layer (e.g. OSC's reverse proxy) handles auth
+  // instead. NODE_ENV is deliberately NOT used as that signal: it reflects the
+  // deployment tier, not the auth architecture, and OSC-hosted deployments
+  // always run with NODE_ENV=production regardless of whether they sit behind
+  // that reverse proxy — so NODE_ENV alone can't distinguish "no auth wall" from
+  // "auth handled externally".
   if (!config.apiKey) {
-    if (process.env['NODE_ENV'] === 'production') {
+    if (process.env['NODE_ENV'] === 'production' && !config.trustExternalAuth) {
       throw new Error(
         'API_KEY must be set in production deployments. ' +
         'Without it all API routes are unauthenticated. ' +
-        'Set API_KEY to a strong random secret, or set NODE_ENV to a value ' +
-        'other than "production" if this deployment intentionally relies on ' +
-        'an external auth layer (e.g. the OSC reverse proxy).'
+        'Set API_KEY to a strong random secret, or set TRUST_EXTERNAL_AUTH=true ' +
+        'if this deployment intentionally relies on an external auth layer ' +
+        '(e.g. the OSC reverse proxy).'
       );
     } else {
       console.warn(


### PR DESCRIPTION
## Problem

The startup guard added in #148 (closes #143) refuses to start when
`NODE_ENV=production` and `API_KEY` is unset, suggesting operators set
`NODE_ENV` to something other than `"production"` if the deployment
intentionally relies on an external auth layer.

That escape hatch is not actionable on OSC, so it currently crash-loops
**every** OSC-hosted `open-live` instance unconditionally (confirmed on the
`openlivedev` beta instance — see #234):

- The published OSC service (`eyevinn-open-live`) config schema has no
  `API_KEY` option at all — an OSC operator has no way to set it.
- `Dockerfile.osc` in the OSC packaging fork
  ([eyevinn-osaas/open-live](https://github.com/eyevinn-osaas/open-live))
  hardcodes `ENV NODE_ENV=production`.

`NODE_ENV` reflects deployment tier, not auth architecture, so it can't
double as the "an external auth layer is present" signal.

## Fix

- `src/config.ts`: add `config.trustExternalAuth`, parsed from a new
  `TRUST_EXTERNAL_AUTH` boolean env var (default `false`).
- `src/main.ts`: the production guard now only throws when
  `NODE_ENV=production` **and** `TRUST_EXTERNAL_AUTH` is not set — instead
  of inferring intent from `NODE_ENV` alone.
- `.env.example` / `README.md`: document `TRUST_EXTERNAL_AUTH` alongside
  `API_KEY`.

## Follow-up

Once this merges and syncs to
[eyevinn-osaas/open-live](https://github.com/eyevinn-osaas/open-live),
`osc-entrypoint.sh` there needs a small update to default-export
`TRUST_EXTERNAL_AUTH=true`, since OSC's own reverse-proxy auth wall is
exactly the external auth layer this flag is meant to acknowledge. Tracked
in #234.

## Testing

- `pnpm run build` — clean
- `pnpm run test` — 241/241 passing

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)