### PR TITLE
fix(audit): record auth method and masked credential in audit log (#51)

### DIFF
--- a/src/__tests__/audit-auth-context.test.ts
+++ b/src/__tests__/audit-auth-context.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for authentication context in the mutating-request audit log (#51).
+ *
+ * The onResponse audit hook emits a structured `{audit:true, ...}` entry for
+ * every mutating /api/v1 call. Before #51 it recorded only method/url/status/ip,
+ * so a suspected key-compromise investigation could not tell which credential
+ * was used. The entry now carries `authMethod` and (when a key was presented) a
+ * MASKED credential — the raw key must never appear in the log.
+ *
+ * CouchDB, Strom client, and the WS controller are mocked — no real services
+ * required. API_KEY is set before importing the server so config.apiKey (read
+ * once at module load) picks it up.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+const TEST_API_KEY = 'test-secret-key';
+process.env['API_KEY'] = TEST_API_KEY;
+
+// ---------------------------------------------------------------------------
+// Mock CouchDB
+// ---------------------------------------------------------------------------
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ get: vi.fn(), insert: vi.fn(), find: vi.fn() }),
+  getSourcesDb: () => ({ get: vi.fn() }),
+  connectDb: vi.fn().mockResolvedValue(undefined),
+  isDbReady: vi.fn().mockResolvedValue(true),
+  isDbConnected: vi.fn().mockReturnValue(true),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket controller (avoids startup side effects)
+// ---------------------------------------------------------------------------
+
+vi.mock('../ws/controller.js', () => ({
+  default: async () => {},
+  clearAudioState: vi.fn(),
+  clearPipState: vi.fn(),
+  clearFxState: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock StromClient / flow-generator (imported transitively via routes)
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/flow-generator.js', () => ({
+  activateStromFlow: vi.fn(),
+  deactivateStromFlow: vi.fn(),
+}));
+
+vi.mock('../lib/strom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/strom.js')>();
+  class MockStromClient {
+    system = { version: vi.fn().mockResolvedValue({ version: '1.0.0' }), iceServers: vi.fn() };
+    flows = {
+      get: vi.fn(),
+      start: vi.fn().mockResolvedValue({}),
+      stop: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    };
+    mixer = { multiviewEndpoint: vi.fn() };
+  }
+  return { ...actual, StromClient: MockStromClient };
+});
+
+vi.mock('../lib/strom-token.js', () => ({
+  getStromToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeAll(async () => {
+  ({ buildServer } = await import('../server.js'));
+});
+
+/**
+ * Builds a server, spies on its logger, performs one injected request, and
+ * returns the captured audit log object (or undefined if none was emitted).
+ * The audit hook logs through `app.log.info`, so spying on it captures the
+ * structured entry without needing a real transport.
+ */
+async function captureAudit(inject: {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  url: string;
+  headers?: Record<string, string>;
+}): Promise<Record<string, unknown> | undefined> {
+  const app = await buildServer();
+  const infoSpy = vi.spyOn(app.log, 'info');
+  await app.inject(inject);
+  for (const call of infoSpy.mock.calls) {
+    const first = call[0];
+    if (first && typeof first === 'object' && (first as Record<string, unknown>)['audit'] === true) {
+      return first as Record<string, unknown>;
+    }
+  }
+  return undefined;
+}
+
+describe('audit log authentication context (#51)', () => {
+  it("records authMethod 'bearer' and a masked credential for Authorization: Bearer requests", async () => {
+    const entry = await captureAudit({
+      method: 'POST',
+      url: '/api/v1/reconnect',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(entry).toBeDefined();
+    expect(entry!['authMethod']).toBe('bearer');
+    expect(entry!['maskedCred']).toBe('key_***-key');
+  });
+
+  it("records authMethod 'none' and no maskedCred when no credential is presented", async () => {
+    // A missing key yields 401, but the onResponse audit hook still fires.
+    const entry = await captureAudit({ method: 'POST', url: '/api/v1/reconnect' });
+    expect(entry).toBeDefined();
+    expect(entry!['authMethod']).toBe('none');
+    expect(entry).not.toHaveProperty('maskedCred');
+  });
+
+  it('never logs the full API key in the audit entry', async () => {
+    const entry = await captureAudit({
+      method: 'POST',
+      url: '/api/v1/reconnect',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(entry).toBeDefined();
+    // The raw secret must not appear in any string field of the entry.
+    const serialised = JSON.stringify(entry);
+    expect(serialised).not.toContain(TEST_API_KEY);
+  });
+
+  it('still records the pre-existing audit fields alongside the auth context', async () => {
+    const entry = await captureAudit({
+      method: 'POST',
+      url: '/api/v1/reconnect',
+      headers: { authorization: `Bearer ${TEST_API_KEY}` },
+    });
+    expect(entry).toMatchObject({
+      audit: true,
+      method: 'POST',
+      url: '/api/v1/reconnect',
+    });
+    expect(entry).toHaveProperty('status');
+    expect(entry).toHaveProperty('ip');
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,6 +67,48 @@ function extractSubprotocolKey(header: string | string[] | undefined): string | 
   return undefined;
 }
 
+// How a request presented its API key, for forensic audit logging (#51). This
+// mirrors the two transports the auth hook accepts: the `Authorization: Bearer`
+// header (REST / non-browser clients) and the `openlive.bearer.<key>`
+// Sec-WebSocket-Protocol subprotocol (browser WS clients, #49). 'none' means no
+// credential was presented on the request.
+type AuthMethod = 'bearer' | 'ws-subprotocol' | 'none';
+
+/**
+ * Masks an API key for audit logging so a suspected-compromise investigation
+ * can correlate which key was used WITHOUT ever persisting the secret itself.
+ * Only a short suffix survives: `key_***<last4>`. Keys too short to safely
+ * reveal a suffix (<8 chars) are fully masked as `key_***`.
+ */
+function maskCredential(key: string): string {
+  if (key.length < 8) return 'key_***';
+  return `key_***${key.slice(-4)}`;
+}
+
+/**
+ * Derives the authentication context for an audit entry from the request
+ * headers, truthfully reflecting how THIS server authenticates (#51):
+ *   - `Authorization: Bearer <key>`            -> 'bearer'
+ *   - `openlive.bearer.<key>` WS subprotocol   -> 'ws-subprotocol'
+ *   - neither present                          -> 'none'
+ * `maskedCred` is only set when a credential was actually presented, and never
+ * contains the raw key — only the `maskCredential` suffix form.
+ */
+function deriveAuthContext(
+  authorization: string | undefined,
+  subprotocol: string | string[] | undefined
+): { authMethod: AuthMethod; maskedCred?: string } {
+  const bearerKey = authorization?.startsWith('Bearer ') ? authorization.slice(7) : undefined;
+  if (bearerKey) {
+    return { authMethod: 'bearer', maskedCred: maskCredential(bearerKey) };
+  }
+  const subprotocolKey = extractSubprotocolKey(subprotocol);
+  if (subprotocolKey) {
+    return { authMethod: 'ws-subprotocol', maskedCred: maskCredential(subprotocolKey) };
+  }
+  return { authMethod: 'none' };
+}
+
 export async function buildServer() {
   const fastify = Fastify({
     logger: {
@@ -269,12 +311,21 @@ export async function buildServer() {
     if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) return;
     if (!req.url.startsWith('/api/v1')) return;
     const ip = req.ip ?? '';
+    // Record which credential authenticated the request (#51) so a suspected
+    // key compromise can be traced. maskedCred only ever carries a masked
+    // suffix — the raw key is never logged.
+    const { authMethod, maskedCred } = deriveAuthContext(
+      req.headers['authorization'],
+      req.headers['sec-websocket-protocol']
+    );
     fastify.log.info({
       audit: true,
       method: req.method,
       url: req.url.split('?')[0],
       status: reply.statusCode,
       ip,
+      authMethod,
+      ...(maskedCred ? { maskedCred } : {}),
     }, 'audit');
   });
 


### PR DESCRIPTION
## Summary
- Audit entries for mutating `/api/v1` requests now record the authentication context, so a suspected API-key compromise can be traced to the credential used (#51).
- Only a masked credential suffix is logged (`key_***<last4>`); the raw key is never written to any log.

## Changes
- `src/server.ts`: added `deriveAuthContext()` / `maskCredential()` helpers and extended the `onResponse` audit hook to log `authMethod` ('bearer' | 'ws-subprotocol' | 'none') plus `maskedCred` when a key was presented. `authMethod` is derived from the exact two transports the auth hook accepts: `Authorization: Bearer <key>` (REST) and the `openlive.bearer.<key>` `Sec-WebSocket-Protocol` subprotocol (browser WS, #49). There is no `?key=` query param or `x-api-key` header in this codebase, so those are not represented.
- `src/__tests__/audit-auth-context.test.ts`: new vitest coverage asserting `authMethod`/`maskedCred` are recorded, `'none'` is used when no credential is presented, pre-existing fields remain, and the full key never appears in the entry.

## Test Plan
- [x] Unit tests pass (`npx vitest run` — 245 passed, incl. 4 new)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes
- [ ] Integration tests pass (n/a — no integration suite for this change)
- [x] Manual verification: confirmed masked suffix form and absence of raw key via test assertion on serialised entry

## Checklist
- [x] Code-quality checks passed
- [x] No hardcoded SRT ports
- [x] GStreamer pipelines have watchdogs (if applicable) — n/a
- [x] EFP sequence validation present (if applicable) — n/a
- [ ] docs/repo-patterns.md updated if non-obvious issue encountered — n/a

Closes #51

🤖 Generated with Claude Code