### PR TITLE
fix(db): always apply safeSelector to db.find() selectors (#64)

### DIFF
--- a/src/__tests__/safe-selector.test.ts
+++ b/src/__tests__/safe-selector.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { safeSelector, MangoInjectionError } from '../db/index.js';
+
+describe('safeSelector', () => {
+  it('passes a hardcoded scalar selector through unchanged', () => {
+    const selector = { type: 'production' };
+    expect(safeSelector(selector)).toBe(selector);
+  });
+
+  it('passes a nested selector with no operators through unchanged', () => {
+    const selector = { type: 'source', meta: { tags: ['live', 'studio'] } };
+    expect(() => safeSelector(selector)).not.toThrow();
+  });
+
+  it('rejects a top-level Mango operator key ($in)', () => {
+    expect(() => safeSelector({ type: { $in: ['production', 'source'] } })).toThrow(
+      MangoInjectionError,
+    );
+  });
+
+  it('rejects a $regex operator smuggled into a value', () => {
+    expect(() => safeSelector({ name: { $regex: '.*' } })).toThrow(MangoInjectionError);
+  });
+
+  it('rejects a logical $or operator', () => {
+    expect(() =>
+      safeSelector({ $or: [{ type: 'production' }, { type: 'source' }] }),
+    ).toThrow(MangoInjectionError);
+  });
+
+  it('rejects an operator nested inside an array element', () => {
+    expect(() =>
+      safeSelector({ $and: [{ type: 'production' }] }),
+    ).toThrow(/\$and/);
+  });
+
+  it('tolerates null and undefined selectors (no-op)', () => {
+    expect(() => safeSelector(null)).not.toThrow();
+    expect(() => safeSelector(undefined)).not.toThrow();
+  });
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -5,6 +5,46 @@ import type { ProductionDoc, SourceDoc, ProductionConfigDoc, GraphicDoc, OutputD
 
 let db: Nano.DocumentScope<ProductionDoc>;
 
+/**
+ * Mango-injection guard for CouchDB `find()` selectors. CouchDB treats any
+ * object key beginning with `$` as a query operator (`$in`, `$or`, `$regex`,
+ * `$gt`, …). If user-supplied input is ever merged into a selector without
+ * sanitising, an attacker could smuggle operators to widen a query, trigger an
+ * expensive `$regex`, or bypass an intended `{ type: '...' }` predicate
+ * (OWASP A03 — Injection).
+ *
+ * This guard walks a selector recursively and throws on any `$`-prefixed key.
+ * All current callers pass hardcoded, operator-free selectors (e.g.
+ * `{ type: 'production' }`), so it is a no-op for them — but by wiring it onto
+ * the `find()` hot path (see `withTypeGuard`) it becomes a real backstop for any
+ * future endpoint that forwards user input to `db.find()` (#64).
+ */
+export class MangoInjectionError extends Error {
+  constructor(key: string) {
+    super(`Unsafe Mango operator '${key}' in find() selector`);
+    this.name = 'MangoInjectionError';
+  }
+}
+
+export function safeSelector<T>(selector: T): T {
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item);
+      return;
+    }
+    if (value !== null && typeof value === 'object') {
+      for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        if (key.startsWith('$')) {
+          throw new MangoInjectionError(key);
+        }
+        walk(child);
+      }
+    }
+  };
+  walk(selector);
+  return selector;
+}
+
 // All document types share one physical CouchDB database and one nano handle,
 // which is re-typed per collection via `as unknown as ...`. There is no
 // database-level isolation, so a wrong-collection read (e.g. fetching a
@@ -18,6 +58,7 @@ function withTypeGuard<T extends { type?: string }>(
   expectedType: T extends { type: infer U } ? U : string,
 ): Nano.DocumentScope<T> {
   const boundGet = scope.get.bind(scope) as (...args: unknown[]) => Promise<T>;
+  const boundFind = scope.find.bind(scope) as (...args: unknown[]) => Promise<unknown>;
   return new Proxy(scope, {
     get(target, prop, receiver) {
       if (prop === 'get') {
@@ -30,6 +71,16 @@ function withTypeGuard<T extends { type?: string }>(
             );
           }
           return doc;
+        };
+      }
+      if (prop === 'find') {
+        // Always run the Mango-injection guard on the selector before it reaches
+        // CouchDB, so no future user-input-driven query can bypass it (#64).
+        return (query: Nano.MangoQuery, ...rest: unknown[]): Promise<unknown> => {
+          if (query && typeof query === 'object') {
+            safeSelector(query.selector);
+          }
+          return boundFind(query, ...rest);
         };
       }
       return Reflect.get(target, prop, receiver);


### PR DESCRIPTION
## Summary

Closes #64.

`safeSelector()` was specified as a Mango-injection guard but had zero call sites — a dead-code safety net that would silently rot. This PR defines the guard and wires it onto the `find()` hot path so it becomes a real backstop for any future user-input-driven query, with no behavior change for the existing hardcoded-selector callers.

## Changes

- `src/db/index.ts`:
  - Add `safeSelector()` + `MangoInjectionError`. The guard walks a selector recursively (objects and arrays) and throws on any `$`-prefixed key (`$in`, `$or`, `$regex`, `$gt`, …), which CouchDB treats as a query operator (OWASP A03 — Injection).
  - Intercept `find` in the existing `withTypeGuard` proxy so every `getDb()/getSourcesDb()/getConfigsDb()/getGraphicsDb()/getOutputsDb().find()` call runs the guard on its `selector` before forwarding to CouchDB. All current `.find()` call sites go through these helpers, so the guard is now on the hot path everywhere without touching each caller.
- `src/__tests__/safe-selector.test.ts`: new vitest suite exercising safe pass-through (scalar + nested) and rejection of injected operators (`$in`, `$regex`, `$or`, `$and`), plus null/undefined no-op tolerance — so the guard can't silently rot.

## Test Plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean
- [x] `npx vitest run` — 248 passed (22 files), including 7 new `safeSelector` tests
- [x] No `.github/workflows/*` changes

## Checklist

- [x] Branched from `main`, not committing to `main`
- [x] No secrets/tokens committed
- [x] Scoped to the issue; no unrelated refactors